### PR TITLE
Rename project to seascape

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
   AWS_ENDPOINT_URL: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
 
 jobs:
-  # Promote data:bathymetry/build/<sha>/ → tiles:bathymetry/<sha>/ — a cross-bucket
+  # Promote data:bathymetry/build/<sha>/ → tiles:seascape/<sha>/ — a cross-bucket
   # server-side copy out of the build bucket into the Worker-fronted serving bucket (no
   # rebuild). build/ is GC'd after 7 days; the tiles bucket has NO lifecycle rule, so the
   # live bundle is never collected out from under the Worker regardless of release
@@ -38,10 +38,10 @@ jobs:
     steps:
       - name: Promote build → tiles bucket
         run: |
-          echo "publishing bathymetry/build/$SHA → tiles:bathymetry/$SHA"
+          echo "publishing bathymetry/build/$SHA → tiles:seascape/$SHA"
           # manifest.json is copied last, so its presence means a complete prior promotion.
-          if aws s3 ls "s3://$TILES_BUCKET/bathymetry/$SHA/manifest.json" >/dev/null 2>&1; then
-            echo "tiles:bathymetry/$SHA already published — skipping promote"
+          if aws s3 ls "s3://$TILES_BUCKET/seascape/$SHA/manifest.json" >/dev/null 2>&1; then
+            echo "tiles:seascape/$SHA already published — skipping promote"
             exit 0
           fi
           if ! aws s3 ls "s3://$DATA_BUCKET/bathymetry/build/$SHA/manifest.json" >/dev/null 2>&1; then
@@ -56,27 +56,27 @@ jobs:
           # the runner (the upload sends no tagging header); contour-maxz.txt is a build-only
           # handoff, so it's just excluded like contour-shards/bundle-frags. New *promoted*
           # small files need the round-trip too; lower the threshold or switch to rclone.
-          aws s3 cp "s3://$DATA_BUCKET/bathymetry/build/$SHA/" "s3://$TILES_BUCKET/bathymetry/$SHA/" \
+          aws s3 cp "s3://$DATA_BUCKET/bathymetry/build/$SHA/" "s3://$TILES_BUCKET/seascape/$SHA/" \
             --recursive --exclude 'contour-shards/*' --exclude 'bundle-frags/*' \
             --exclude 'manifest.json' --exclude 'contour-maxz.txt' --copy-props none
           aws s3 cp "s3://$DATA_BUCKET/bathymetry/build/$SHA/manifest.json" - \
-            | aws s3 cp - "s3://$TILES_BUCKET/bathymetry/$SHA/manifest.json" --content-type application/json
+            | aws s3 cp - "s3://$TILES_BUCKET/seascape/$SHA/manifest.json" --content-type application/json
       - name: Prune old releases (keep newest 3)
         run: |
           # Count-based retention (current + 2 rollback targets), ordered by each
           # release's manifest.json mtime — never age/cadence dependent, so the tiles
           # bucket needs no lifecycle rule. The copy above runs first, so $SHA is always kept.
