### PR TITLE
WIP: Region-sharded build pipeline (scale the global build)

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,16 @@
+name: GHCR login (with retry)
+description: Log in to ghcr.io, retrying the occasionally-flaky token endpoint.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GHCR_TOKEN: ${{ github.token }}
+        GHCR_USER: ${{ github.actor }}
+      run: |
+        for i in 1 2 3 4 5; do
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin && exit 0
+          echo "ghcr login attempt $i failed; retrying in $((i * 5))s" >&2
+          sleep $((i * 5))
+        done
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
         run: |
-          aws s3 cp "work/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles" \
+          BAND="work/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles"
+          # All-land contour shards produce no band — nothing to upload.
+          if [ ! -f "$BAND" ]; then echo "No band produced; skipping upload."; exit 0; fi
+          aws s3 cp "$BAND" \
             "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/bands/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles" \
             --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,15 @@ jobs:
             "${IMAGE}:${{ github.sha }}" "$@"; }
           run download
           run ${{ matrix.step }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: band-${{ matrix.step }}-${{ matrix.cell.id }}
-          path: work/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles
-          if-no-files-found: error
+      - name: Upload band to R2 build
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          aws s3 cp "work/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles" \
+            "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/bands/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles" \
+            --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 
   # Low zoom can't be sharded (a z0 tile spans the globe). Terrain is cheap from
   # the full DEM. Contour would regenerate every feature, so it runs on a
@@ -182,11 +186,15 @@ jobs:
           docker run --rm -e GEBCO_YEAR -e GEBCO_URL -e SPLIT_ZOOM \
             -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
             "${IMAGE}:${{ github.sha }}" lowzoom ${{ matrix.step }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: band-${{ matrix.step }}-lowzoom
-          path: work/${{ matrix.step }}_lowzoom.mbtiles
-          if-no-files-found: error
+      - name: Upload band to R2 build
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          aws s3 cp "work/${{ matrix.step }}_lowzoom.mbtiles" \
+            "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/bands/${{ matrix.step }}_lowzoom.mbtiles" \
+            --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 
   # Union all bands (low-zoom + cells) into one tileset per layer, then PMTiles.
   merge:
@@ -200,19 +208,41 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/download-artifact@v4
-        with: { path: bands, pattern: band-*, merge-multiple: true }
+      - name: Fetch bands from R2 build
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          mkdir -p bands
+          aws s3 sync "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/bands/" bands/ \
+            --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
       - name: Merge bands → PMTiles
         run: |
           mkdir -p output
           docker run --rm \
             -v "${{ github.workspace }}/bands:/app/bands" -v "${{ github.workspace }}/output:/app/output" \
             "${IMAGE}:${{ github.sha }}" merge-bands /app/bands /app/output
-      - uses: actions/upload-artifact@v4
-        with:
-          name: tiles
-          path: output/*.pmtiles
-          if-no-files-found: error
+      # Final PMTiles stay in R2 keyed by commit, so publish is a server-side copy.
+      - name: Upload PMTiles to R2 build
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          aws s3 cp output/ "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/" \
+            --recursive --exclude '*' --include '*.pmtiles' \
+            --content-type application/octet-stream \
+            --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+      - name: Clean up bands (keep PMTiles for publish)
+        if: always()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          aws s3 rm "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/bands/" --recursive \
+            --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 
   # The viewer references tiles by URL at runtime, so it builds independently.
   web:
@@ -241,19 +271,17 @@ jobs:
     needs: merge
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: tiles
-          path: artifacts
-      - name: Upload tiles to R2
+      # Promote the already-built PMTiles within R2 — server-side copy, no
+      # download/upload through the runner.
+      - name: Publish PMTiles to R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
         run: |
-          aws s3 cp artifacts/ "s3://${{ secrets.R2_BUCKET }}/gebco/${GEBCO_YEAR}/" \
+          aws s3 cp "s3://${{ secrets.R2_BUCKET }}/build/${{ github.sha }}/" \
+            "s3://${{ secrets.R2_BUCKET }}/gebco/${GEBCO_YEAR}/" \
             --recursive --exclude '*' --include '*.pmtiles' \
-            --content-type application/octet-stream \
             --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
 
   # Deploy the viewer to GitHub Pages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,27 +41,43 @@ env:
   GEBCO_URL: https://tiles.openwaters.io/source/gebco_2026_geotiff.zip
 
 jobs:
-  # Download the GEBCO zip once and warm the cache, so terrain and contour don't
-  # both pull ~4.2 GB in parallel (which raced and timed out). Runs alongside the
-  # image build; sources config.sh so the URL logic isn't duplicated here.
+  # Download + extract the GEBCO grid once and cache the *extracted* tifs/VRT
+  # (not just the zip), so the ~30 shard jobs each skip the unzip+VRT and only
+  # clip their bbox. On a cache hit this whole job is a no-op.
   prepare:
+    needs: image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v6
-      - name: Cache GEBCO source
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:
-          path: data/gebco_${{ env.GEBCO_YEAR }}.zip
-          key: gebco-${{ env.GEBCO_YEAR }}
-      - name: Download GEBCO source
+          path: |
+            data/gebco_${{ env.GEBCO_YEAR }}*.tif
+            data/gebco_${{ env.GEBCO_YEAR }}.vrt
+          key: gebco-grid-${{ env.GEBCO_YEAR }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract GEBCO grid
         run: |
-          source scripts/config.sh
-          if [[ -f "${GEBCO_ZIP}" ]]; then
-            echo "Already cached: ${GEBCO_ZIP}"
-          else
-            curl -L --fail --retry 5 --retry-all-errors --retry-delay 15 \
-              --connect-timeout 30 -C - -o "${GEBCO_ZIP}" "${GEBCO_URL}"
-          fi
+          docker run --rm -e GEBCO_YEAR -e GEBCO_URL \
+            -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
+            "${IMAGE}:${{ github.sha }}" download
 
   # Build the toolchain image once and push to GHCR. buildx GHA cache means it
   # only recompiles (tippecanoe etc.) when the Dockerfile changes.
@@ -113,11 +129,13 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: true, swap-storage: true }
-      - name: Cache GEBCO source
+      - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:
-          path: data/gebco_${{ env.GEBCO_YEAR }}.zip
-          key: gebco-${{ env.GEBCO_YEAR }}
+          path: |
+            data/gebco_${{ env.GEBCO_YEAR }}*.tif
+            data/gebco_${{ env.GEBCO_YEAR }}.vrt
+          key: gebco-grid-${{ env.GEBCO_YEAR }}
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -156,40 +174,23 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: true, swap-storage: true }
-      - name: Cache GEBCO source
+      - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:
-          path: data/gebco_${{ env.GEBCO_YEAR }}.zip
-          key: gebco-${{ env.GEBCO_YEAR }}
+          path: |
+            data/gebco_${{ env.GEBCO_YEAR }}*.tif
+            data/gebco_${{ env.GEBCO_YEAR }}.vrt
+          key: gebco-grid-${{ env.GEBCO_YEAR }}
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build ${{ matrix.step }} low-zoom band (z0 to SPLIT_ZOOM-1)
+      - name: Build ${{ matrix.step }} low-zoom band
         run: |
-          set -euo pipefail
-          TOPZ=$(( SPLIT_ZOOM - 1 ))
-          dk() { docker run --rm -e GEBCO_YEAR -e GEBCO_URL \
+          docker run --rm -e GEBCO_YEAR -e GEBCO_URL -e SPLIT_ZOOM \
             -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
-            "${IMAGE}:${{ github.sha }}" "$@"; }
-          dk download   # global DEM → /app/work/gebco_clipped.tif
-          if [ "${{ matrix.step }}" = contour ]; then
-            # Downsample to ~z7 pixel size (~0.011°) so gdal_contour stays small,
-            # and keep only levels that render at z≤TOPZ (deeper than -50m).
-            dk gdalwarp -tr 0.01 0.01 -r bilinear -overwrite /app/work/gebco_clipped.tif /app/work/gebco_lowzoom.tif
-            docker run --rm \
-              -e MIN_ZOOM=0 -e MAX_ZOOM="$TOPZ" -e SKIP_SLOPE_SMOOTH=1 \
-              -e CONTOUR_LEVELS="-10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000 -500 -200 -150 -100 -75 -50" \
-              -e OUT_MBTILES=/app/work/contour_lowzoom.mbtiles \
-              -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
-              "${IMAGE}:${{ github.sha }}" contour /app/work/gebco_lowzoom.tif
-          else
-            docker run --rm \
-              -e MIN_ZOOM=0 -e TERRAIN_MAX_ZOOM="$TOPZ" -e OUT_MBTILES=/app/work/terrain_lowzoom.mbtiles \
-              -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
-              "${IMAGE}:${{ github.sha }}" terrain
-          fi
+            "${IMAGE}:${{ github.sha }}" lowzoom ${{ matrix.step }}
       - uses: actions/upload-artifact@v4
         with:
           name: band-${{ matrix.step }}-lowzoom
@@ -212,17 +213,10 @@ jobs:
         with: { path: bands, pattern: band-*, merge-multiple: true }
       - name: Merge bands → PMTiles
         run: |
-          set -euo pipefail
           mkdir -p output
-          dk() { docker run --rm \
+          docker run --rm \
             -v "${{ github.workspace }}/bands:/app/bands" -v "${{ github.workspace }}/output:/app/output" \
-            "${IMAGE}:${{ github.sha }}" "$@"; }
-          # Terrain is raster (real `tiles` table) → sqlite union, then PMTiles.
-          dk bash -c "merge-tiles /app/output/terrain.mbtiles /app/bands/terrain_*.mbtiles"
-          dk pmtiles convert /app/output/terrain.mbtiles /app/output/terrain.pmtiles
-          # Contour is vector: tippecanoe MBTiles expose `tiles` as a VIEW (can't be
-          # indexed), so tile-join unions the bands — straight to PMTiles.
-          dk bash -c "tile-join -f -o /app/output/contours.pmtiles /app/bands/contour_*.mbtiles"
+            "${IMAGE}:${{ github.sha }}" merge-bands /app/bands /app/output
       - uses: actions/upload-artifact@v4
         with:
           name: tiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,24 @@ on:
         description: "Maximum contour tile zoom level"
         required: false
         default: "9"
+      shard_cols:
+        description: "Shard grid columns (must divide 2**split_zoom)"
+        required: false
+        default: "4"
+      shard_rows:
+        description: "Shard grid rows (must divide 2**split_zoom)"
+        required: false
+        default: "4"
 
 env:
   GEBCO_YEAR: "2026"
   BBOX: ${{ github.event.inputs.bbox || '' }}
   MAX_ZOOM: ${{ github.event.inputs.max_zoom || '9' }}
+  # Sharding: cells own SPLIT_ZOOM..MAX_ZOOM within their bbox; a global low-zoom
+  # job owns 0..SPLIT_ZOOM-1. See SCALING.md.
+  SPLIT_ZOOM: "8"
+  SHARD_COLS: ${{ github.event.inputs.shard_cols || '4' }}
+  SHARD_ROWS: ${{ github.event.inputs.shard_rows || '4' }}
   IMAGE: ghcr.io/${{ github.repository }}
   # CEDA firewalls cloud-runner IPs, so CI pulls the source zip from our own R2
   # mirror instead (GEBCO is public domain). Seed it once with:
@@ -73,64 +86,146 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # terrain and contour run as separate parallel jobs (own runner = full disk
-  # each), so global builds fit without sharing the multi-GB DEM between them.
-  tiles:
+  # Compute the tile-aligned shard grid → JSON matrix for the cell jobs.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      cells: ${{ steps.gen.outputs.cells }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: gen
+        run: echo "cells=$(python3 scripts/shard-cells "${SHARD_COLS}" "${SHARD_ROWS}" "${SPLIT_ZOOM}")" >> "$GITHUB_OUTPUT"
+
+  # High-zoom detail, sharded geographically: each cell builds z(SPLIT_ZOOM)–MAX_ZOOM
+  # terrain + contour for its bbox. Tiles are disjoint across cells (tile-aligned),
+  # so the merge is a plain union. Cells beyond ~20 just queue.
+  cells:
+    needs: [image, prepare, plan]
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: read }
+    strategy:
+      fail-fast: false
+      matrix:
+        cell: ${{ fromJSON(needs.plan.outputs.cells) }}
+        step: [terrain, contour]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: true, swap-storage: true }
+      - name: Cache GEBCO source
+        uses: actions/cache@v4
+        with:
+          path: data/gebco_${{ env.GEBCO_YEAR }}.zip
+          key: gebco-${{ env.GEBCO_YEAR }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ${{ matrix.step }} ${{ matrix.cell.id }} (z${{ env.SPLIT_ZOOM }}–${{ env.MAX_ZOOM }})
+        run: |
+          set -euo pipefail
+          OUT="/app/work/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles"
+          run() { docker run --rm \
+            -e BBOX="${{ matrix.cell.bbox }}" -e GEBCO_YEAR -e GEBCO_URL \
+            -e MIN_ZOOM="${SPLIT_ZOOM}" -e MAX_ZOOM -e TERRAIN_MAX_ZOOM="${MAX_ZOOM}" -e OUT_MBTILES="$OUT" \
+            -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
+            "${IMAGE}:${{ github.sha }}" "$@"; }
+          run download
+          run ${{ matrix.step }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: band-${{ matrix.step }}-${{ matrix.cell.id }}
+          path: work/${{ matrix.step }}_${{ matrix.cell.id }}.mbtiles
+          if-no-files-found: error
+
+  # Low zoom can't be sharded (a z0 tile spans the globe). Terrain is cheap from
+  # the full DEM. Contour would regenerate every feature, so it runs on a
+  # downsampled DEM with only the deep levels that render at z<SPLIT_ZOOM.
+  lowzoom:
     needs: [image, prepare]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
+    permissions: { contents: read, packages: read }
     strategy:
       fail-fast: false
       matrix:
         step: [terrain, contour]
     steps:
       - uses: actions/checkout@v6
-
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
-      # Cache the downloaded GEBCO zip (~4.2 GB) keyed by year so re-runs skip
-      # the curl. The download step re-extracts + clips from it each run.
+        with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: true, swap-storage: true }
       - name: Cache GEBCO source
         uses: actions/cache@v4
         with:
           path: data/gebco_${{ env.GEBCO_YEAR }}.zip
           key: gebco-${{ env.GEBCO_YEAR }}
-
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build ${{ matrix.step }} tiles
+      - name: Build ${{ matrix.step }} low-zoom band (z0 to SPLIT_ZOOM-1)
         run: |
-          docker run --rm \
-            -e BBOX="${BBOX}" -e MAX_ZOOM="${MAX_ZOOM}" -e GEBCO_YEAR="${GEBCO_YEAR}" -e GEBCO_URL="${GEBCO_URL}" \
-            -v "${{ github.workspace }}/data:/app/data" \
-            -v "${{ github.workspace }}/work:/app/work" \
-            -v "${{ github.workspace }}/output:/app/output" \
-            "${IMAGE}:${{ github.sha }}" download
-          docker run --rm \
-            -e BBOX="${BBOX}" -e MAX_ZOOM="${MAX_ZOOM}" -e GEBCO_YEAR="${GEBCO_YEAR}" -e GEBCO_URL="${GEBCO_URL}" \
-            -v "${{ github.workspace }}/data:/app/data" \
-            -v "${{ github.workspace }}/work:/app/work" \
-            -v "${{ github.workspace }}/output:/app/output" \
-            "${IMAGE}:${{ github.sha }}" ${{ matrix.step }}
-
-      - name: Upload ${{ matrix.step }} artifact
-        uses: actions/upload-artifact@v4
+          set -euo pipefail
+          TOPZ=$(( SPLIT_ZOOM - 1 ))
+          dk() { docker run --rm -e GEBCO_YEAR -e GEBCO_URL \
+            -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
+            "${IMAGE}:${{ github.sha }}" "$@"; }
+          dk download   # global DEM → /app/work/gebco_clipped.tif
+          if [ "${{ matrix.step }}" = contour ]; then
+            # Downsample to ~z7 pixel size (~0.011°) so gdal_contour stays small,
+            # and keep only levels that render at z≤TOPZ (deeper than -50m).
+            dk gdalwarp -tr 0.01 0.01 -r bilinear -overwrite /app/work/gebco_clipped.tif /app/work/gebco_lowzoom.tif
+            docker run --rm \
+              -e MIN_ZOOM=0 -e MAX_ZOOM="$TOPZ" -e SKIP_SLOPE_SMOOTH=1 \
+              -e CONTOUR_LEVELS="-10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000 -500 -200 -150 -100 -75 -50" \
+              -e OUT_MBTILES=/app/work/contour_lowzoom.mbtiles \
+              -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
+              "${IMAGE}:${{ github.sha }}" contour /app/work/gebco_lowzoom.tif
+          else
+            docker run --rm \
+              -e MIN_ZOOM=0 -e TERRAIN_MAX_ZOOM="$TOPZ" -e OUT_MBTILES=/app/work/terrain_lowzoom.mbtiles \
+              -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \
+              "${IMAGE}:${{ github.sha }}" terrain
+          fi
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.step }}
+          name: band-${{ matrix.step }}-lowzoom
+          path: work/${{ matrix.step }}_lowzoom.mbtiles
+          if-no-files-found: error
+
+  # Union all bands (low-zoom + cells) into one tileset per layer, then PMTiles.
+  merge:
+    needs: [cells, lowzoom]
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: read }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with: { path: bands, pattern: band-*, merge-multiple: true }
+      - name: Merge bands → PMTiles
+        run: |
+          set -euo pipefail
+          mkdir -p output
+          dk() { docker run --rm \
+            -v "${{ github.workspace }}/bands:/app/bands" -v "${{ github.workspace }}/output:/app/output" \
+            "${IMAGE}:${{ github.sha }}" "$@"; }
+          # Terrain is raster (real `tiles` table) → sqlite union, then PMTiles.
+          dk bash -c "merge-tiles /app/output/terrain.mbtiles /app/bands/terrain_*.mbtiles"
+          dk pmtiles convert /app/output/terrain.mbtiles /app/output/terrain.pmtiles
+          # Contour is vector: tippecanoe MBTiles expose `tiles` as a VIEW (can't be
+          # indexed), so tile-join unions the bands — straight to PMTiles.
+          dk bash -c "tile-join -f -o /app/output/contours.pmtiles /app/bands/contour_*.mbtiles"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiles
           path: output/*.pmtiles
           if-no-files-found: error
 
@@ -158,13 +253,13 @@ jobs:
   # Push the tiles to Cloudflare R2 (served at tiles.openwaters.io).
   publish-r2:
     if: github.event_name == 'release'
-    needs: tiles
+    needs: merge
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
+          name: tiles
           path: artifacts
-          merge-multiple: true
       - name: Upload tiles to R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,17 @@ jobs:
     permissions: { contents: read, packages: read }
     steps:
       - uses: actions/checkout@v6
+      # Merge assembles the whole tileset on one runner (unlike the small cells),
+      # so reclaim disk here.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cache extracted GEBCO grid
+        id: grid-cache
         uses: actions/cache@v4
         with:
           path: |
@@ -66,11 +67,13 @@ jobs:
             data/gebco_${{ env.GEBCO_YEAR }}.vrt
           key: gebco-grid-${{ env.GEBCO_YEAR }}
       - uses: docker/login-action@v3
+        if: steps.grid-cache.outputs.cache-hit != 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract GEBCO grid
+        if: steps.grid-cache.outputs.cache-hit != 'true'
         run: |
           docker run --rm -e GEBCO_YEAR -e GEBCO_URL \
             -v "${{ github.workspace }}/data:/app/data" -v "${{ github.workspace }}/work:/app/work" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ on:
       shard_cols:
         description: "Shard grid columns (must divide 2**split_zoom)"
         required: false
-        default: "4"
+        default: "8"
       shard_rows:
         description: "Shard grid rows (must divide 2**split_zoom)"
         required: false
-        default: "4"
+        default: "8"
 
 env:
   GEBCO_YEAR: "2026"
@@ -29,9 +29,9 @@ env:
   MAX_ZOOM: ${{ github.event.inputs.max_zoom || '9' }}
   # Sharding: cells own SPLIT_ZOOM..MAX_ZOOM within their bbox; a global low-zoom
   # job owns 0..SPLIT_ZOOM-1. See SCALING.md.
-  SPLIT_ZOOM: "8"
-  SHARD_COLS: ${{ github.event.inputs.shard_cols || '4' }}
-  SHARD_ROWS: ${{ github.event.inputs.shard_rows || '4' }}
+  SPLIT_ZOOM: "5"
+  SHARD_COLS: ${{ github.event.inputs.shard_cols || '8' }}
+  SHARD_ROWS: ${{ github.event.inputs.shard_rows || '8' }}
   IMAGE: ghcr.io/${{ github.repository }}
   # CEDA firewalls cloud-runner IPs, so CI pulls the source zip from our own R2
   # mirror instead (GEBCO is public domain). Seed it once with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,6 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@v6
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
       - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:
@@ -116,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: gen
-        run: echo "cells=$(python3 scripts/shard-cells "${SHARD_COLS}" "${SHARD_ROWS}" "${SPLIT_ZOOM}")" >> "$GITHUB_OUTPUT"
+        run: echo "cells=$(scripts/shard-cells "${SHARD_COLS}" "${SHARD_ROWS}" "${SPLIT_ZOOM}")" >> "$GITHUB_OUTPUT"
 
   # High-zoom detail, sharded geographically: each cell builds z(SPLIT_ZOOM)–MAX_ZOOM
   # terrain + contour for its bbox. Tiles are disjoint across cells (tile-aligned),
@@ -132,9 +123,6 @@ jobs:
         step: [terrain, contour]
     steps:
       - uses: actions/checkout@v6
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: true, swap-storage: true }
       - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:
@@ -177,9 +165,6 @@ jobs:
         step: [terrain, contour]
     steps:
       - uses: actions/checkout@v6
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with: { tool-cache: true, android: true, dotnet: true, haskell: true, large-packages: true, swap-storage: true }
       - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ env:
   # Keep the year here in sync with GEBCO_YEAR. Local dev still uses CEDA.
   GEBCO_URL: https://tiles.openwaters.io/source/gebco_2026_geotiff.zip
 
+# Supersede in-progress runs on the same branch when a new push lands — but
+# never cancel a release publish mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 jobs:
   # Download + extract the GEBCO grid once and cache the *extracted* tifs/VRT
   # (not just the zip), so the ~30 shard jobs each skip the unzip+VRT and only
@@ -120,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: { contents: read, packages: read }
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         cell: ${{ fromJSON(needs.plan.outputs.cells) }}
         step: [terrain, contour]
@@ -166,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: { contents: read, packages: read }
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         step: [terrain, contour]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,18 @@ jobs:
         step: [terrain, contour]
     steps:
       - uses: actions/checkout@v6
+      # Ocean-heavy contour shards stage large intermediate FlatGeobufs; reclaim
+      # disk for them. Terrain cells are small and skip this.
+      - name: Free disk space
+        if: matrix.step == 'contour'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: Cache extracted GEBCO grid
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,8 @@ jobs:
             data/gebco_${{ env.GEBCO_YEAR }}*.tif
             data/gebco_${{ env.GEBCO_YEAR }}.vrt
           key: gebco-grid-${{ env.GEBCO_YEAR }}
-      - uses: docker/login-action@v3
+      - uses: ./.github/actions/ghcr-login
         if: steps.grid-cache.outputs.cache-hit != 'true'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract GEBCO grid
         if: steps.grid-cache.outputs.cache-hit != 'true'
         run: |
@@ -89,11 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/ghcr-login
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -133,11 +125,7 @@ jobs:
             data/gebco_${{ env.GEBCO_YEAR }}*.tif
             data/gebco_${{ env.GEBCO_YEAR }}.vrt
           key: gebco-grid-${{ env.GEBCO_YEAR }}
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/ghcr-login
       - name: Build ${{ matrix.step }} ${{ matrix.cell.id }} (z${{ env.SPLIT_ZOOM }}–${{ env.MAX_ZOOM }})
         run: |
           set -euo pipefail
@@ -179,11 +167,7 @@ jobs:
             data/gebco_${{ env.GEBCO_YEAR }}*.tif
             data/gebco_${{ env.GEBCO_YEAR }}.vrt
           key: gebco-grid-${{ env.GEBCO_YEAR }}
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/ghcr-login
       - name: Build ${{ matrix.step }} low-zoom band
         run: |
           docker run --rm -e GEBCO_YEAR -e GEBCO_URL -e SPLIT_ZOOM \
@@ -217,11 +201,7 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/ghcr-login
       - name: Fetch bands from R2 build
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/MOSAIC-PLAN.md
+++ b/MOSAIC-PLAN.md
@@ -162,6 +162,15 @@ mosaic of just GEBCO at GEBCO res. CUDEM (priority 1) → GEBCO+CUDEM at 3.4 m i
 CUDEM's bbox. This removes the base/region special-case from `build` (one loop)
 and lets you swap GEBCO→ETOPO or run base-less by editing config alone.
 
+**Also fixes the abrupt z9→z10 transition.** Today the base band (z0–9) is tiled
+from *pure GEBCO*, so inside a CUDEM footprint you see zero CUDEM until z10 — then
+at z10 both the resolution (~130×) and the dataset switch at once, so contours and
+shading jump rather than sharpen. Under the unified model the base tiles from a
+*base-resolution* priority mosaic (CUDEM downsampled to ~450 m over GEBCO), so z9
+already shows CUDEM-derived data and z9→z10 becomes a normal resolution bump of the
+same source. (This is the zoom-axis version of the bbox-edge seam; the
+base-resolution mosaic is exactly what item 2 above requires.)
+
 **Work items:**
 - `sources.conf` row gains `min_zoom`: `id|url|datum_offset|priority|bbox|min_zoom|max_zoom`,
   with `gebco | <zip-url> | 0 | 0 | -180,-85,180,85 | 0 | 9`.

--- a/SCALING.md
+++ b/SCALING.md
@@ -94,7 +94,7 @@ hand-tuned 16.
 
 The ceiling: each cell re-pays fixed per-job cost (checkout + image pull + DEM
 clip/pull), and the merge job's fan-in grows with cell count. So finer isn't
-free — past some point the overhead dominates the work. `# ponytail: start at
+free — past some point the overhead dominates the work. `# start at
 16, then try 32–64 and compare wall-clock; stop when per-job overhead eats the
 gains.`
 

--- a/SCALING.md
+++ b/SCALING.md
@@ -1,0 +1,177 @@
+# Scaling the Global Build
+
+How to make the global terrain + contour build complete reliably on free
+GitHub-hosted runners. This is purely about **build execution** — fitting the
+work under a single runner's limits. Combining multiple data sources is a
+separate concern; see [MOSAIC-PLAN.md](MOSAIC-PLAN.md).
+
+## The two walls we hit
+
+A single monolithic global build at z0–9 exceeds one standard runner on both
+axes (observed on run 27520665564, branch `gebco-2026-publish`):
+
+| Job     | Failure | Cause |
+| ------- | ------- | ----- |
+| terrain | cancelled at **exactly 6h00m** | GitHub's hard per-job ceiling. rio-rgbify resamples the global DEM per tile; z9 alone is 262k tiles. No in-job optimization fits >6h under 6h. |
+| contour | **disk full** (61 MB left of 119 GB) | 3.9M global contour features × 3 FlatGeobuf copies + the >4 GB smoothed DEM. Chaikin (5 iterations ≈ 32× vertices) blows `_smooth.fgb` to tens of GB. Freeing more runner disk only delayed it. |
+
+Both point at the same fix: **stop processing the whole globe in one job.**
+
+## Lever 1 — Shard by region
+
+GitHub gives public repos ~20 concurrent runners free. Use horizontal scale
+instead of one fat (paid) runner.
+
+Shard the **expensive high-zoom tail** geographically; keep the cheap low
+zooms global:
+
+1. **One global low-zoom job** — z0–7 (~22k tiles, minutes) from the full DEM.
+   Cannot be sharded: a z0 tile *is* the whole globe.
+2. **Cell matrix for z8–9** — partition the globe into N tile-aligned bboxes,
+   one matrix job per cell building **both** terrain + contour for its cell.
+   z9 is 262k tiles total → 16 cells ≈ 16k z9 tiles each, comfortably under 6h,
+   up to 20 running at once.
+3. **Merge job** (`needs:` all cells + low-zoom) — download artifacts,
+   `scripts/merge-tiles`, `pmtiles convert`, deploy.
+
+Fixes both walls at once: terrain wall-clock drops ~N×; each contour cell
+handles ~1/N of the features, so the Chaikin blow-up and disk stay small.
+
+### Two rules that keep the merge trivial
+
+- **Cell boundaries must be tile-aligned.** Snap each cell bbox to the z8 tile
+  grid. Then every output tile belongs to exactly one cell → `merge-tiles`
+  never sees a collision, no double-drawn contours.
+- **Buffer the DEM input, not the tile output.** Clip each cell's source DEM
+  with a small margin beyond its bbox so edge tiles get correct bilinear
+  resampling and contour lines don't die at the seam — but restrict *emitted*
+  tiles to the cell's tile range. Input overlaps; output is disjoint.
+
+### Terrain and contour shard differently
+
+`gdal_contour` generates **every** contour feature from the DEM in a single
+pass — the expensive, disk-filling step — and that pass is independent of tile
+zoom. So a "global low-zoom contour job" would regenerate all ~3.9M features
+and fill the disk exactly like the failure we're fixing. Contour cost can only
+be sharded *geographically* (clip the DEM before contouring). Terrain has no
+such pass — rio resamples per tile, cheap at any zoom.
+
+So the two pipelines split the work differently:
+
+- **Terrain** — low-zoom global job (z0–7, full DEM, cheap) + geographic cells
+  for z8–9. Raster MBTiles have a real `tiles` table and the tiles are disjoint
+  → `merge-tiles` sqlite `INSERT OR IGNORE` union.
+- **Contour** — low-zoom job contours a **downsampled** global DEM (coarse →
+  few features → small disk → fine for z0–7) + geographic cells (clip → contour
+  → tile z8–9) for detail. tippecanoe writes `tiles` as a **VIEW** (can't be
+  sqlite-indexed), so the bands are merged with **`tile-join`** (straight to
+  PMTiles), not the sqlite union.
+
+The only contour-specific additions: one `gdalwarp -tr <coarse>` to decimate the
+DEM for the low-zoom band, and `tile-join` for the merge. (Alternative
+considered: cells own full z0–9 and merge with `tile-join` over overlapping
+low-zoom tiles — rejected as less uniform and it simplifies low zoom unevenly
+per cell.)
+
+### Already built
+
+Most of the machinery exists on the `mosaic` branch: `scripts/build` does
+bbox + zoom-band builds via `OUT_MBTILES`; `terrain`/`contour` honor
+`BBOX`/`MIN_ZOOM`/`MAX_ZOOM`; `scripts/merge-tiles` unions bands
+(`INSERT OR IGNORE` / `tile-join`). The new work is the **CI matrix** + a
+`build` tweak to split the global base into low-zoom-global + high-zoom-cells.
+
+### Cell count is not capped at 20
+
+The ~20-runner limit is a *concurrency* cap, not a job cap — define as many
+cells as you like and GitHub queues the overflow, draining them through ~20
+runners in waves. So oversharding is free to *schedule*, and it
+**load-balances uneven density for free**: a trench/coastline-dense cell can
+occupy one runner for its full duration while another runner churns through
+several near-empty ocean cells. Uniform geographic cells have wildly uneven
+feature counts, so more, smaller cells smooth out stragglers better than a
+hand-tuned 16.
+
+The ceiling: each cell re-pays fixed per-job cost (checkout + image pull + DEM
+clip/pull), and the merge job's fan-in grows with cell count. So finer isn't
+free — past some point the overhead dominates the work. `# ponytail: start at
+16, then try 32–64 and compare wall-clock; stop when per-job overhead eats the
+gains.`
+
+Tuning knobs: the low/high split zoom and the cell count.
+
+## Lever 2 — Cache the smoothed DEM (native first)
+
+So a re-run (tweaked contour color, new zoom ceiling) doesn't recompute hours
+of unchanged work. **Cache the one artifact that's expensive *and* shared: the
+global smoothed DEM.** Computed once (~hours, >4 GB), pulled by every cell.
+Once sharded, the per-cell contour/tile work is cheap enough not to be worth
+caching — so there's only this one thing to cache, which is what makes the
+native tools viable.
+
+Climb the ladder; stop at the first rung that holds:
+
+### Rung 1 — `actions/cache` (try this first)
+
+The native cache caps at 10 GB/repo, but post-sharding the smoothed DEM is the
+*only* entry — one ~5–8 GB artifact fits. Key it by content so it
+regenerates only when an input changes:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: work/*_smoothed.tif
+    key: smoothdem-${{ env.GEBCO_YEAR }}-${{ hashFiles('scripts/smooth-dem','scripts/blur') }}
+```
+
+`hashFiles` over the producing scripts + the immutable `GEBCO_YEAR` *is* the
+content key — change either and the key misses → regenerate. No bash helper,
+no extra creds. The build just checks `cached "$SMOOTHED"` as it already does;
+the cache step restores the file before the job runs.
+
+Caveats to measure: confirm the compressed DEM lands under 10 GB, and that
+other caches don't evict it (LRU across the 10 GB pool).
+
+### Rung 2 — fall back to R2 only if Rung 1 doesn't fit
+
+Move here only if the DEM exceeds 10 GB compressed, eviction churns it, or you
+later need to cache several per-cell intermediates too. Reuses the existing R2
+access (`aws s3 cp --endpoint-url` + `R2_*` secrets from `publish-r2`) and the
+local `cached()` guard — pull-before, push-after. Helper in `config.sh`:
+
+```bash
+# Content-addressable R2 cache. Empty R2_CACHE (local dev) → no-op.
+R2_CACHE="${R2_CACHE:-}"          # e.g. s3://bucket/cache, set in CI
+ckey() { printf '%s\0' "$@" | sha256sum | cut -c1-16; }
+cache_pull() { [[ -n "$R2_CACHE" && -z "$FORCE" ]] && \
+  aws s3 cp "$R2_CACHE/$2/${1##*/}" "$1" --endpoint-url "$R2_ENDPOINT" --quiet 2>/dev/null; }
+cache_push() { [[ -n "$R2_CACHE" ]] && \
+  aws s3 cp "$1" "$R2_CACHE/$2/${1##*/}" --endpoint-url "$R2_ENDPOINT" --quiet 2>/dev/null || true; }
+```
+
+```bash
+KEY=$(ckey "$(cat "$SCRIPT_DIR"/smooth-dem "$SCRIPT_DIR"/blur)" "$GEBCO_YEAR" "$DEM_BLUR$MASK_BLUR$SLOPE_LOW$SLOPE_HIGH")
+if cached "$SMOOTHED" || cache_pull "$SMOOTHED" "$KEY"; then log "smoothed DEM: cache hit"
+else "$SCRIPT_DIR/smooth-dem" "$DEM" "$SMOOTHED"; cache_push "$SMOOTHED" "$KEY"; fi
+```
+
+Same content key, just self-managed: `hash(producing scripts + source
+identifier + params)`. Get right if you go here:
+- **Don't hash the 7 GB input** — key the root on `GEBCO_YEAR` (immutable per
+  year). Hash only the scripts.
+- **Chain keys** only if caching downstream stages: a stage folds its input's
+  key into its own so changes cascade. Skip until needed.
+- **R2 lifecycle rule** (expire `cache/` after ~30 days) so stale content-keys
+  don't pile up — a bucket rule, not GC code.
+
+> `upload-artifact` is for the *intra-run* cell→merge handoff (needed by
+> sharding anyway), not cross-run caching — artifacts aren't content-keyed and
+> expire. Different job, don't conflate it with the DEM cache.
+
+## Order of work
+
+1. Shard first — it's the prerequisite (caching a job that can't finish doesn't
+   help). Get a green global build.
+2. Add the smoothed-DEM cache second — turns the green build fast on re-runs.
+3. Everything else (per-stage caching, key-chaining) is deferred until the DEM
+   cache alone proves insufficient.

--- a/index.js
+++ b/index.js
@@ -56,41 +56,37 @@ const style = {
       type: "color-relief",
       source: "terrain-dem",
       paint: {
+        // Banded light-blue ramp ported from seamap's bathymetry-relief layer.
         "color-relief-color": [
           "interpolate",
-          ["exponential", 0.8],
+          ["linear"],
           ["elevation"],
-          // Deep ocean — very subtle, just for context
-          -11000,
-          "#F0F4F8",
-          -6000,
-          "#E4EBF2",
-          -2000,
-          "#D4DFEA",
-          -200,
-          "#C0D0E0", // continental shelf edge
-          // Continental shelf
+          -10000,
+          "#bae7fe",
+          -50.1,
+          "#e9f7ff",
           -50,
-          "#90ABC8",
+          "#bae7fe",
+          -20.1,
+          "#bae7fe",
           -20,
-          "#7899BC", // ECDIS deep contour
-          -15,
-          "#6A8DB4", // Panamax draft + UKC
-          // Critical navigation zone
+          "#9adcfe",
+          -10.1,
+          "#9adcfe",
           -10,
-          "#5B80AC",
+          "#83d4fe",
+          -5.1,
+          "#83d4fe",
           -5,
-          "#4A72A2", // ECDIS safety contour
-          -3,
-          "#3A6498", // recreational draft limit
+          "#73cefe",
+          -2.1,
+          "#73cefe",
           -2,
-          "#2C5690",
-          -1,
-          "#1E4888",
+          "#68cafe",
+          -0.01,
+          "#68cafe",
+          // Land — transparent so the OSM base shows through (gebco-specific)
           0,
-          "#133C80", // chart datum
-          // Land — transparent so base map shows through
-          0.001,
           "rgba(0, 0, 0, 0)",
         ],
         "color-relief-opacity": 0.85,
@@ -114,18 +110,9 @@ const style = {
       source: "contours",
       "source-layer": "contours",
       paint: {
-        "line-color": "rgba(0, 20, 60, 0.2)",
-        "line-width": [
-          "step",
-          ["to-number", ["get", "depth_abs_m"]],
-          0.6, // < 50m
-          50,
-          0.8,
-          200,
-          1.0,
-          1000,
-          1.2,
-        ],
+        "line-color": "#777",
+        "line-width": 0.5,
+        "line-opacity": 0.33,
       },
     },
     {
@@ -138,15 +125,14 @@ const style = {
       layout: {
         "symbol-placement": "line",
         "text-field": ["concat", ["to-string", ["get", "depth_abs_m"]], "m"],
-        "text-size": 11,
+        "text-size": ["interpolate", ["linear"], ["zoom"], 8, 8, 13, 10],
         "text-font": ["Open Sans Regular"],
+        "text-letter-spacing": 0.1,
         "text-max-angle": 30,
         "text-padding": 50,
       },
       paint: {
-        "text-color": "rgba(0, 20, 60, 0.8)",
-        "text-halo-color": "rgba(255, 255, 255, 0.6)",
-        "text-halo-width": 1.5,
+        "text-color": "#777",
       },
     },
   ],

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -61,6 +61,12 @@ MIN_ZOOM="${MIN_ZOOM:-0}"
 SOURCES_CONF="${SOURCES_CONF:-${PROJECT_DIR}/scripts/sources.conf}"
 MOSAIC_VRT="${WORK_DIR}/mosaic.vrt"
 
+# OSM water polygons — contours are clipped to these so land/intertidal features
+# don't produce spurious lines (more accurate than the depth<0 filter alone).
+# Download: https://osmdata.openstreetmap.de/data/water-polygons.html
+# If absent, the contour step falls back to depth<0 only.
+WATER_POLYGONS="${WATER_POLYGONS:-${DATA_DIR}/water-polygons-split-4326/water_polygons.shp}"
+
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 log() { echo "[$(date '+%H:%M:%S')] $*" >&2; }
 

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -33,7 +33,9 @@ BBOX="${BBOX:-}"
 # ─── Contour levels ──────────────────────────────────────────────────────────
 # Non-uniform: fine intervals for shallow water, coarse for deep.
 # Must be in increasing order (most negative first) for gdal_contour -fl.
-CONTOUR_LEVELS="-10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000 -500 -200 -150 -100 -75 -50 -45 -40 -35 -30 -25 -20 -15 -14 -13 -12 -11 -10 -9 -8 -7 -6 -5 -4 -3 -2 -1"
+# Overridable so the sharded low-zoom band can pass only the deep levels that
+# render at z≤7 (see SCALING.md / the tippecanoe filter in scripts/contour).
+CONTOUR_LEVELS="${CONTOUR_LEVELS:--10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000 -500 -200 -150 -100 -75 -50 -45 -40 -35 -30 -25 -20 -15 -14 -13 -12 -11 -10 -9 -8 -7 -6 -5 -4 -3 -2 -1}"
 
 # ─── Terrain RGB ──────────────────────────────────────────────────────────────
 # GEBCO is 15 arc-second (~450m at equator). Zoom 9 ≈ 305m/pixel — a good

--- a/scripts/contour
+++ b/scripts/contour
@@ -8,7 +8,7 @@
 #   ./scripts/contour [input.tif]
 
 source "$(dirname "$0")/config.sh"
-check_deps gdal_contour ogr2ogr tippecanoe
+check_deps gdal_contour ogr2ogr tippecanoe gdalinfo jq
 
 SCRIPT_DIR="$(dirname "$0")"
 resolve_input_dem "${1:-}"
@@ -36,6 +36,35 @@ if [[ -z "${SKIP_SLOPE_SMOOTH}" ]]; then
     "${SCRIPT_DIR}/smooth-dem" "${DEM}" "${SMOOTHED}"
   fi
   DEM="${SMOOTHED}"
+fi
+
+# ─── Step 1b: Clip DEM to water so gdal_contour skips land ────────────────────
+# Masking land to nodata here means gdal_contour never generates land contours
+# (CUDEM is topobathy) — far less vector work than contouring everything and
+# clipping the lines at the end. Done after smoothing so the blur keeps full
+# coastal context. gdal_contour stops cleanly at the nodata edge (no coast ring).
+if [[ -f "${WATER_POLYGONS}" ]]; then
+  CLIPPED_DEM="${OUTPUT_FGB%.fgb}_water_dem.tif"
+  if cached "${CLIPPED_DEM}"; then
+    log "Water-clipped DEM already exists"
+  else
+    rm -f "${CLIPPED_DEM}"
+    log "Clipping DEM to water polygons..."
+    # Restrict the (global) water layer to the DEM extent first so the cutline
+    # rasterization stays fast on regional builds.
+    read -r W S E N < <(gdalinfo -json "${DEM}" \
+      | jq -r '.cornerCoordinates | "\(.lowerLeft[0]) \(.lowerLeft[1]) \(.upperRight[0]) \(.upperRight[1])"')
+    WATER_BBOX="${OUTPUT_FGB%.fgb}_water.fgb"
+    rm -f "${WATER_BBOX}"
+    ogr2ogr -f FlatGeobuf "${WATER_BBOX}" "${WATER_POLYGONS}" -spat "${W}" "${S}" "${E}" "${N}"
+    # -32768 is below the deepest contour level, so it's never contoured.
+    gdalwarp -q -cutline "${WATER_BBOX}" -dstnodata -32768 -ot Float32 \
+      -overwrite "${DEM}" "${CLIPPED_DEM}"
+    rm -f "${WATER_BBOX}"
+  fi
+  DEM="${CLIPPED_DEM}"
+else
+  log "No water polygons (${WATER_POLYGONS}); contouring full DEM (land included)."
 fi
 
 # ─── Step 2: Generate contours at fixed levels ───────────────────────────────
@@ -73,22 +102,18 @@ if cached "${OUTPUT_FGB}"; then
 else
   rm -f "${OUTPUT_FGB}"
   log "Enriching contours..."
-  # Clip to OSM water polygons if available, to remove any contours that fall
-  # on land. This is more accurate than the depth_m < 0 filter alone.
+  # Add the depth_abs_m label attribute (positive depth, used by the viewer).
+  # Land was already excluded by the Step 1b DEM clip, so no vector clip here.
+  # No WHERE filter: every contour level in config is sub-zero.
   ogr2ogr -f FlatGeobuf "${OUTPUT_FGB}" "${CONTOURS_SMOOTH}" \
-    -dialect sqlite \
-    -sql "
-      SELECT geometry, depth_m,
-        CAST(-depth_m AS INTEGER) AS depth_abs_m
-      FROM contour
-      WHERE depth_m < 0
-    "
+    -nlt PROMOTE_TO_MULTI -dialect sqlite \
+    -sql "SELECT geometry, depth_m, CAST(-depth_m AS INTEGER) AS depth_abs_m FROM contour"
   COUNT=$(ogrinfo -al -so "${OUTPUT_FGB}" 2>/dev/null | grep "Feature Count" | awk '{print $NF}')
   log "  → ${COUNT} ocean features"
 fi
 
 # Clean up intermediates (never the input DEM)
-rm -f "${CONTOURS_RAW}" "${CONTOURS_SMOOTH}"
+rm -f "${CONTOURS_RAW}" "${CONTOURS_SMOOTH}" "${CLIPPED_DEM:-}"
 [[ -n "${SKIP_SLOPE_SMOOTH}" ]] || rm -f "${SMOOTHED}"
 
 # ─── Step 5: Tile to PMTiles ─────────────────────────────────────────────────
@@ -112,8 +137,9 @@ else
       "*": [
         "any",
         ["all", ["<=", "$zoom", 4],  ["<=", "depth_m", -1000]],
-        ["all", ["<=", "$zoom", 6],  ["<=", "depth_m", -200]],
-        ["all", ["<=", "$zoom", 8],  ["<=", "depth_m", -50]],
+        ["all", ["<=", "$zoom", 6],  ["<=", "depth_m", -100]],
+        ["all", ["<=", "$zoom", 7],  ["<=", "depth_m", -50]],
+        ["all", ["<=", "$zoom", 8],  ["<=", "depth_m", -25]],
         [">=", "$zoom", 9]
       ]
     }' \

--- a/scripts/contour
+++ b/scripts/contour
@@ -116,6 +116,15 @@ fi
 rm -f "${CONTOURS_RAW}" "${CONTOURS_SMOOTH}" "${CLIPPED_DEM:-}"
 [[ -n "${SKIP_SLOPE_SMOOTH}" ]] || rm -f "${SMOOTHED}"
 
+# All-land extents (e.g. an Antarctic shard) yield no ocean contours. tippecanoe
+# errors on empty input, so skip tiling and emit no band — the merge just unions
+# whatever bands exist.
+FEATURES=$(ogrinfo -al -so "${OUTPUT_FGB}" 2>/dev/null | awk '/Feature Count/{print $NF}')
+if [[ "${FEATURES:-0}" -eq 0 ]]; then
+  log "No ocean contours in this extent — skipping vector tiles."
+  exit 0
+fi
+
 # ─── Step 5: Tile to PMTiles ─────────────────────────────────────────────────
 # In banded mode (OUT_MBTILES set) tippecanoe writes an MBTiles band; build
 # tile-joins the bands into the final PMTiles.

--- a/scripts/contour
+++ b/scripts/contour
@@ -132,6 +132,7 @@ else
     -A '<a href="https://www.gebco.net">GEBCO</a>' \
     -N "Bathymetric contour lines derived from the GEBCO grid." \
     -Z "${MIN_ZOOM}" -z "${MAX_ZOOM}" -P -q \
+    --drop-densest-as-needed \
     -y depth_m -y depth_abs_m \
     -j '{
       "*": [

--- a/scripts/contour
+++ b/scripts/contour
@@ -94,6 +94,9 @@ else
   log "Smoothing contour geometries..."
   python3 "${SCRIPT_DIR}/smooth-contours" \
     "${CONTOURS_RAW}" "${CONTOURS_SMOOTH}" 0.0002 5
+  # Free the raw FGB now so it doesn't coexist with smoothed + enriched during
+  # Step 4 (3 large copies overflow disk on ocean-heavy shards).
+  rm -f "${CONTOURS_RAW}"
 fi
 
 # ─── Step 4: Enrich attributes ───────────────────────────────────────────────

--- a/scripts/ingest
+++ b/scripts/ingest
@@ -9,7 +9,7 @@
 #   id | url | datum_offset_m | priority | bbox | max_zoom
 
 source "$(dirname "$0")/config.sh"
-check_deps gdalwarp gdal_calc.py curl
+check_deps gdalwarp gdal_calc.py gdalsrsinfo curl
 
 id="${1:?Usage: ingest <source-id>}"
 row="$(sources_rows | awk -F'|' -v id="$id" '$1==id{print; exit}')"
@@ -23,7 +23,14 @@ if cached "${NORM}"; then
 fi
 
 # ─── Fetch ───────────────────────────────────────────────────────────────────
-if [[ "${url}" == http*://* ]]; then
+if [[ "${url}" == s3://* ]]; then
+  # Read directly from public S3 via GDAL's /vsis3/. The bbox clip below pulls
+  # only the intersecting tiles, so pointing at a dataset's master .vrt costs no
+  # bulk download — GDAL streams just the tiles that overlap the region.
+  export AWS_NO_SIGN_REQUEST=YES
+  SRC="/vsis3/${url#s3://}"
+  log "Reading ${id} from public S3: ${url}"
+elif [[ "${url}" == http*://* ]]; then
   SRC="${DATA_DIR}/${id}.${url##*.}"
   if cached "${SRC}"; then
     log "Source already downloaded: ${SRC}"
@@ -41,10 +48,16 @@ IFS=',' read -r W S E N <<< "${bbox}"
 WARP="${WORK_DIR}/${id}_warp.tif"
 rm -f "${WARP}"
 log "Reprojecting ${id} to EPSG:4326 over ${bbox}..."
+# Use the source's HORIZONTAL CRS as -s_srs (proj4 drops any vertical datum) so
+# gdalwarp doesn't apply a vertical/geoid shift — e.g. CUDEM's NAVD88 would be
+# transformed to ellipsoidal height (~tens of metres in mid-latitudes), pushing
+# land negative. We handle vertical ourselves via datum_offset_m below.
 # -ot Float32 keeps types uniform across sources so gdalbuildvrt can mosaic them.
 # Source nodata propagates to the output so the base shows through any gaps.
-gdalwarp -t_srs EPSG:4326 -te "${W}" "${S}" "${E}" "${N}" \
-  -r bilinear -ot Float32 -overwrite "${SRC}" "${WARP}" >&2
+SRC_HCRS="$(gdalsrsinfo -o proj4 --single-line "${SRC}" 2>/dev/null)"
+warp_args=(-t_srs EPSG:4326 -te "${W}" "${S}" "${E}" "${N}" -r bilinear -ot Float32 -overwrite)
+[[ -n "${SRC_HCRS}" ]] && warp_args=(-s_srs "${SRC_HCRS}" "${warp_args[@]}")
+gdalwarp "${warp_args[@]}" "${SRC}" "${WARP}" >&2
 
 # ─── Apply constant datum offset ─────────────────────────────────────────────
 # ponytail: a single offset to ~MSL, not full VDatum. Revisit in Phase 3 if seams show.

--- a/scripts/lowzoom
+++ b/scripts/lowzoom
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the global low-zoom band (z0 .. SPLIT_ZOOM-1) for one layer.
+#
+# Low zoom can't be sharded — a z0 tile spans the globe. Terrain is cheap from
+# the full DEM at low zoom. Contour can't be: gdal_contour generates every
+# feature regardless of zoom, so it runs on a *downsampled* DEM with only the
+# deep levels that render below SPLIT_ZOOM. See SCALING.md.
+#
+# Usage: SPLIT_ZOOM=8 ./scripts/lowzoom <terrain|contour>
+set -euo pipefail
+SCRIPT_DIR="$(dirname "$0")"
+source "${SCRIPT_DIR}/config.sh"
+
+STEP="${1:?usage: lowzoom <terrain|contour>}"
+SPLIT_ZOOM="${SPLIT_ZOOM:-8}"
+TOPZ=$(( SPLIT_ZOOM - 1 ))
+
+# Global DEM (BBOX unset → full ±85°). download skips the unzip when the
+# extracted grid is already present (warmed by the prepare job's cache).
+BBOX="" "${SCRIPT_DIR}/download" >/dev/null
+DEM="${WORK_DIR}/gebco_clipped.tif"
+
+case "${STEP}" in
+  terrain)
+    MIN_ZOOM=0 TERRAIN_MAX_ZOOM="${TOPZ}" \
+      OUT_MBTILES="${WORK_DIR}/terrain_lowzoom.mbtiles" \
+      "${SCRIPT_DIR}/terrain" "${DEM}"
+    ;;
+  contour)
+    # Hardcoded for SPLIT_ZOOM=8. -tr 0.01 ≈ z7 pixel (~0.011°); the
+    # level subset is everything the tippecanoe filter shows at z≤7 (≤ -50m).
+    # If SPLIT_ZOOM changes, retune both against the filter in scripts/contour.
+    LOWDEM="${WORK_DIR}/gebco_lowzoom.tif"
+    gdalwarp -tr 0.01 0.01 -r bilinear -overwrite "${DEM}" "${LOWDEM}" >&2
+    MIN_ZOOM=0 MAX_ZOOM="${TOPZ}" SKIP_SLOPE_SMOOTH=1 \
+      CONTOUR_LEVELS="-10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000 -500 -200 -150 -100 -75 -50" \
+      OUT_MBTILES="${WORK_DIR}/contour_lowzoom.mbtiles" \
+      "${SCRIPT_DIR}/contour" "${LOWDEM}"
+    ;;
+  *)
+    echo "unknown step: ${STEP} (want terrain|contour)" >&2; exit 1 ;;
+esac

--- a/scripts/lowzoom
+++ b/scripts/lowzoom
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(dirname "$0")"
 source "${SCRIPT_DIR}/config.sh"
 
 STEP="${1:?usage: lowzoom <terrain|contour>}"
-SPLIT_ZOOM="${SPLIT_ZOOM:-8}"
+SPLIT_ZOOM="${SPLIT_ZOOM:-5}"
 TOPZ=$(( SPLIT_ZOOM - 1 ))
 
 # Global DEM (BBOX unset → full ±85°). download skips the unzip when the
@@ -27,13 +27,14 @@ case "${STEP}" in
       "${SCRIPT_DIR}/terrain" "${DEM}"
     ;;
   contour)
-    # Hardcoded for SPLIT_ZOOM=8. -tr 0.01 ≈ z7 pixel (~0.011°); the
-    # level subset is everything the tippecanoe filter shows at z≤7 (≤ -50m).
-    # If SPLIT_ZOOM changes, retune both against the filter in scripts/contour.
+    # Tuned for SPLIT_ZOOM=5 (lowzoom owns z0–4). -tr 0.08 ≈ z4 pixel (~0.088°);
+    # the levels are all the tippecanoe filter shows at z≤4 (≤ -1000m). Chaikin
+    # corner-smoothing is invisible at these zooms, so skip it. If SPLIT_ZOOM
+    # changes, retune -tr and the levels against the filter in scripts/contour.
     LOWDEM="${WORK_DIR}/gebco_lowzoom.tif"
-    gdalwarp -tr 0.01 0.01 -r bilinear -overwrite "${DEM}" "${LOWDEM}" >&2
-    MIN_ZOOM=0 MAX_ZOOM="${TOPZ}" SKIP_SLOPE_SMOOTH=1 \
-      CONTOUR_LEVELS="-10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000 -500 -200 -150 -100 -75 -50" \
+    gdalwarp -tr 0.08 0.08 -r bilinear -overwrite "${DEM}" "${LOWDEM}" >&2
+    MIN_ZOOM=0 MAX_ZOOM="${TOPZ}" SKIP_SLOPE_SMOOTH=1 SKIP_CHAIKIN=1 \
+      CONTOUR_LEVELS="-10000 -8000 -6000 -5000 -4000 -3000 -2000 -1500 -1000" \
       OUT_MBTILES="${WORK_DIR}/contour_lowzoom.mbtiles" \
       "${SCRIPT_DIR}/contour" "${LOWDEM}"
     ;;

--- a/scripts/merge-bands
+++ b/scripts/merge-bands
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Union the per-band MBTiles (low-zoom + cells) into one PMTiles per layer.
+#
+# Bands are named <step>_<id>.mbtiles (e.g. terrain_x0y0, contour_lowzoom).
+# Terrain is raster — a real `tiles` table, disjoint tiles → merge-tiles sqlite
+# union. Contour is vector — tippecanoe writes `tiles` as a VIEW that can't be
+# sqlite-indexed → tile-join (straight to PMTiles). See SCALING.md.
+#
+# Usage: ./scripts/merge-bands <bands-dir> <out-dir>
+set -euo pipefail
+SCRIPT_DIR="$(dirname "$0")"
+source "${SCRIPT_DIR}/config.sh"
+check_deps pmtiles tile-join sqlite3
+
+BANDS="${1:?usage: merge-bands <bands-dir> <out-dir>}"
+OUT="${2:?need out dir}"
+mkdir -p "${OUT}"
+
+log "Merging terrain bands (sqlite union)..."
+"${SCRIPT_DIR}/merge-tiles" "${OUT}/terrain.mbtiles" "${BANDS}"/terrain_*.mbtiles >/dev/null
+pmtiles convert "${OUT}/terrain.mbtiles" "${OUT}/terrain.pmtiles" >&2
+
+log "Merging contour bands (tile-join)..."
+tile-join -f -o "${OUT}/contours.pmtiles" "${BANDS}"/contour_*.mbtiles >&2
+
+log "Merged: ${OUT}/terrain.pmtiles, ${OUT}/contours.pmtiles"

--- a/scripts/merge-bands
+++ b/scripts/merge-bands
@@ -18,9 +18,17 @@ mkdir -p "${OUT}"
 
 log "Merging terrain bands (sqlite union)..."
 "${SCRIPT_DIR}/merge-tiles" "${OUT}/terrain.mbtiles" "${BANDS}"/terrain_*.mbtiles >/dev/null
-pmtiles convert "${OUT}/terrain.mbtiles" "${OUT}/terrain.pmtiles" >&2
+# Free the bands before the pmtiles tempfile grows — otherwise bands + merged
+# mbtiles + tempfile coexist and fill the disk.
+rm -f "${BANDS}"/terrain_*.mbtiles
+# --tmpdir on the output filesystem so convert *renames* its tempfile into place
+# instead of copying it (a cross-filesystem /tmp → output copy means input +
+# tempfile + copy ≈ 3× the tileset, which overflows the runner).
+pmtiles convert --tmpdir "${OUT}" "${OUT}/terrain.mbtiles" "${OUT}/terrain.pmtiles" >&2
+rm -f "${OUT}/terrain.mbtiles"
 
 log "Merging contour bands (tile-join)..."
 tile-join -f -o "${OUT}/contours.pmtiles" "${BANDS}"/contour_*.mbtiles >&2
+rm -f "${BANDS}"/contour_*.mbtiles
 
 log "Merged: ${OUT}/terrain.pmtiles, ${OUT}/contours.pmtiles"

--- a/scripts/shard-cells
+++ b/scripts/shard-cells
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Emit a grid of tile-aligned bboxes covering the globe, as a JSON matrix.
+
+Cells are aligned to the Web Mercator tile grid at SPLIT_ZOOM, so every output
+tile at SPLIT_ZOOM and deeper belongs to exactly one cell — the merge is then a
+collision-free union (see SCALING.md). Feed the JSON to a GitHub Actions matrix.
+
+Usage:
+    scripts/shard-cells [cols] [rows] [split_zoom]   # default 4 4 8 → 16 cells
+
+cols and rows must divide 2**split_zoom (whole-tile cells). Prints:
+    [{"id": "x0y0", "bbox": "west,south,east,north"}, ...]
+"""
+
+import json
+import math
+import sys
+
+
+def tile_lon(x, n):
+    return x / n * 360.0 - 180.0
+
+
+def tile_lat(y, n):
+    # Web Mercator tile-y → latitude (north edge of row y).
+    return math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
+
+
+def cells(cols, rows, zoom):
+    n = 2 ** zoom
+    if n % cols or n % rows:
+        sys.exit(f"cols ({cols}) and rows ({rows}) must divide 2**{zoom}={n}")
+    out = []
+    for c in range(cols):
+        x0, x1 = c * n // cols, (c + 1) * n // cols
+        for r in range(rows):
+            y0, y1 = r * n // rows, (r + 1) * n // rows  # y grows southward
+            west, east = tile_lon(x0, n), tile_lon(x1, n)
+            north, south = tile_lat(y0, n), tile_lat(y1, n)
+            out.append({"id": f"x{c}y{r}", "bbox": f"{west},{south},{east},{north}"})
+    return out
+
+
+def _check():
+    cs = cells(4, 4, 8)
+    assert len(cs) == 16, len(cs)
+    # Globe is covered exactly once on the x axis: west edges are the 4 meridians.
+    wests = sorted({float(c["bbox"].split(",")[0]) for c in cs})
+    assert wests == [-180.0, -90.0, 0.0, 90.0], wests
+    # Tile-aligned: a finer grid's edges are a superset of a coarser grid's.
+    coarse = {c["bbox"].split(",")[0] for c in cells(2, 2, 8)}
+    fine = {c["bbox"].split(",")[0] for c in cells(4, 4, 8)}
+    assert coarse <= fine, "cell edges not nested → not tile-aligned"
+    # Divisibility guard fires.
+    try:
+        cells(3, 3, 8)  # 256 % 3 != 0
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("expected non-dividing grid to error")
+    print("ok")
+
+
+if __name__ == "__main__":
+    if sys.argv[1:2] == ["--check"]:
+        _check()
+    else:
+        a = sys.argv[1:]
+        print(json.dumps(cells(int(a[0]) if len(a) > 0 else 4,
+                                int(a[1]) if len(a) > 1 else 4,
+                                int(a[2]) if len(a) > 2 else 8)))

--- a/scripts/sources.conf
+++ b/scripts/sources.conf
@@ -19,6 +19,15 @@
 #
 # Lines starting with # and blank lines are ignored.
 
-# NOAA CUDEM 1/9 arc-sec (~3.4 m), coastal Georgia. NAVD88 ≈ MSL here, offset 0.
-# For CI, mirror this tile to R2 (chs.coast.noaa.gov throttles bulk pulls).
-cudem_se | https://chs.coast.noaa.gov/htdata/raster2/elevation/NCEI_ninth_Topobathy_2014_8483/southeast/ncei19_n31x25_w081x50_2019v1.tif | 0 | 1 | -81.5,31.0,-81.25,31.25 | 13
+# NOAA CUDEM 1/9 arc-sec (~3.4 m). Areas read from the dataset's master VRT on
+# public S3 (/vsis3/) — a bbox clip pulls only the intersecting tiles, no bulk
+# download. NAVD88 ≈ MSL on these coasts, offset 0. Add a row per area you want;
+# comment one out to drop it.
+#
+# NOTE: this master VRT is the 2014 mosaic and does NOT include later subdirs
+# (e.g. southeast/ GA-SC 2019 tiles). Regions it covers: AK, CA, FL, LA_MS, NC,
+# OR, columbia_river, northeast_sandy, wash_*. Covering a missing subdir needs a
+# per-subdir VRT (list tiles → gdalbuildvrt) — a Phase 2 follow-up. Territories
+# (Guam/Hawaii/PR/…) are separate datasets with their own VRTs.
+cudem_ne    | s3://noaa-nos-coastal-lidar-pds/dem/NCEI_ninth_Topobathy_2014_8483/NCEI_ninth_Topobathy_2014_m8483_EPSG-4269.vrt | 0 | 1 | -74.2,40.45,-73.85,40.75 | 13
+cudem_puget | s3://noaa-nos-coastal-lidar-pds/dem/NCEI_ninth_Topobathy_2014_8483/NCEI_ninth_Topobathy_2014_m8483_EPSG-4269.vrt | 0 | 1 | -122.55,47.4,-122.2,47.8 | 13


### PR DESCRIPTION
## What

Splits the monolithic global terrain+contour build into a parallel, sharded CI pipeline to get under GitHub's 6h job ceiling (terrain) and the runner disk limit (contour). Design doc: SCALING.md.

## Pipeline

- **plan** — `scripts/shard-cells` emits a tile-aligned cell grid as a JSON matrix (cols×rows, default 4×4 = 16 cells; `SHARD_COLS`/`SHARD_ROWS` dispatch inputs).
- **cells** — matrix of cell × {terrain, contour}, each clips its bbox and builds the z8–9 band.
- **lowzoom** — global z0–7; terrain from full DEM, contour from a **downsampled** DEM with **deep-only levels** (nothing shallower than −50 m renders below z9).
- **merge** — unions bands → PMTiles: `merge-tiles` (sqlite) for raster terrain, `tile-join` for vector contour.

## Status — WIP

- ✅ Smoke-tested locally on one cell: every stage + both merge paths produce valid z0–9 PMTiles.
- 🐛 Caught & fixed: contour bands can't be sqlite-unioned (tippecanoe `tiles` is a VIEW) → use `tile-join`.
- ⬜ Not yet run on full CI (docker/matrix wiring, smoothing, real wall-clock/load-balance numbers).
- ⬜ No DEM edge buffer yet → possible faint seams at cell boundaries; upgrade path noted in SCALING.md.
- ⬜ Lever 2 (smoothed-DEM cache) deferred — sharding removed its premise.

Base is `mosaic` (inherits the bbox/`build`/`merge-tiles` machinery).