### PR TITLE
Add NOAA NCEI Great Lakes Bathymetry (fills the Canadian Great Lakes)

### DIFF
--- a/pipelines/source_download_greatlakes.py
+++ b/pipelines/source_download_greatlakes.py
@@ -6,12 +6,14 @@ low-water chart-datum analog), so the lake bed is negative and the surrounding l
 These are full open-lake grids, so they cover both the US and Canadian sides (the lakes are
 single water bodies — this fills the Canadian Great Lakes that had no source).
 
-file_list.txt holds the six tarball URLs. The recipe then drops land above LWD
-(source_datum --clamp-positive → lake-only) and assigns EPSG:4269 in normalize (the CRS
-ships as a .prj sidecar we don't keep). No login, ~220 MB total.
+file_list.txt holds the five main-lake tarball URLs (Superior, Michigan, Huron, Erie,
+Ontario; St. Clair — tiny, Huron–Erie corridor — isn't published at NGDC's path). The
+recipe then drops land above LWD (source_datum --clamp-positive → lake-only) and assigns
+EPSG:4269 in normalize (the CRS ships as a .prj sidecar we don't keep). No login, ~220 MB.
 """
 
 import os
+import shutil
 import sys
 import tarfile
 
@@ -34,10 +36,12 @@ def main():
         print(f"downloading {url}")
         utils.http_download(url, tgz)
         with tarfile.open(tgz) as t:
-            member = next(m for m in t.getmembers() if m.name.lower().endswith(".tif"))
-            name = os.path.basename(member.name)
-            with t.extractfile(member) as src, open(f"{out_dir}/{name}", "wb") as dst:
-                dst.write(src.read())
+            tifs = [m for m in t.getmembers() if m.name.lower().endswith("_lld.tif")]
+            if len(tifs) != 1:
+                sys.exit(f"expected exactly one *_lld.tif in {url}, found {len(tifs)}")
+            name = os.path.basename(tifs[0].name)
+            with t.extractfile(tifs[0]) as src, open(f"{out_dir}/{name}", "wb") as dst:
+                shutil.copyfileobj(src, dst)  # stream to disk, don't buffer the whole raster
             print(f"  extracted {name}")
         os.remove(tgz)
 

--- a/pipelines/source_download_greatlakes.py
+++ b/pipelines/source_download_greatlakes.py
@@ -1,0 +1,46 @@
+"""Fetch the NOAA NCEI Great Lakes Bathymetry grids and extract each lake's DEM.
+
+Each lake is a .tar.gz on ngdc.noaa.gov holding ``<lake>_lld/<lake>_lld.tif`` (+ .prj/.tfw):
+a 3 arc-sec (~90 m) NAD83 grid, elevation on each lake's **Low Water Datum** (LWD — a
+low-water chart-datum analog), so the lake bed is negative and the surrounding land positive.
+These are full open-lake grids, so they cover both the US and Canadian sides (the lakes are
+single water bodies — this fills the Canadian Great Lakes that had no source).
+
+file_list.txt holds the six tarball URLs. The recipe then drops land above LWD
+(source_datum --clamp-positive → lake-only) and assigns EPSG:4269 in normalize (the CRS
+ships as a .prj sidecar we don't keep). No login, ~220 MB total.
+"""
+
+import os
+import sys
+import tarfile
+
+import config
+import utils
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: source_download_greatlakes.py <source-id>")
+    source = sys.argv[1]
+    urls = config.file_list(source)
+    if not urls:
+        sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
+    out_dir = f"store/source/{source}"
+    os.makedirs(out_dir, exist_ok=True)
+
+    for i, url in enumerate(urls):
+        tgz = f"{out_dir}/_{i}.tar.gz"
+        print(f"downloading {url}")
+        utils.http_download(url, tgz)
+        with tarfile.open(tgz) as t:
+            member = next(m for m in t.getmembers() if m.name.lower().endswith(".tif"))
+            name = os.path.basename(member.name)
+            with t.extractfile(member) as src, open(f"{out_dir}/{name}", "wb") as dst:
+                dst.write(src.read())
+            print(f"  extracted {name}")
+        os.remove(tgz)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/source_download_greatlakes.py
+++ b/pipelines/source_download_greatlakes.py
@@ -6,8 +6,9 @@ low-water chart-datum analog), so the lake bed is negative and the surrounding l
 These are full open-lake grids, so they cover both the US and Canadian sides (the lakes are
 single water bodies — this fills the Canadian Great Lakes that had no source).
 
-file_list.txt holds the five main-lake tarball URLs (Superior, Michigan, Huron, Erie,
-Ontario; St. Clair — tiny, Huron–Erie corridor — isn't published at NGDC's path). The
+file_list.txt holds five tarball URLs (Superior, Michigan, Huron, Erie, Ontario) — which
+cover all six Great Lakes water bodies: NGDC's Erie grid is "Lake Erie and Lake Saint
+Clair", so Lake St. Clair rides along in erie_lld (no separate St. Clair grid exists). The
 recipe then drops land above LWD (source_datum --clamp-positive → lake-only) and assigns
 EPSG:4269 in normalize (the CRS ships as a .prj sidecar we don't keep). No login, ~220 MB.
 """

--- a/sources/great_lakes/Justfile
+++ b/sources/great_lakes/Justfile
@@ -1,6 +1,6 @@
 # NOAA NCEI Great Lakes Bathymetry (~90 m) — full open-lake, US + Canadian sides.
 # Run from pipelines/:  just ../sources/great_lakes/
-# source_download_greatlakes fetches the 6 lake tarballs and extracts each _lld.tif.
+# source_download_greatlakes fetches the 5 main-lake tarballs and extracts each _lld.tif.
 # Values are elevation on each lake's Low Water Datum (LWD): bed negative, land positive.
 # --clamp-positive drops cells above LWD (surrounding land) → lake-only; no negate, no offset
 # (LWD is already the low-water/chart datum). CRS is a .prj sidecar we drop → normalize

--- a/sources/great_lakes/Justfile
+++ b/sources/great_lakes/Justfile
@@ -1,0 +1,15 @@
+# NOAA NCEI Great Lakes Bathymetry (~90 m) — full open-lake, US + Canadian sides.
+# Run from pipelines/:  just ../sources/great_lakes/
+# source_download_greatlakes fetches the 6 lake tarballs and extracts each _lld.tif.
+# Values are elevation on each lake's Low Water Datum (LWD): bed negative, land positive.
+# --clamp-positive drops cells above LWD (surrounding land) → lake-only; no negate, no offset
+# (LWD is already the low-water/chart datum). CRS is a .prj sidecar we drop → normalize
+# assigns EPSG:4269 (NAD83 ≈ WGS84). Lakes are isolated → no ocean seam.
+[no-cd]
+default:
+    uv run python source_download_greatlakes.py great_lakes
+    uv run python source_datum.py great_lakes --clamp-positive
+    uv run python source_normalize.py great_lakes --crs EPSG:4269
+    uv run python source_bounds.py great_lakes
+    uv run python source_polygonize.py great_lakes 8
+    uv run python source_create_tarball.py great_lakes

--- a/sources/great_lakes/file_list.txt
+++ b/sources/great_lakes/file_list.txt
@@ -1,0 +1,9 @@
+# NOAA NCEI Great Lakes Bathymetry — the 5 main lakes, 3 arc-sec (~90 m), NAD83, LWD datum.
+# Full open-lake grids (US + Canadian sides), direct HTTP .tar.gz, no login. Lake St. Clair
+# (small, Huron–Erie corridor) isn't published at this path, so it's skipped — minor and
+# sitting between the Huron and Erie grids.
+https://www.ngdc.noaa.gov/mgg/greatlakes/superior/data/geotiff/superior_lld.geotiff.tar.gz
+https://www.ngdc.noaa.gov/mgg/greatlakes/michigan/data/geotiff/michigan_lld.geotiff.tar.gz
+https://www.ngdc.noaa.gov/mgg/greatlakes/huron/data/geotiff/huron_lld.geotiff.tar.gz
+https://www.ngdc.noaa.gov/mgg/greatlakes/erie/data/geotiff/erie_lld.geotiff.tar.gz
+https://www.ngdc.noaa.gov/mgg/greatlakes/ontario/data/geotiff/ontario_lld.geotiff.tar.gz

--- a/sources/great_lakes/file_list.txt
+++ b/sources/great_lakes/file_list.txt
@@ -1,7 +1,7 @@
-# NOAA NCEI Great Lakes Bathymetry — the 5 main lakes, 3 arc-sec (~90 m), NAD83, LWD datum.
-# Full open-lake grids (US + Canadian sides), direct HTTP .tar.gz, no login. Lake St. Clair
-# (small, Huron–Erie corridor) isn't published at this path, so it's skipped — minor and
-# sitting between the Huron and Erie grids.
+# NOAA NCEI Great Lakes Bathymetry — 5 grids, 3 arc-sec (~90 m), NAD83, LWD datum.
+# Full open-lake grids (US + Canadian sides), direct HTTP .tar.gz, no login. This covers all
+# SIX Great Lakes water bodies: NGDC's Erie grid is "Lake Erie AND Lake Saint Clair", so
+# St. Clair is included in erie_lld (confirmed ~4.6 m at the lake centre) — no separate grid.
 https://www.ngdc.noaa.gov/mgg/greatlakes/superior/data/geotiff/superior_lld.geotiff.tar.gz
 https://www.ngdc.noaa.gov/mgg/greatlakes/michigan/data/geotiff/michigan_lld.geotiff.tar.gz
 https://www.ngdc.noaa.gov/mgg/greatlakes/huron/data/geotiff/huron_lld.geotiff.tar.gz

--- a/sources/great_lakes/metadata.json
+++ b/sources/great_lakes/metadata.json
@@ -1,0 +1,8 @@
+{
+    "name": "NOAA NCEI Great Lakes Bathymetry (~90 m)",
+    "producer": "NOAA NCEI",
+    "website": "https://www.ncei.noaa.gov/products/great-lakes-bathymetry",
+    "license": "public domain (U.S. Government work)",
+    "max_zoom": 10,
+    "datum": "Low Water Datum (LWD) per lake — a low-water / chart-datum analog"
+}


### PR DESCRIPTION
The Canadian side of the Great Lakes had no source after NONNA was removed. NOAA NCEI's Great Lakes Bathymetry grids are **full open-lake** — both the US and Canadian sides, since the lakes are single water bodies — so they fill the gap.

**Source:** NOAA NCEI Great Lakes Bathymetry — 5 grids covering all **6** Great Lakes water bodies, ~90 m (3 arc-sec), NAD83, public domain, no login (~220 MB total). *(NGDC's Erie grid is "Lake Erie and Lake Saint Clair", so Lake St. Clair is included — confirmed ~4.6 m depth at the lake centre — with no separate St. Clair grid.)*

**Recipe** — `sources/great_lakes/` + `pipelines/source_download_greatlakes.py`:
- fetch the 5 lake `.tar.gz` grids, extract each `_lld.tif` (match the expected member; stream to disk)
- **datum: Low Water Datum (LWD)** per lake — a low-water / chart-datum analog, so it already fits the roadmap's *bias-shallow, low-water datum* principle; no negate, no offset
- `--clamp-positive` drops land above LWD → lake-only
- assign `EPSG:4269` (NAD83 ≈ WGS84), z10

**Validated:** Huron range −224.3 → 0.0 m (matches the lake's ~229 m max depth); the coverage polygon contains the reported Georgian Bay hole (−81.795, 45.292); Lake St. Clair centre reads −4.6 m. Builds green through the source stage.