-          keep=$(aws s3 ls "s3://$TILES_BUCKET/bathymetry/" --recursive \
+          keep=$(aws s3 ls "s3://$TILES_BUCKET/seascape/" --recursive \
             | grep '/manifest\.json$' | sort -r | awk '{print $4}' | cut -d/ -f2 | head -3)
           [ -n "$keep" ] || { echo "::error::no releases found — refusing to prune"; exit 1; }
-          for sha in $(aws s3 ls "s3://$TILES_BUCKET/bathymetry/" | awk '{print $2}' | tr -d /); do
+          for sha in $(aws s3 ls "s3://$TILES_BUCKET/seascape/" | awk '{print $2}' | tr -d /); do
             grep -qx "$sha" <<<"$keep" || {
-              echo "pruning bathymetry/$sha"
-              aws s3 rm "s3://$TILES_BUCKET/bathymetry/$sha" --recursive
+              echo "pruning seascape/$sha"
+              aws s3 rm "s3://$TILES_BUCKET/seascape/$sha" --recursive
             }
           done
 
-  # Deploy the serving Worker pointed at bathymetry/<sha>/. This deploy IS the atomic
+  # Deploy the serving Worker pointed at seascape/<sha>/. This deploy IS the atomic
   # cutover: Cloudflare rolls the new version globally as a unit, so no client ever
   # sees a mix of old/new bundles. Rollback = re-dispatch with a prior (kept) sha.
   deploy-worker:
@@ -99,7 +99,7 @@ jobs:
           # Bind the same bucket the build writes to; wrangler.toml can't read env vars,
           # so overwrite the placeholder name at deploy (keeps worker + build in sync).
           sed -i "s|^bucket_name = .*|bucket_name = \"$TILES_BUCKET\"|" wrangler.toml
-          npx wrangler deploy --var "RELEASE_PREFIX:bathymetry/$SHA/"
+          npx wrangler deploy --var "RELEASE_PREFIX:seascape/$SHA/"
 
   # Build the viewer (pointed at the Worker) and deploy it to GitHub Pages.
   deploy-pages:
@@ -115,7 +115,7 @@ jobs:
         with: { node-version: 22, cache: npm }
       - name: Build viewer
         env:
-          VITE_TILES_BASE: https://tiles.openwaters.io/bathymetry
+          VITE_TILES_BASE: https://tiles.openwaters.io/seascape
         run: |
           npm ci
           npm run build -- --base=/${{ github.event.repository.name }}/
@@ -151,7 +151,7 @@ jobs:
               fail=1
             fi
           }
-          check "raster tile"     200 "$BASE/bathymetry/0/0/0.webp"            image/webp
-          check "vector tile"     200 "$BASE/bathymetry/0/0/0.pbf"             protobuf
-          check "raster.json"     200 "$BASE/bathymetry/raster.json"           json
+          check "raster tile"     200 "$BASE/seascape/0/0/0.webp"            image/webp
+          check "vector tile"     200 "$BASE/seascape/0/0/0.pbf"             protobuf
+          check "raster.json"     200 "$BASE/seascape/raster.json"           json
           exit $fail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,10 +110,10 @@ the optional `max_zoom` cap only.
 The Worker presents one endpoint per layer and resolves per tile:
 
 ```
-GET /bathymetry/{z}/{x}/{y}.webp   raster: z≤8 → planet · z>8 covered → overlay · else → overzoom the planet (nearest-neighbour) · miss → transparent
-GET /bathymetry/{z}/{x}/{y}.pbf    vector: contours.pmtiles passthrough
-GET /bathymetry/raster.json        TileJSON (terrarium raster)
-GET /bathymetry/vector.json        TileJSON (vector layers)
+GET /seascape/{z}/{x}/{y}.webp   raster: z≤8 → planet · z>8 covered → overlay · else → overzoom the planet (nearest-neighbour) · miss → transparent
+GET /seascape/{z}/{x}/{y}.pbf    vector: contours.pmtiles passthrough
+GET /seascape/raster.json        TileJSON (terrarium raster)
+GET /seascape/vector.json        TileJSON (vector layers)
 ```
 
 This keeps the base at native z8 (no global upsampling) while presenting a single

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-LABEL org.opencontainers.image.source="https://github.com/openwatersio/bathymetry"
+LABEL org.opencontainers.image.source="https://github.com/openwatersio/seascape"
 LABEL org.opencontainers.image.description="Bathymetry → tile pipeline)"
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Open Waters: Bathymetry
+# Seascape
 
 Bathymetry as web map tiles for MapLibre / Mapbox GL, build from a mosaic of global and regional sources. Served as raster DEM tiles for depth shading and hillshade, and vector contour tiles for crisp lines and labels.
 
 Coverage is global through z8 (~15″) with regional detail to z14 (~0.25″) where high-res sources exist.
 
-### **[Preview](https://openwatersio.github.io/bathymetry/)**
+### **[Preview](https://openwatersio.github.io/seascape/)**
 
 > [!WARNING]
 > **Not for navigational use.** Do not use this bathymetry for navigation, or in any
@@ -25,8 +25,8 @@ Coverage is global through z8 (~15″) with regional detail to z14 (~0.25″) wh
 
 The bathymetry is available as XYZ tiles in two flavors:
 
