### PR TITLE
Update to GEBCO 2026 and split CI into per-artifact publish pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
 
       # Cache the downloaded GEBCO zip (~4.2 GB) keyed by year so re-runs skip
       # the curl. The download step re-extracts + clips from it each run.


### PR DESCRIPTION
## Summary

Gets the project publish-ready: moves to **GEBCO 2026**, splits the build so each artifact is its own GitHub Actions job, saves artifacts on every push, and publishes to **Cloudflare R2** (`tiles.openwaters.io`) on release.

## Changes

- **GEBCO 2026** — `GEBCO_YEAR` (default `2026`) drives the source URL/paths; README citation/DOI updated.
- **Global-safe pipeline** — drop raster upsampling entirely and cap contours at **z9** (15″ data is native at ~z8.4; z14 was ~64× wasted overzoom) so a global build fits a runner.
- **Self-contained steps** — `contour` now tiles to PMTiles itself, mirroring `terrain`; `build` just orchestrates `download → terrain → contour`.
- **CI rework** — build the toolchain image once (GHCR), run `terrain` and `contour` as parallel matrix jobs, upload pmtiles as workflow artifacts on every push. The viewer builds independently.
- **Publish on release** — push tiles to R2 at `gebco/<year>/{terrain,contours}.pmtiles` and deploy the viewer to Pages.
- **Viewer** — loads tiles from `tiles.openwaters.io` via `TILES_BASE`; fixes the DEM encoding (`mapbox`, matching the encoder).

## Required before the release path works
Repo secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`; and an R2 bucket bound to `tiles.openwaters.io`.

## Open risk
The **global single-pass** build is unproven on a hosted runner — the first CI run is the real test of disk/time. Fast-follow if it overflows: an 8-quadrant matrix. `SKIP_SLOPE_SMOOTH=1` is the escape hatch if smoothing is slow on the global raster.

## Test plan
- [x] All scripts pass `bash -n`; regional build produces `terrain.pmtiles` (PNG z0–9) + `contours.pmtiles` (z9)
- [x] `npm run build` injects `tiles.openwaters.io` and keeps `mapbox` encoding
- [ ] First CI run on push: `image`/`terrain`/`contour`/`web` succeed and upload artifacts
- [ ] Pre-release: tiles land in R2 and the viewer loads them