-- **Raster** (Terrarium-encoded DEM) — [TileJSON](https://tiles.openwaters.io/bathymetry/raster.json) - depth per pixel, for depth shading (color-relief), hillshade, and 3D terrain.<br/>
-- **Vector** (MVT) - [TileJSON](https://tiles.openwaters.io/bathymetry/vector.json) — bathymetric contour lines at non-uniform depth intervals.<br\>
+- **Raster** (Terrarium-encoded DEM) — [TileJSON](https://tiles.openwaters.io/seascape/raster.json) - depth per pixel, for depth shading (color-relief), hillshade, and 3D terrain.<br/>
+- **Vector** (MVT) - [TileJSON](https://tiles.openwaters.io/seascape/vector.json) — bathymetric contour lines at non-uniform depth intervals.<br\>
 
 Point any mapping library that supports XYZ tiles at these URLs. The TileJSONs include attribution and metadata, so libraries that support TileJSON will credit the sources automatically.
 
@@ -37,7 +37,7 @@ Point a `raster-dem` source and a `vector` source at the two TileJSONs:
 ```js
 import maplibregl from "maplibre-gl";
 
-const BASE = "https://tiles.openwaters.io/bathymetry";
+const BASE = "https://tiles.openwaters.io/seascape";
 
 const map = new maplibregl.Map({
   container: "map",

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Open Waters Bathymetry</title>
+  <title>Open Waters Seascape</title>
   <style>
     body {
       margin: 0;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 //   {base}/{z}/{x}/{y}.webp   — Terrarium terrain raster (planet + overlays, overzoomed)
 //   {base}/{z}/{x}/{y}.pbf    — MVT vector (contours, more layers later)
 // VITE_TILES_BASE is the full bathymetry endpoint base — it includes the
-// /bathymetry route prefix in prod (e.g. https://tiles.openwaters.io/bathymetry);
+// /seascape route prefix in prod (e.g. https://tiles.openwaters.io/seascape);
 // the dev default points at the worker root. VITE_BBOX sets the initial view.
 const BBOX = import.meta.env.VITE_BBOX
   ? import.meta.env.VITE_BBOX.split(",").map(Number)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "gebco",
+  "name": "seascape",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gebco",
+      "name": "seascape",
       "devDependencies": {
         "maplibre-gl": "^5.21.1",
         "pmtiles": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gebco",
+  "name": "seascape",
   "private": true,
   "license": "BSD-3-Clause",
   "type": "module",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "bathymetry-worker",
+  "name": "seascape-worker",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bathymetry-worker",
+      "name": "seascape-worker",
       "dependencies": {
         "@jsquash/webp": "^1.5.0",
         "pmtiles": "^4.4.0"

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bathymetry-worker",
+  "name": "seascape-worker",
   "private": true,
   "license": "BSD-3-Clause",
   "type": "module",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * Unified bathymetry tile endpoint.
  *
- *   GET /bathymetry/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
- *   GET /bathymetry/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, more layers later)
+ *   GET /seascape/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
+ *   GET /seascape/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, more layers later)
  *
  * Extension picks the representation: webp/png → raster, pbf/mvt → vector.
  *
@@ -42,8 +42,8 @@ function ensureCodec(): Promise<void> {
 
 export interface Env {
   TILES: R2Bucket;
-  RELEASE_PREFIX?: string; // R2 key prefix selecting which release to serve, e.g. "bathymetry/<sha>/"; default ""
-  BASE_PATH?: string; // URL mount path = the Cloudflare route prefix; default "/bathymetry"
+  RELEASE_PREFIX?: string; // R2 key prefix selecting which release to serve, e.g. "seascape/<sha>/"; default ""
+  BASE_PATH?: string; // URL mount path = the Cloudflare route prefix; default "/seascape"
 }
 
 interface BundleMeta {
@@ -269,7 +269,7 @@ export default {
     // dev at root — tolerate both: strip it when present, else treat the path as
     // already relative. `mount` is echoed back into TileJSON tile URLs so they
     // stay correct either way.
-    const base = (env.BASE_PATH ?? "/bathymetry").replace(/\/+$/, "");
+    const base = (env.BASE_PATH ?? "/seascape").replace(/\/+$/, "");
     const mounted =
       base !== "" && (path === base || path.startsWith(base + "/"));
     const rel = mounted ? path.slice(base.length) : path;

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,13 +1,13 @@
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 main = "src/index.ts"
-name = "bathymetry-tiles"
+name = "seascape-tiles"
 
 # Mounted under the unified tiles host by path prefix. `wrangler dev` ignores
-# this and serves at localhost:8787 root — the worker tolerates the /bathymetry
+# this and serves at localhost:8787 root — the worker tolerates the /seascape
 # prefix being present (prod) or absent (dev). Keep in sync with BASE_PATH below.
 routes = [
-  {pattern = "tiles.openwaters.io/bathymetry/*", zone_name = "openwaters.io"},
+  {pattern = "tiles.openwaters.io/seascape/*", zone_name = "openwaters.io"},
 ]
 
 # R2 bucket holding the published bundles: planet.pmtiles, <source>.pmtiles,
@@ -19,10 +19,10 @@ bucket_name = "tiles"
 
 [vars]
 # R2 key prefix selecting which release the Worker serves. Prod overrides this at deploy
-# with the promoted release dir (e.g. "bathymetry/<sha>/"); "" = local seed at root.
+# with the promoted release dir (e.g. "seascape/<sha>/"); "" = local seed at root.
 RELEASE_PREFIX = ""
 # URL mount path; must match the route prefix above. "" would serve at root.
-BASE_PATH = "/bathymetry"
+BASE_PATH = "/seascape"
 
 # jSquash WebP codecs are imported as WebAssembly modules.
 [[rules]]


### PR DESCRIPTION
Renames the project/service identity from **bathymetry / gebco** to **seascape** — pairing with **seamap**, the larger product that merges this with OpenStreetMap. GEBCO the *data source* is untouched.

## What changed in code
- **Names:** root `package.json`/`package-lock.json` `gebco → seascape`; worker service `bathymetry-tiles → seascape-tiles`; worker package `bathymetry-worker → seascape-worker`.
- **Public route:** `/bathymetry → /seascape` (`wrangler.toml` route + `BASE_PATH`, worker `src/index.ts` defaults/docs, `index.js`, `release.yml` `VITE_TILES_BASE` + smoke tests).
- **`tiles` serving prefix:** `tiles:bathymetry/<sha>/ → tiles:seascape/<sha>/` (`release.yml` promote destination, prune, published-check, `RELEASE_PREFIX`).
- **Docs:** README title + preview link + TileJSON URLs, CONTRIBUTING route block, `index.html` title, `Dockerfile` `image.source` label.

## What deliberately did NOT change
- **GEBCO the data source** — `sources/gebco/*`, attribution, the viewer's "GEBCO Bathymetry" layer.
- **`data` bucket keeps its `bathymetry/` prefix** — all build state (`source/`, `aggregation/`, `pmtiles/`, `contour/`, `build/`) stays put, so **no R2 migration and no rebuild**. `build.yml`, `pull-covering`, `Justfile` VSI bases, `config.py` example are unchanged by design.
- R2 bucket names (`tiles`, `data`), `openwaters.io`, secrets.

Safe because nothing is officially released yet — no consumer of the old `/bathymetry` URL to coordinate.

## Manual steps (not doable from this PR)
- [x] **Rename the GitHub repo** `openwatersio/bathymetry → openwatersio/seascape` (Settings → General). GitHub keeps redirects; Actions secrets and the `github-pages` environment survive. Pages URL becomes `openwatersio.github.io/seascape/` (README preview link already points there).
- [x] **Update local git remote** after the repo rename: `git remote set-url origin https://github.com/openwatersio/seascape.git`
- [ ] **Rename the local working directory** `…/openwaters/gebco → …/openwaters/seascape` (pure OS move; git doesn't care).
- [ ] **After the first release deploy** on this branch, delete the now-orphaned Worker: `npx wrangler delete --name bathymetry-tiles` (renaming `name` in `wrangler.toml` creates `seascape-tiles` and moves the route to it; the old worker lingers otherwise).

## Note on sequencing
The `tiles`-prefix change and the worker's `RELEASE_PREFIX` both live in this PR, so the next release cuts over atomically (promote writes `tiles:seascape/<sha>/`, worker reads `seascape/<sha>/`). The build half is untouched, so builds keep working throughout.
