### PR TITLE
Bundle terrain overlays by fixed grid cell, not by source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -459,8 +459,9 @@ jobs:
             xargs -P 8 -I{} sh -c 'k="$1"; d="store/${k#bathymetry/}"; mkdir -p "$(dirname "$d")"; for a in 1 2 3 4 5; do aws s3 cp "s3://$DATA_BUCKET/$k" "$d" --only-show-errors && exit 0; sleep "$a"; done; echo "giving up on $k after 5 attempts" >&2; exit 1' _ {} < store/keys.txt
             docker run --rm -v "$PWD/store:/app/pipelines/store" \
               "$IMAGE:${{ github.sha }}" just bundle-group "$group"
-            out=$(ls store/bundle/*.pmtiles)
-            aws s3 cp "$out" "$B/$(basename "$out")" --content-type application/octet-stream
+            # Archive name is deterministic from the group (see bundle.archive_filename).
+            pm=$([ "$group" = planet ] && echo "planet.pmtiles" || echo "overlay-$group.pmtiles")
+            aws s3 cp "store/bundle/$pm" "$B/$pm" --content-type application/octet-stream
             aws s3 cp "store/bundle/$group.json" "$B/bundle-frags/$group.json" --content-type application/json
             # Drop this group's tiles + archive before the next group — this per-iteration
             # clean is what bounds the disk (the container wrote store/bundle as root).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,18 +363,22 @@ jobs:
           aws s3 sync store/aggregation "s3://$DATA_BUCKET/bathymetry/aggregation" --exclude '*' --include '*.done'
 
   # Terrain bundle, fanned out so each runner holds only ONE group's tiles + output — not
-  # the whole store plus every overlay at once, which overran the disk (the pmtiles writer
-  # spools each tile then copies it into the archive, so finalize ~2x's a bundle). bundle-plan
-  # finishes the coarse pyramid tail (it spans ancestors, so it can't be a deep shard) and
-  # verifies the pyramid is whole, then emits one matrix job per group; bundle-merge stitches
-  # the per-group manifest fragments. Contours are built separately (sharded, below).
+  # the whole store plus every bundle at once, which overran the disk (the pmtiles writer
+  # spools each tile then copies it into the archive, so finalize ~2x's a bundle). Groups
+  # are the planet base + one overlay per OVERLAY_SPLIT_Z grid cell — never per source,
+  # whose footprint-sized archives outgrew a runner as sources accumulated. bundle-plan
+  # finishes the coarse pyramid tail (it spans ancestors, so it can't be a deep shard),
+  # verifies the pyramid is whole, and emits the matrix: each entry is a comma-joined
+  # CHUNK of group names (the partition rides in the matrix, so jobs can't drift from the
+  # plan's store view). A matrix job loops its chunk pull→bundle→push→clean one group at
+  # a time; bundle-merge stitches the fragments. Contours are built separately (below).
   bundle-plan:
     needs: downsample
     if: ${{ !cancelled() && needs.downsample.result == 'success' }}
     runs-on: ubuntu-latest
     permissions: { contents: read, packages: read }
     outputs:
-      groups: ${{ steps.g.outputs.groups }}
+      chunks: ${{ steps.g.outputs.chunks }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/ghcr-login
@@ -383,24 +387,24 @@ jobs:
       - name: Pull pmtiles store from R2
         run: |
           # The tail is finished here on one runner from the full store; the matrix jobs
-          # below each pull only their group. Contours are bundled by the separate sharded
-          # jobs, so store/contour is NOT pulled here.
+          # below each pull only one group's slice at a time. Contours are bundled by the
+          # separate sharded jobs, so store/contour is NOT pulled here.
           mkdir -p store/pmtiles
           aws s3 sync "s3://$DATA_BUCKET/bathymetry/pmtiles" store/pmtiles
-      - name: Coarse tail + group matrix
+      - name: Coarse tail + bundle matrix
         id: g
         run: |
           docker run --rm -e FORCE_REBUILD -v "$PWD/store:/app/pipelines/store" "$IMAGE:${{ github.sha }}" just downsample-tail
-          docker run --rm -e FORCE_REBUILD -v "$PWD/store:/app/pipelines/store" "$IMAGE:${{ github.sha }}" just bundle-groups > /tmp/groups.txt
+          docker run --rm -e FORCE_REBUILD -v "$PWD/store:/app/pipelines/store" "$IMAGE:${{ github.sha }}" just bundle-matrix "$AGG_SHARDS" > /tmp/chunks.txt
           # Emit the JSON matrix via the heredoc form, NOT name=value: the runner's post-step
-          # processing of `groups=[...]` fails the step (every shell op here exits 0 — the
+          # processing of `chunks=[...]` fails the step (every shell op here exits 0 — the
           # failure is in GitHub's output handling, not the script), and <<EOF is accepted.
           {
-            echo "groups<<EOF"
-            tail -n1 /tmp/groups.txt
+            echo "chunks<<EOF"
+            tail -n1 /tmp/chunks.txt
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-          echo "bundle groups: $(tail -n1 /tmp/groups.txt)"
+          echo "bundle chunks: $(tail -n1 /tmp/chunks.txt)"
       - name: Push tail tiles + done-markers to R2
         run: |
           # Tail overview tiles + downsampling done-markers feed the next incremental run,
@@ -409,9 +413,9 @@ jobs:
           # Markers only — covering tarball is immutable, untarred CSVs must not re-upload.
           aws s3 sync store/aggregation "s3://$DATA_BUCKET/bathymetry/aggregation" --exclude '*' --include '*.done'
 
-  # One runner per group: pull only this group's pmtiles slice, bundle it, push the overlay
-  # + its manifest fragment. Peak disk = one group's tiles + ~2x its output, so it scales
-  # with the biggest single overlay, not the whole planet.
+  # One runner per chunk of groups, bundled strictly one at a time (pull slice → bundle →
+  # push → clean). Peak disk = the single biggest group's tiles + ~2x its output, no
+  # matter how many groups a chunk holds or how many sources the planet accumulates.
   bundle:
     needs: bundle-plan
     if: ${{ !cancelled() && needs.bundle-plan.result == 'success' }}
@@ -420,7 +424,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ${{ fromJSON(needs.bundle-plan.outputs.groups) }}
+        chunk: ${{ fromJSON(needs.bundle-plan.outputs.chunks) }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/ghcr-login
@@ -433,26 +437,36 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
-      # Covering — group-keys derives which pmtiles belong to this group, the same way
-      # bundle assigns local files, so we pull only this group's slice.
+      # Covering — group-keys derives which pmtiles belong to each group, the same way
+      # bundle assigns local files, so we pull only one group's slice at a time.
       - name: Pull covering from R2
         uses: ./.github/actions/pull-covering
-      - name: Pull this group's tiles from R2
+      - name: List pmtiles store
         run: |
           mkdir -p store/pmtiles store/bundle
           aws s3 ls "s3://$DATA_BUCKET/bathymetry/pmtiles/" --recursive | awk '{print $4}' > store/pmtiles-keys.txt
-          docker run --rm -v "$PWD/store:/app/pipelines/store" \
-            "$IMAGE:${{ github.sha }}" just bundle-group-keys ${{ matrix.group }}
-          echo "pulling $(wc -l < store/keys.txt) of $(wc -l < store/pmtiles-keys.txt) pmtiles for ${{ matrix.group }}"
-          # Bounded outer retry + visible errors — see the downsample pull above.
-          xargs -P 8 -I{} sh -c 'k="$1"; d="store/${k#bathymetry/}"; mkdir -p "$(dirname "$d")"; for a in 1 2 3 4 5; do aws s3 cp "s3://$DATA_BUCKET/$k" "$d" --only-show-errors && exit 0; sleep "$a"; done; echo "giving up on $k after 5 attempts" >&2; exit 1' _ {} < store/keys.txt
-      - name: Bundle ${{ matrix.group }}
-        run: docker run --rm -v "$PWD/store:/app/pipelines/store" "$IMAGE:${{ github.sha }}" just bundle-group ${{ matrix.group }}
-      - name: Push ${{ matrix.group }} overlay + fragment to R2
+      - name: Bundle chunk (one group at a time)
+        env:
+          CELLS: ${{ matrix.chunk.cells }}
         run: |
           B="s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}"
-          aws s3 cp "store/bundle/${{ matrix.group }}.pmtiles" "$B/${{ matrix.group }}.pmtiles" --content-type application/octet-stream
-          aws s3 cp "store/bundle/${{ matrix.group }}.json" "$B/bundle-frags/${{ matrix.group }}.json" --content-type application/json
+          for group in ${CELLS//,/ }; do
+            echo "── group: $group ──"
+            docker run --rm -v "$PWD/store:/app/pipelines/store" \
+              "$IMAGE:${{ github.sha }}" just bundle-group-keys "$group"
+            echo "pulling $(wc -l < store/keys.txt) of $(wc -l < store/pmtiles-keys.txt) pmtiles for $group"
+            # Bounded outer retry + visible errors — see the downsample pull above.
+            xargs -P 8 -I{} sh -c 'k="$1"; d="store/${k#bathymetry/}"; mkdir -p "$(dirname "$d")"; for a in 1 2 3 4 5; do aws s3 cp "s3://$DATA_BUCKET/$k" "$d" --only-show-errors && exit 0; sleep "$a"; done; echo "giving up on $k after 5 attempts" >&2; exit 1' _ {} < store/keys.txt
+            docker run --rm -v "$PWD/store:/app/pipelines/store" \
+              "$IMAGE:${{ github.sha }}" just bundle-group "$group"
+            out=$(ls store/bundle/*.pmtiles)
+            aws s3 cp "$out" "$B/$(basename "$out")" --content-type application/octet-stream
+            aws s3 cp "store/bundle/$group.json" "$B/bundle-frags/$group.json" --content-type application/json
+            # Drop this group's tiles + archive before the next group — this per-iteration
+            # clean is what bounds the disk (the container wrote store/bundle as root).
+            sudo rm -rf store/pmtiles store/bundle store/keys.txt
+            mkdir -p store/pmtiles store/bundle
+          done
 
   # Stitch the per-group manifest fragments into manifest.json (copied last, so its
   # presence marks a complete build for release.yml). A failed overlay leaves no manifest.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,7 @@ jobs:
           npm run build
       - name: Worker self-checks
         run: |
+          # The .mjs checks import .ts directly — needs Node >= 22.18 (default type
+          # stripping); "node-version: 22" above resolves the latest 22.x, which is past it.
           node worker/src/terrarium.test.mjs
           node worker/src/overlay.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,8 @@ jobs:
           docker run --rm "$IMAGE:${{ github.sha }}" just test-sources
           docker run --rm "$IMAGE:${{ github.sha }}" just test-engine
 
-  # Compile-check the viewer (it's built + deployed on release; see release.yml).
+  # Compile-check the viewer (it's built + deployed on release; see release.yml)
+  # and run the Worker's dependency-free self-checks (plain node assert scripts).
   web:
     runs-on: ubuntu-latest
     steps:
@@ -57,3 +58,7 @@ jobs:
         run: |
           npm ci
           npm run build
+      - name: Worker self-checks
+        run: |
+          node worker/src/terrarium.test.mjs
+          node worker/src/overlay.test.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,10 @@ just test-sources  # offline source-stage self-check (synthetic, no network)
 just test-engine   # offline aggregation/bundle self-check (priority, zoom cap, pyramid)
 ```
 
-Outputs land in `pipelines/store/bundle/`: `planet.pmtiles`, one `<source>.pmtiles`
-overlay per high-res source, `contours.pmtiles`, and `manifest.json`. Inspect a
-`.pmtiles` by dragging it into https://protomaps.github.io/PMTiles/.
+Outputs land in `pipelines/store/bundle/`: `planet.pmtiles`, one
+`overlay-{z}-{x}-{y}.pmtiles` per populated grid cell, `contours.pmtiles`, and
+`manifest.json`. Inspect a `.pmtiles` by dragging it into
+https://protomaps.github.io/PMTiles/.
 
 ## Architecture
 
@@ -48,19 +49,24 @@ overlay per high-res source, `contours.pmtiles`, and `manifest.json`. Inspect a
 - **source** (`source_*.py`, per `sources/<id>/`): fetch → datum offset → normalize to a 4326 COG → `bounds.csv` → coverage polygon → tarball. Each source owns its recipe (`sources/<id>/Justfile`) composing the shared steps; `metadata.json` is attribution + an optional `max_zoom` cap. Priority derives from `(maxzoom, id)` — GEBCO loses (smallest maxzoom), so regional sources win in overlap.
 - **aggregation** (`aggregation_*.py`): `cover` slices the planet into source-aware aggregation tiles (one CSV each); `run` reprojects each source by priority into a merged Float32 DEM (Gaussian seam feather), slope-smooths it (`smooth.py`), encodes Terrarium raster tiles, and forks contours (`contour_run.py`) off the same merged DEM.
 - **downsampling**: 2×2-average overview pyramid below each source's native maxzoom.
-- **bundle** (`bundle.py`): concat single-zoom pmtiles into `planet.pmtiles` (z0..`PLANET_MAX_ZOOM` = `macrotile_z`) + one `<source>.pmtiles` overlay per dominant high-res source + `manifest.json`. Contours bundle via tippecanoe.
+- **bundle** (`bundle.py`): concat single-zoom pmtiles into `planet.pmtiles` (z0..`PLANET_MAX_ZOOM` = `macrotile_z`) + one `overlay-{cell}.pmtiles` per populated `OVERLAY_SPLIT_Z` grid cell (default z5) + `manifest.json`. Contours bundle via tippecanoe.
 
-### Why a planet cap + overlays + Worker (the serving model)
+### Why a planet cap + grid overlays + Worker (the serving model)
 
-GEBCO is ~z8 native; regional sources reach ~z13. Baking a full z0–13 pyramid
+GEBCO is ~z8 native; regional sources reach ~z14. Baking a full z0–14 pyramid
 means upsampling GEBCO globally (hundreds of GB, no new data). Instead: **planet
-capped at `macrotile_z`** (complete, all-sources-merged base, ~1–2 GB), **per-source
-overlays** above it (each carrying the GEBCO-filled merged mosaic — Terrarium has no
-transparency, so an overlay must not punch holes), and the **`worker/` Cloudflare
-Worker** resolves per tile: z≤cap → planet; z>cap covered → overlay; else → overzoom
-the planet (nearest-neighbour for Terrarium) — one endpoint, no global upsampling, no
-holes. Reads all pmtiles from R2 over HTTP range. The viewer (`index.js`) points at
-the Worker; `VITE_TILES_BASE` selects the endpoint (empty → `localhost:8787` dev).
+capped at `macrotile_z`** (complete, all-sources-merged base, ~1–2 GB), **fixed-grid
+overlays** above it — one archive per populated `OVERLAY_SPLIT_Z` cell, each carrying
+the GEBCO-filled merged mosaic (Terrarium has no transparency, so an overlay must not
+punch holes) — and the **`worker/` Cloudflare Worker** resolves per tile: z≤cap →
+planet; z>cap in a populated cell → that cell's archive (the cell is computed from
+the tile address — no footprint search); else → overzoom the planet — one endpoint,
+no global upsampling, no holes. Overlays are grid cells rather than per-source
+archives on purpose: a cell is a fixed fraction of the globe, so a new source adds
+*cells* instead of growing any single archive (a per-source overlay's size tracked
+its footprint and outgrew CI runner disks). Reads all pmtiles from R2 over HTTP
+range. The viewer (`index.js`) points at the Worker; `VITE_TILES_BASE` selects the
+endpoint (empty → `localhost:8787` dev).
 
 ### Contours (the custom vector layer)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 This repo turns bathymetry DEMs (GEBCO + regional high-res sources) into MapLibre/Mapbox tiles, served through a single Cloudflare Worker endpoint. Per-source build
-steps feed a planet build, which produces a base + per-source overlays.
+steps feed a planet build, which produces a base + fixed-grid overlays.
 
 <!-- FIXME[claude]: remove this illustration or convert to mermaid? -->
 
@@ -68,12 +68,14 @@ just test-engine     # offline aggregation/bundle self-check (priority, zoom cap
 `just planet` writes to `pipelines/store/bundle/`:
 
 - `planet.pmtiles` — the all-sources-merged base, z0–`macrotile_z` (z8 = GEBCO native, no upsampling).
-- `<source>.pmtiles` — one per high-res source, z`macrotile_z+1`→source-max, carrying the GEBCO-filled merged mosaic in its footprint.
+- `overlay-{z}-{x}-{y}.pmtiles` — one per populated `OVERLAY_SPLIT_Z` grid cell (default z5), z`macrotile_z+1`→cell-max, carrying the GEBCO-filled merged mosaic under that cell.
 - `contours.pmtiles` — MVT contours (GEBCO baked to the deepest zoom by tippecanoe).
-- `manifest.json` — planet + per-source coverage (which source/zoom covers where) for the Worker.
+- `manifest.json` — planet metadata + `overlay.cells` ({cell: max_zoom}) for the Worker.
 
 Key knobs (env vars, read by `pipelines/utils.py` / `bundle.py`):
-`MACROTILE_Z` (base/overlay split, default 8), `NUM_OVERVIEWS`, `BBOX`,
+`MACROTILE_Z` (base/overlay split, default 8), `OVERLAY_SPLIT_Z` (overlay grid
+cell zoom, default 5 — raise it if a cell's bundle ever outgrows a CI runner),
+`NUM_OVERVIEWS`, `BBOX`,
 `SMOOTH_DEM_SIGMA`/`SMOOTH_SLOPE_LOW`/`SMOOTH_SLOPE_HIGH`, `SKIP_SMOOTH`,
 `SKIP_CONTOURS`, `SKIP_SOUNDINGS`, `CONTOUR_NAV_SMOOTH_MAX` (navigable-band
 contour-smoothing gate; replaces the retired `SKIP_CONTOUR_SMOOTH`),
@@ -102,7 +104,7 @@ Set `BBOX="W,S,E,N"` for a regional build; `just --list` shows all recipes.
      - positive-down depths or a datum offset → `source_datum --negate --offset N`.
      - always: `source_normalize --crs EPSG:… [--nodata N]` → `source_bounds` → `source_polygonize <id> 8` → `source_create_tarball`.
 2. `just source <id>` (verify it lands in `pipelines/store/source/<id>/`).
-3. `just planet` — it appears as a new `<source>.pmtiles` overlay + a manifest entry automatically (priority is derived from `(maxzoom, id)`).
+3. `just planet` — its tiles fold into the grid-cell overlays + manifest automatically (priority is derived from `(maxzoom, id)`).
 
 Transform params live in the recipe (CLI args); `metadata.json` is attribution +
 the optional `max_zoom` cap only.
@@ -112,7 +114,7 @@ the optional `max_zoom` cap only.
 The Worker presents one endpoint per layer and resolves per tile:
 
 ```
-GET /seascape/{z}/{x}/{y}.webp   raster: z≤8 → planet · z>8 covered → overlay · else → overzoom the planet (nearest-neighbour) · miss → transparent
+GET /seascape/{z}/{x}/{y}.webp   raster: z≤8 → planet · z>8 in a populated grid cell → that cell's overlay · else → overzoom the planet · miss → transparent
 GET /seascape/{z}/{x}/{y}.pbf    vector: contours.pmtiles passthrough
 GET /seascape/raster.json        TileJSON (terrarium raster)
 GET /seascape/vector.json        TileJSON (vector layers)

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 # Bathymetry tiling pipeline. Run recipes from the repo root; they execute in
 # pipelines/ (via `set working-directory`). Stages: source -> aggregation ->
-# downsampling -> bundle; then worker/ serves planet + per-source overlays.
+# downsampling -> bundle; then worker/ serves planet + grid-cell overlays.
 # See CONTRIBUTING.md.
 
 set working-directory := 'pipelines'
@@ -57,7 +57,7 @@ combine:
 #   plan job   -> just downsample-matrix N (the shard matrix, sized to the dirt)
 #   matrix job -> just downsample-shard-keys i n  (pick this shard's pmtiles to pull)
 #   matrix job -> just downsample-shard i n
-#   plan  job  -> just downsample-tail + bundle-groups   (coarse tail, then the matrix)
+#   plan  job  -> just downsample-tail + bundle-matrix   (coarse tail, then the matrix)
 downsample-cover:
     uv run python downsampling.py cover
 downsample-matrix max:
@@ -71,14 +71,15 @@ downsample-shard i n:
 downsample-tail:
     uv run python downsampling.py run tail
 
-# CI terrain bundle fan-out (one matrix job per group keeps each runner's disk bounded by
-# ONE group's tiles + output, not the whole store; mirrors the downsample/contour shards):
-#   plan job   -> just downsample-tail + bundle-groups   (tail, verify, emit group matrix)
+# CI terrain bundle fan-out (planet + one overlay per OVERLAY_SPLIT_Z grid cell; each
+# matrix job loops its chunk of groups pull->bundle->push->clean one group at a time, so
+# a runner's disk is bounded by ONE group's tiles + output no matter how many sources land):
+#   plan job   -> just downsample-tail + bundle-matrix N (tail, verify, emit chunk matrix)
 #   matrix job -> just bundle-group-keys <name>          (pick this group's pmtiles to pull)
 #   matrix job -> just bundle-group <name>               (bundle one group + its fragment)
 #   merge job  -> just bundle-merge                      (fragments -> manifest.json)
-bundle-groups:
-    @uv run python bundle.py groups
+bundle-matrix max:
+    @uv run python bundle.py matrix {{max}}
 bundle-group-keys name:
     uv run python bundle.py group-keys {{name}}
 bundle-group name:

--- a/index.js
+++ b/index.js
@@ -20,22 +20,22 @@ const MAX_ZOOM = 13; // deepest source; the Worker overzooms the base for the re
 
 // The Worker overzooms the raster terrain server-side up to MAX_ZOOM, but vector
 // contours are a plain passthrough — so tell MapLibre their true max zoom (the
-// deepest source in the manifest) and it overzooms them client-side above that.
+// deepest overlay cell in the manifest) and it overzooms them client-side above that.
 const manifest = await fetch(`${tilesBase}/manifest.json`)
   .then((r) => r.json())
   .catch(() => null);
 const contourMax = manifest
   ? Math.max(
       manifest.planet.max_zoom,
-      ...manifest.sources.map((s) => s.max_zoom),
+      ...Object.values(manifest.overlay?.cells ?? {}),
     )
   : MAX_ZOOM;
 
 // ─── Source coverage (provenance) ───────────────────────────────────────────
 // The `coverage` layer baked into contours.pmtiles (source footprints, props
 // source_id / source_name / source_maxzoom). Drawn as polygons and queried on click to
-// report which source a depth came from. Colour each source by id off the manifest list
-// (a match expression); footprints of sources not in the manifest fall back to grey.
+// report which source a depth came from. Colour each source by id off the manifest's
+// source_ids (a match expression); ids not in the manifest fall back to grey.
 const COVERAGE_PALETTE = [
   "#e6194b",
   "#3cb44b",
@@ -49,12 +49,12 @@ const COVERAGE_PALETTE = [
   "#000075",
 ];
 const coverageColor =
-  manifest && manifest.sources.length
+  manifest && (manifest.source_ids ?? []).length
     ? [
         "match",
         ["get", "source_id"],
-        ...manifest.sources.flatMap((s, i) => [
-          s.id,
+        ...manifest.source_ids.flatMap((id, i) => [
+          id,
           COVERAGE_PALETTE[i % COVERAGE_PALETTE.length],
         ]),
         "#888",

--- a/pipelines/bundle.py
+++ b/pipelines/bundle.py
@@ -1,12 +1,21 @@
-"""Concatenate the single-zoom PMTiles into a planet base + per-source overlays.
+"""Concatenate the single-zoom PMTiles into a planet base + fixed-grid overlays.
 
 Everything at ``child_z <= PLANET_MAX_ZOOM`` (the GEBCO-native base cap, default =
-macrotile_z) goes into a complete ``planet.pmtiles`` (z0..cap). Higher-res tiles
-go into one ``<source>.pmtiles`` per **dominant high-res source** (e.g.
-``cudem_ne.pmtiles``, z(cap+1)..source-max), so each source is independently
-publishable. A ``manifest.json`` records planet + per-source coverage so the
-serving Worker can resolve regional-vs-planet and overzoom the base on miss (see
-SERVING / the plan's §Serving architecture).
+macrotile_z) goes into a complete ``planet.pmtiles`` (z0..cap). Higher-res tiles go
+into one ``overlay-{z}-{x}-{y}.pmtiles`` per populated cell of a fixed
+``OVERLAY_SPLIT_Z`` grid — each holding every z(cap+1)..zmax tile under that cell,
+from whatever sources are there.
+
+The grid is deliberately source-agnostic. Grouping overlays by source made each
+archive's size a function of a source's footprint: one deep source whose bbox
+swallowed the continent's interior became a catch-all that outgrew a CI runner's
+disk, and every new source made it worse. A grid cell is a fixed fraction of the
+globe, so new sources add *cells*, never bytes-per-cell; if a cell ever outgrows a
+runner, raise OVERLAY_SPLIT_Z. It also gives the serving Worker an O(1) route: the
+owning cell is computed from the tile address (no footprint search).
+
+``manifest.json`` records planet metadata + ``overlay`` ({split_z, cells: {cell:
+max_zoom}}) + the configured source ids (the viewer's provenance palette).
 
 Pure concat in tile-id order. Bundling everything (incremental rebuild is Phase E3).
 
@@ -29,37 +38,37 @@ import utils
 
 # Base cap = the GEBCO-native zoom (the planet is complete + overzoomable below it).
 PLANET_MAX_ZOOM = int(os.environ.get("PLANET_MAX_ZOOM", str(utils.macrotile_z)))
+# The overlay grid zoom. Every overlay tile (child_z > PLANET_MAX_ZOOM) belongs to
+# its ancestor cell at this zoom; one archive per populated cell.
+SPLIT_Z = int(os.environ.get("OVERLAY_SPLIT_Z", "5"))
+# cell_of shifts by (z - SPLIT_Z), so the grid must sit at or above the shallowest
+# overlay content zoom — fail fast here, not as a ValueError inside a matrix job.
+if SPLIT_Z > PLANET_MAX_ZOOM + 1:
+    sys.exit(f"OVERLAY_SPLIT_Z ({SPLIT_Z}) must be <= PLANET_MAX_ZOOM + 1 ({PLANET_MAX_ZOOM + 1})")
 
 
-def high_res_sources(aggregation_id):
-    """{source_id: {'bbox': [w,s,e,n], 'max_zoom': int}} for sources that own
-    regional (child_z > PLANET_MAX_ZOOM) aggregation tiles. The owner of a tile is
-    its deepest source (maxzoom == child_z), lex-first on a tie."""
-    sources = {}
-    for csv in glob(f"store/aggregation/{aggregation_id}/*-aggregation.csv"):
-        z, x, y, child_z = (int(a) for a in csv.split("/")[-1].replace("-aggregation.csv", "").split("-"))
-        if child_z <= PLANET_MAX_ZOOM:
-            continue
-        with open(csv) as f:
-            rows = [line.strip().split(",") for line in f.readlines()[1:]]
-        owner = sorted(s for s, fn, mz in rows if int(mz) == child_z)[0]
-        w, s, e, n = mercantile.bounds(x, y, z)
-        info = sources.setdefault(owner, {"bbox": [math.inf, math.inf, -math.inf, -math.inf], "max_zoom": 0})
-        b = info["bbox"]
-        b[0], b[1], b[2], b[3] = min(b[0], w), min(b[1], s), max(b[2], e), max(b[3], n)
-        info["max_zoom"] = max(info["max_zoom"], child_z)
-    return sources
+def cell_of(z, x, y):
+    """The SPLIT_Z grid cell name owning tile (z,x,y), z >= SPLIT_Z."""
+    return f"{SPLIT_Z}-{x >> (z - SPLIT_Z)}-{y >> (z - SPLIT_Z)}"
 
 
-def assign_source(z, x, y, sources):
-    """Pick the deepest high-res source whose footprint the tile extent overlaps."""
-    w, s, e, n = mercantile.bounds(x, y, z)
-    best, best_mz = None, -1
-    for src, info in sources.items():
-        bw, bs, be, bn = info["bbox"]
-        if w < be and e > bw and s < bn and n > bs and info["max_zoom"] > best_mz:
-            best, best_mz = src, info["max_zoom"]
-    return best
+def stem_groups(stem):
+    """Group name(s) a pmtiles stem {z}-{x}-{y}-{child_z} contributes to: 'planet'
+    for base zooms, else the overlay cell(s) its content tiles live under. Overlay
+    parents normally sit at z >= SPLIT_Z (exactly one cell — downsample extents
+    stay at z >= child_z - num_overviews); a coarser parent spans its descendant
+    cells, and create_archive keeps only each cell's own tiles."""
+    z, x, y, child_z = (int(a) for a in stem.split("-"))
+    if child_z <= PLANET_MAX_ZOOM:
+        return ["planet"]
+    if z >= SPLIT_Z:
+        return [cell_of(z, x, y)]
+    parent = mercantile.Tile(x=x, y=y, z=z)
+    return [f"{c.z}-{c.x}-{c.y}" for c in mercantile.children(parent, zoom=SPLIT_Z)]
+
+
+def archive_filename(name):
+    return f"{name}.pmtiles" if name == "planet" else f"overlay-{name}.pmtiles"
 
 
 def covering_stems(aggregation_id):
@@ -76,18 +85,17 @@ def covering_stems(aggregation_id):
 
 
 def group_filepaths(aggregation_id):
-    """{'planet': [...], '<source>': [...]} grouping every single-zoom pmtiles."""
-    sources = high_res_sources(aggregation_id)
+    """{'planet': [...], '<z>-<x>-<y>': [...]} — the grid partition of every
+    single-zoom pmtiles in the local store."""
     stems = covering_stems(aggregation_id)
     groups = {}
     for fp in sorted(glob("store/pmtiles/*.pmtiles") + glob("store/pmtiles/*/*.pmtiles")):
         stem = fp.split("/")[-1].replace(".pmtiles", "")
         if stem not in stems:  # orphan from a re-tiled covering (see covering_stems)
             continue
-        z, x, y, child_z = (int(a) for a in stem.split("-"))
-        name = "planet" if child_z <= PLANET_MAX_ZOOM else (assign_source(z, x, y, sources) or "planet")
-        groups.setdefault(name, []).append(fp)
-    return groups, sources
+        for name in stem_groups(stem):
+            groups.setdefault(name, []).append(fp)
+    return groups
 
 
 def read_full_archive(filepath):
@@ -100,8 +108,11 @@ def read_full_archive(filepath):
 
 
 def create_archive(filepaths, name):
+    """Concat the single-zoom pmtiles into store/bundle/<archive_filename(name)>.
+    For an overlay cell, tiles outside the cell (a coarse parent spanning cells)
+    are left to the sibling cells' archives."""
     utils.create_folder("store/bundle")
-    out_filepath = f"store/bundle/{name}.pmtiles"
+    out_filepath = f"store/bundle/{archive_filename(name)}"
     min_z, max_z = math.inf, 0
     min_lon, min_lat, max_lon, max_lat = math.inf, math.inf, -math.inf, -math.inf
 
@@ -114,12 +125,14 @@ def create_archive(filepaths, name):
             z, x, y, child_z = (int(a) for a in filepath.split("/")[-1].replace(".pmtiles", "").split("-"))
             parent = mercantile.Tile(x=x, y=y, z=z)
             tiles = [parent] if z == child_z else list(mercantile.children(parent, zoom=child_z))
+            if name != "planet":
+                tiles = [t for t in tiles if cell_of(t.z, t.x, t.y) == name]
             for tile in tiles:
                 tile_ids_and_filepaths.append((zxy_to_tileid(tile.z, tile.x, tile.y), filepath))
-            max_z, min_z = max(max_z, child_z), min(min_z, child_z)
-            west, south, east, north = mercantile.bounds(x, y, z)
-            min_lon, min_lat = min(min_lon, west), min(min_lat, south)
-            max_lon, max_lat = max(max_lon, east), max(max_lat, north)
+                max_z, min_z = max(max_z, tile.z), min(min_z, tile.z)
+                west, south, east, north = mercantile.bounds(tile)
+                min_lon, min_lat = min(min_lon, west), min(min_lat, south)
+                max_lon, max_lat = max(max_lon, east), max(max_lat, north)
 
         last_filepath = None
         tile_id_to_bytes = None
@@ -145,8 +158,8 @@ def create_archive(filepaths, name):
         )
         checksum = hash_writer.md5.hexdigest()
 
-    return {"file": f"{name}.pmtiles", "size": os.path.getsize(out_filepath), "md5sum": checksum,
-            "min_zoom": min_z, "max_zoom": max_z,
+    return {"file": archive_filename(name), "size": os.path.getsize(out_filepath),
+            "md5sum": checksum, "min_zoom": min_z, "max_zoom": max_z,
             "bbox": [min_lon, min_lat, max_lon, max_lat]}
 
 
@@ -163,10 +176,9 @@ def attribution():
     return " | ".join(parts)
 
 
-def bundle_group(item):
-    name, filepaths = item
-    print(f"bundling {name} ({len(filepaths)} pmtiles)...")
-    return name, create_archive(filepaths, name)
+def bundle_group(name, filepaths):
+    print(f"bundling {archive_filename(name)} ({len(filepaths)} pmtiles)...")
+    return create_archive(filepaths, name)
 
 
 def verify_complete(aggregation_id):
@@ -188,34 +200,37 @@ def verify_complete(aggregation_id):
 
 
 def _fragment(name, meta):
-    """{kind, [id], ...meta} — one per-group manifest fragment so a matrix bundle job's
-    metadata survives to the merge step (kind marks the planet base vs an overlay)."""
-    kind = "planet" if name == "planet" else "source"
-    return {"kind": kind, **({"id": name} if kind == "source" else {}), **meta}
+    """One per-group manifest fragment so a matrix bundle job's metadata survives to
+    the merge step. Planet keeps its full metadata; an overlay cell only needs its
+    max_zoom (the Worker computes the cell from the tile address — no bbox search)."""
+    if name == "planet":
+        return {"kind": "planet", **meta}
+    return {"kind": "cell", "cell": name, "max_zoom": meta["max_zoom"]}
 
 
 def _manifest_from_fragments(frags):
-    manifest = {"planet": None, "sources": []}
+    manifest = {"planet": None, "overlay": {"split_z": SPLIT_Z, "cells": {}}}
     for frag in frags:
-        frag = dict(frag)
-        if frag.pop("kind") == "planet":
-            manifest["planet"] = frag
+        if frag["kind"] == "planet":
+            manifest["planet"] = {k: v for k, v in frag.items() if k != "kind"}
         else:
-            manifest["sources"].append(frag)
-    # deepest first so the Worker picks the highest-res overlay where they overlap.
-    manifest["sources"].sort(key=lambda s: -s["max_zoom"])
+            manifest["overlay"]["cells"][frag["cell"]] = frag["max_zoom"]
+    manifest["source_ids"] = config.sources()  # the viewer's provenance palette
     manifest["attribution"] = attribution()
     return manifest
 
 
-def groups_matrix():
-    """Verify the pyramid is whole, then print the group names as a JSON matrix (the CI
-    spins one bundle job per group). Runs on the tail/plan runner, which holds the full
-    store after the coarse tail; a hole here fails the build before any overlay ships."""
+def groups_matrix(maxn):
+    """Verify the pyramid is whole, then print the CI bundle matrix: <= maxn chunks,
+    each a comma-joined strided slice of the group names. The partition rides IN the
+    matrix (not re-derived per job from a live R2 listing), so every job bundles the
+    exact set this full-store runner saw — the same freeze-the-plan reasoning as the
+    aggregate/downsample shards."""
     aggregation_id = utils.get_aggregation_ids()[-1]
     verify_complete(aggregation_id)
-    groups, _ = group_filepaths(aggregation_id)
-    print(json.dumps(sorted(groups)))
+    names = sorted(group_filepaths(aggregation_id))
+    n = min(maxn, max(len(names), 1))
+    print(json.dumps([{"cells": ",".join(names[i::n])} for i in range(n)]))
 
 
 def group_keys(name):
@@ -223,7 +238,6 @@ def group_keys(name):
     R2 listing (store/pmtiles-keys.txt) by the same rule group_filepaths uses on local
     files — so a matrix job pulls ONLY its group's slice, never the whole store."""
     aggregation_id = utils.get_aggregation_ids()[-1]
-    sources = high_res_sources(aggregation_id)
     stems = covering_stems(aggregation_id)
     out = []
     with open("store/pmtiles-keys.txt") as f:
@@ -235,12 +249,10 @@ def group_keys(name):
             if stem not in stems:  # orphan from a re-tiled covering (see covering_stems)
                 continue
             try:
-                z, x, y, child_z = (int(a) for a in stem.split("-"))
+                if name in stem_groups(stem):
+                    out.append(key)
             except ValueError:
                 continue
-            g = "planet" if child_z <= PLANET_MAX_ZOOM else (assign_source(z, x, y, sources) or "planet")
-            if g == name:
-                out.append(key)
     with open("store/keys.txt", "w") as f:
         f.write("".join(k + "\n" for k in out))
     print(f"group {name}: {len(out)} pmtiles selected")
@@ -250,7 +262,7 @@ def group(name):
     """Bundle one group from the tiles pulled locally (its slice only) + write its
     fragment. Disk stays bounded by one group's tiles + output, not the whole planet."""
     filepaths = sorted(glob("store/pmtiles/*.pmtiles") + glob("store/pmtiles/*/*.pmtiles"))
-    _, meta = bundle_group((name, filepaths))
+    meta = bundle_group(name, filepaths)
     utils.create_folder("store/bundle")
     with open(f"store/bundle/{name}.json", "w") as f:
         json.dump(_fragment(name, meta), f)
@@ -263,33 +275,32 @@ def merge():
     utils.create_folder("store/bundle")
     with open("store/bundle/manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
-    print(f"merged manifest: planet + {len(manifest['sources'])} overlay(s)")
+    print(f"merged manifest: planet + {len(manifest['overlay']['cells'])} overlay cell(s)")
 
 
 def main():
     """Local / single-runner: bundle every group sequentially, biggest first. The pmtiles
     writer spools each tile to a temp file then copies it into the archive (finalize ~2x's
     a bundle on disk), so building all groups at once piled every temp+final onto one disk
-    and blew it at planet scale — CI fans this out per group (groups/group/merge) instead."""
+    and blew it at planet scale — CI fans this out in cell chunks instead."""
     aggregation_id = utils.get_aggregation_ids()[-1]
     verify_complete(aggregation_id)
-    groups, _ = group_filepaths(aggregation_id)
+    groups = group_filepaths(aggregation_id)
     frags = []
     for name, filepaths in sorted(groups.items(), key=lambda kv: -len(kv[1])):
-        _, meta = bundle_group((name, filepaths))
-        frags.append(_fragment(name, meta))
+        frags.append(_fragment(name, bundle_group(name, filepaths)))
     manifest = _manifest_from_fragments(frags)
     with open("store/bundle/manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
-    print(f"created {len(groups)} bundle(s): {', '.join(groups)} + manifest.json")
+    print(f"created {len(groups)} bundle(s): {', '.join(sorted(groups))} + manifest.json")
 
 
 if __name__ == "__main__":
     a = sys.argv[1:]
     if not a:
         main()
-    elif a[:1] == ["groups"]:
-        groups_matrix()
+    elif a[:1] == ["matrix"] and len(a) == 2:
+        groups_matrix(int(a[1]))
     elif a[:1] == ["group-keys"] and len(a) == 2:
         group_keys(a[1])
     elif a[:1] == ["group"] and len(a) == 2:
@@ -297,4 +308,4 @@ if __name__ == "__main__":
     elif a[:1] == ["merge"]:
         merge()
     else:
-        sys.exit("usage: bundle.py [groups | group-keys <name> | group <name> | merge]")
+        sys.exit("usage: bundle.py [matrix <max> | group-keys <name> | group <name> | merge]")

--- a/pipelines/test_engine.py
+++ b/pipelines/test_engine.py
@@ -8,8 +8,9 @@ z11 in metadata) inside it — then runs the whole engine and asserts:
   - PRIORITY: at the fine source's zoom the merged value is the fine value (-50),
     not the base (-100) — highest-maxzoom source wins in overlap;
   - the base shows through where fine is absent (-100 present);
-  - the E1 split: planet.pmtiles spans z0..macrotile_z and the deeper fine tiles
-    land in the fine.pmtiles overlay (so the engine covers z0..11 across bundles).
+  - the bundle split: planet.pmtiles spans z0..macrotile_z and the deeper fine
+    tiles land in one overlay-{cell}.pmtiles per populated OVERLAY_SPLIT_Z grid
+    cell (so the engine covers z0..11 across bundles).
 
 Run from pipelines/:  uv run python test_engine.py
 """
@@ -52,8 +53,8 @@ def make_source(tmp, sid, west, north, deg, px, value, max_zoom):
 
 def decode_bundles(tmp):
     """Return {zoom: [median elevation per tile]} across ALL bundle pmtiles —
-    planet (z0..PLANET_MAX_ZOOM) plus the per-source overlays above it (E1
-    routes child_z > PLANET_MAX_ZOOM into <source>.pmtiles, not planet)."""
+    planet (z0..PLANET_MAX_ZOOM) plus the grid-cell overlays above it (bundle
+    routes child_z > PLANET_MAX_ZOOM into overlay-{cell}.pmtiles, not planet)."""
     import glob
     import imagecodecs
     from pmtiles.reader import Reader, MmapSource, all_tiles
@@ -200,6 +201,57 @@ def check_stale_overview():
             os.environ["FORCE_REBUILD"] = env_force
 
 
+def check_grid_split():
+    """The bundle grid: stem_groups routes base zooms to planet and deep stems to their
+    OVERLAY_SPLIT_Z cell; a coarse parent (z < split, a broad downsample extent) fans out
+    to its descendant cells, and create_archive keeps only each cell's own tiles — so the
+    sibling cells' archives partition the shared file exactly (no leaks, no dupes)."""
+    import bundle
+    import mercantile
+    from pmtiles.reader import Reader, MmapSource, all_tiles
+    from pmtiles.writer import Writer
+    from pmtiles.tile import zxy_to_tileid, TileType, Compression
+
+    assert bundle.stem_groups("8-77-95-8") == ["planet"], "base zoom must route to planet"
+    assert bundle.stem_groups("8-77-95-14") == ["5-9-11"], "deep macrotile → its z5 cell"
+    assert bundle.stem_groups("6-11-13-9") == ["5-5-6"], "overview parent → its z5 cell"
+    fan = bundle.stem_groups("4-4-5-9")
+    assert sorted(fan) == sorted(f"5-{x}-{y}" for x in (8, 9) for y in (10, 11)), \
+        f"coarse parent must fan out to its 4 descendant cells: {fan}"
+
+    tmp = tempfile.mkdtemp()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp)
+        os.makedirs("store/pmtiles")
+        # One single-zoom archive under the coarse parent (4,4,5) at z9 — 1024 tiles
+        # spanning the 4 cells; payload = the tile id, so reads are verifiable.
+        children = list(mercantile.children(mercantile.Tile(x=4, y=5, z=4), zoom=9))
+        with open("store/pmtiles/4-4-5-9.pmtiles", "wb") as f:
+            w = Writer(f)
+            for tid in sorted(zxy_to_tileid(t.z, t.x, t.y) for t in children):
+                w.write_tile(tid, str(tid).encode())
+            w.finalize({"tile_type": TileType.WEBP, "tile_compression": Compression.NONE,
+                        "min_zoom": 9, "max_zoom": 9, "min_lon_e7": 0, "min_lat_e7": 0,
+                        "max_lon_e7": 1, "max_lat_e7": 1, "center_zoom": 9,
+                        "center_lon_e7": 0, "center_lat_e7": 0}, {})
+        seen = set()
+        for cell in fan:
+            meta = bundle.create_archive(["store/pmtiles/4-4-5-9.pmtiles"], cell)
+            with open(f"store/bundle/{meta['file']}", "r+b") as f:
+                for (z, x, y), data in all_tiles(Reader(MmapSource(f)).get_bytes):
+                    assert bundle.cell_of(z, x, y) == cell, f"tile {(z, x, y)} leaked into {cell}"
+                    assert data == str(zxy_to_tileid(z, x, y)).encode(), "payload mismatch"
+                    assert (z, x, y) not in seen, f"tile {(z, x, y)} bundled twice"
+                    seen.add((z, x, y))
+        assert len(seen) == len(children), \
+            f"cells must partition the coarse parent: {len(seen)} of {len(children)} tiles"
+        print(f"grid-split ok — {len(children)} tiles partitioned across {len(fan)} cells, no leaks/dupes")
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
 def main():
     tmp = tempfile.mkdtemp()
     try:
@@ -241,23 +293,32 @@ def main():
         assert not (selected[0] & selected[1]), f"shards must be disjoint: {selected[0] & selected[1]}"
         print(f"shard-keys ok — {len(deep)} deep pmtiles partitioned across 2 shards, none below z{shard_root_z}")
 
-        # bundle group-keys (the CI per-group pull filter) must partition EVERY terrain
+        # bundle matrix + group-keys (the CI pull filter) must partition EVERY terrain
         # pmtiles across the groups: a tile in no group is missing from the bundles (a
-        # hole the Worker overzooms GEBCO into); a tile in two is double-bundled.
+        # hole the Worker overzooms GEBCO into); a tile in two is double-bundled. The
+        # groups are planet + one overlay per z5 grid cell holding a deep (z11) tile.
+        agg_dir = f"{tmp}/store/aggregation"
+        agg_id = sorted(os.listdir(agg_dir))[-1]
+        agg_stems = [n.replace("-aggregation.csv", "").split("-")
+                     for n in os.listdir(f"{agg_dir}/{agg_id}") if n.endswith("-aggregation.csv")]
+        expected = {"planet"} | {f"5-{int(x) >> (int(z) - 5)}-{int(y) >> (int(z) - 5)}"
+                                 for z, x, y, cz in agg_stems if int(cz) > 10}
         cli_env = {**os.environ, "SOURCES_DIR": "sources", "PYTHONPATH": PIPE,
                    "MACROTILE_Z": "10", "NUM_OVERVIEWS": "2", "SKIP_CONTOURS": "1", "SKIP_SMOOTH": "1"}
-        names = json.loads(subprocess.run(
-            [sys.executable, os.path.join(PIPE, "bundle.py"), "groups"],
+        chunks = json.loads(subprocess.run(
+            [sys.executable, os.path.join(PIPE, "bundle.py"), "matrix", "2"],
             cwd=tmp, env=cli_env, check=True, capture_output=True, text=True).stdout.splitlines()[-1])
-        assert set(names) == {"planet", "fine"}, f"unexpected groups: {names}"
-        gsel = []
+        assert len(chunks) <= 2, f"matrix must respect the shard cap: {chunks}"
+        names = [n for c in chunks for n in c["cells"].split(",") if n]
+        assert sorted(names) == sorted(expected), f"unexpected groups: {sorted(names)} != {sorted(expected)}"
+        gsel = {}
         for name in names:
             run(tmp, "bundle.py", "group-keys", name)
             with open(f"{tmp}/store/keys.txt") as f:
-                gsel.append({os.path.basename(l.strip()) for l in f if l.strip()})
-        gunion = set().union(*gsel)
+                gsel[name] = {os.path.basename(l.strip()) for l in f if l.strip()}
+        gunion = set().union(*gsel.values())
         assert gunion == set(pmtiles), f"group-keys miscovers; missing {set(pmtiles) - gunion}, extra {gunion - set(pmtiles)}"
-        assert not (gsel[0] & gsel[1]), f"groups overlap: {gsel[0] & gsel[1]}"
+        assert sum(len(s) for s in gsel.values()) == len(gunion), "groups overlap"
         print(f"group-keys ok — {len(pmtiles)} pmtiles partitioned across {len(names)} group(s)")
 
         # orphan exclusion: a pmtiles left from a re-tiled covering (stem not in the
@@ -273,17 +334,19 @@ def main():
             assert orphan not in got, f"orphan {orphan} leaked into group {name}"
         print(f"orphan-exclusion ok — {orphan} excluded from every group")
 
-        # covering wrote the cap into child_z: the deepest aggregation tile is z9, not z11.
-        agg_dir = f"{tmp}/store/aggregation"
-        agg_id = sorted(os.listdir(agg_dir))[-1]
-        child_zs = [int(n.replace("-aggregation.csv", "").split("-")[3])
-                    for n in os.listdir(f"{agg_dir}/{agg_id}") if n.endswith("-aggregation.csv")]
+        # covering wrote the cap into child_z: the deepest aggregation tile is z11, not z13.
+        child_zs = [int(cz) for _, _, _, cz in agg_stems]
         assert max(child_zs) == 11, f"cap not applied (want 11): child_z={sorted(set(child_zs))}"
 
-        # E1 split: planet caps at macrotile_z (10); the z11 fine tiles route to
-        # the fine.pmtiles overlay. Both must exist.
+        # Bundle split: planet caps at macrotile_z (10); the z11 fine tiles route to
+        # their grid cells' overlay archives, and the manifest records the cells.
         assert os.path.exists(f"{tmp}/store/bundle/planet.pmtiles"), "missing planet.pmtiles"
-        assert os.path.exists(f"{tmp}/store/bundle/fine.pmtiles"), "missing fine overlay"
+        for cell in expected - {"planet"}:
+            assert os.path.exists(f"{tmp}/store/bundle/overlay-{cell}.pmtiles"), f"missing overlay {cell}"
+        mf = json.load(open(f"{tmp}/store/bundle/manifest.json"))
+        assert mf["planet"]["max_zoom"] == 10, f"planet cap wrong: {mf['planet']}"
+        assert set(mf["overlay"]["cells"]) == expected - {"planet"}, f"manifest cells: {mf['overlay']}"
+        assert all(v == 11 for v in mf["overlay"]["cells"].values()), f"cell max_zoom: {mf['overlay']}"
         by_zoom = decode_bundles(tmp)
         assert by_zoom, "no tiles in any bundle"
         max_z = max(by_zoom)
@@ -318,4 +381,5 @@ if __name__ == "__main__":
     check_priority()
     check_shard_partition()
     check_stale_overview()
+    check_grid_split()
     main()

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * Unified bathymetry tile endpoint.
  *
- *   GET /bathymetry/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
- *   GET /bathymetry/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, more layers later)
+ *   GET /seascape/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
+ *   GET /seascape/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, more layers later)
  *
  * Extension picks the representation: webp/png → raster, pbf/mvt → vector.
  *
@@ -47,8 +47,8 @@ function ensureCodec(): Promise<void> {
 
 export interface Env {
   TILES: R2Bucket;
-  RELEASE_PREFIX?: string; // R2 key prefix selecting which release to serve, e.g. "bathymetry/<sha>/"; default ""
-  BASE_PATH?: string; // URL mount path = the Cloudflare route prefix; default "/bathymetry"
+  RELEASE_PREFIX?: string; // R2 key prefix selecting which release to serve, e.g. "seascape/<sha>/"; default ""
+  BASE_PATH?: string; // URL mount path = the Cloudflare route prefix; default "/seascape"
 }
 
 interface BundleMeta {
@@ -264,7 +264,7 @@ export default {
     // dev at root — tolerate both: strip it when present, else treat the path as
     // already relative. `mount` is echoed back into TileJSON tile URLs so they
     // stay correct either way.
-    const base = (env.BASE_PATH ?? "/bathymetry").replace(/\/+$/, "");
+    const base = (env.BASE_PATH ?? "/seascape").replace(/\/+$/, "");
     const mounted =
       base !== "" && (path === base || path.startsWith(base + "/"));
     const rel = mounted ? path.slice(base.length) : path;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,16 +1,18 @@
 /**
  * Unified bathymetry tile endpoint.
  *
- *   GET /seascape/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
- *   GET /seascape/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, more layers later)
+ *   GET /bathymetry/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
+ *   GET /bathymetry/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, more layers later)
  *
  * Extension picks the representation: webp/png → raster, pbf/mvt → vector.
  *
- * Reads the bundles published to R2 (planet.pmtiles + per-source <id>.pmtiles +
- * contours.pmtiles + manifest.json) and resolves per tile:
+ * Reads the bundles published to R2 (planet.pmtiles + one overlay-{cell}.pmtiles
+ * per populated grid cell + contours.pmtiles + manifest.json) and resolves per tile:
  *   - z ≤ planet.max_zoom        → planet tile
- *   - z > planet.max_zoom, a source overlay covers it → that overlay's tile
+ *   - z > planet.max_zoom, the tile's grid cell is populated → that cell's tile
+ *     (or the overzoomed deepest ancestor present in the cell)
  *   - otherwise                  → OVERZOOM the planet's deepest ancestor tile
+ * The owning cell is computed from the tile address (overlay.ts) — no bbox search.
  *
  * Overzoom of Terrarium is a cubic B-spline ON DECODED HEIGHTS, not on the packed bytes:
  * decode each source pixel to a float elevation, resample the elevations, re-encode.
@@ -24,6 +26,7 @@
 
 import { PMTiles, Source, RangeResponse } from "pmtiles";
 import { unpackTerrarium, packTerrariumInto, cubicBSpline } from "./terrarium";
+import { OverlayIndex, overlayFor } from "./overlay";
 // jSquash on Workers: WASM must be imported as a module and passed to init()
 // (no fetch-based instantiation in the Workers runtime).
 import decodeWebp, { init as initWebpDecode } from "@jsquash/webp/decode";
@@ -44,8 +47,8 @@ function ensureCodec(): Promise<void> {
 
 export interface Env {
   TILES: R2Bucket;
-  RELEASE_PREFIX?: string; // R2 key prefix selecting which release to serve, e.g. "seascape/<sha>/"; default ""
-  BASE_PATH?: string; // URL mount path = the Cloudflare route prefix; default "/seascape"
+  RELEASE_PREFIX?: string; // R2 key prefix selecting which release to serve, e.g. "bathymetry/<sha>/"; default ""
+  BASE_PATH?: string; // URL mount path = the Cloudflare route prefix; default "/bathymetry"
 }
 
 interface BundleMeta {
@@ -56,7 +59,8 @@ interface BundleMeta {
 }
 interface Manifest {
   planet: BundleMeta;
-  sources: (BundleMeta & { id: string })[]; // pre-sorted deepest-first
+  overlay: OverlayIndex; // {split_z, cells: {"z-x-y": max_zoom}}
+  source_ids?: string[]; // every configured source (the viewer's provenance palette)
   attribution?: string; // combined HTML credit for every contributing dataset
 }
 
@@ -97,6 +101,8 @@ async function manifest(env: Env): Promise<Manifest> {
     );
     if (!obj) throw new Error("manifest.json missing");
     manifestCache = JSON.parse(await obj.text());
+    // Tolerate a pre-grid manifest (old release / local seed): planet-only, no 500s.
+    manifestCache!.overlay ??= { split_z: 0, cells: {} };
   }
   return manifestCache!;
 }
@@ -110,22 +116,6 @@ async function tile(
 ): Promise<ArrayBuffer | undefined> {
   const r = await pm(env, file).getZxy(z, x, y);
   return r?.data;
-}
-
-// ── tile geometry ─────────────────────────────────────────────────────────
-function tileBounds(
-  z: number,
-  x: number,
-  y: number,
-): [number, number, number, number] {
-  const n = 2 ** z;
-  const lon = (i: number) => (i / n) * 360 - 180;
-  const lat = (j: number) =>
-    (Math.atan(Math.sinh(Math.PI * (1 - (2 * j) / n))) * 180) / Math.PI;
-  return [lon(x), lat(y + 1), lon(x + 1), lat(y)]; // w, s, e, n
-}
-function intersects(a: number[], b: number[]): boolean {
-  return a[0] < b[2] && a[2] > b[0] && a[1] < b[3] && a[3] > b[1];
 }
 
 // ── Terrarium overzoom: cubic B-spline on decoded heights ───────────────────
@@ -274,7 +264,7 @@ export default {
     // dev at root — tolerate both: strip it when present, else treat the path as
     // already relative. `mount` is echoed back into TileJSON tile URLs so they
     // stay correct either way.
-    const base = (env.BASE_PATH ?? "/seascape").replace(/\/+$/, "");
+    const base = (env.BASE_PATH ?? "/bathymetry").replace(/\/+$/, "");
     const mounted =
       base !== "" && (path === base || path.startsWith(base + "/"));
     const rel = mounted ? path.slice(base.length) : path;
@@ -292,10 +282,10 @@ export default {
         name: "Open Waters Bathymetry (raster)",
         tiles: [`${url.origin}${mount}/{z}/{x}/{y}.webp`],
         minzoom: mf.planet.min_zoom,
-        // Worker overzooms past native data, so the served ceiling is the deepest source.
+        // Worker overzooms past native data, so the served ceiling is the deepest cell.
         maxzoom: Math.max(
           mf.planet.max_zoom,
-          ...mf.sources.map((s) => s.max_zoom),
+          ...Object.values(mf.overlay.cells),
         ),
         bounds: mf.planet.bbox,
         encoding: "terrarium",
@@ -369,28 +359,34 @@ export default {
       const t = await tile(env, "planet.pmtiles", z, x, y);
       return t ? send(t, WEBP) : send(await transparentBytes(), WEBP);
     }
-    // Deepest-first: serve (or overzoom) the highest-res source covering this tile,
-    // so above an overlay's native zoom we upscale THAT overlay's regional detail
-    // instead of the coarse planet.
-    const tb = tileBounds(z, x, y);
-    for (const s of mf.sources) {
-      if (!intersects(tb, s.bbox)) continue;
-      // A miss (covering claims this bbox but lacks the tile) OR an error (R2 miss, bad
-      // range, decode failure) must not dead-end the tile — fall through to the next
-      // covering source, then the planet overzoom below.
-      try {
-        const t =
-          z <= s.max_zoom
-            ? await tile(env, s.file, z, x, y)
-            : await overzoom(env, s.file, s.max_zoom, z, x, y);
-        if (t) return send(t, WEBP);
-      } catch (e) {
-        console.log(
-          `overlay ${s.file} failed at ${z}/${x}/${y}, trying next: ${e}`,
-        );
+    // The tile's grid cell, if populated: serve it directly, else overzoom the
+    // deepest ancestor present in the cell — the cell's max_zoom is only its
+    // deepest spot, and a shallower source in the same cell stops lower, so walk
+    // the ancestor zooms down until one is there (upscales the regional detail,
+    // not the coarse planet). A miss OR an error (R2 miss, bad range, decode
+    // failure) must not dead-end the tile — try the next level, then the planet.
+    const ov = overlayFor(mf.overlay, z, x, y);
+    if (ov) {
+      if (z <= ov.maxZoom) {
+        try {
+          const t = await tile(env, ov.file, z, x, y);
+          if (t) return send(t, WEBP);
+        } catch (e) {
+          console.log(`overlay ${ov.file} failed at ${z}/${x}/${y}: ${e}`);
+        }
+      }
+      for (let sm = Math.min(ov.maxZoom, z - 1); sm > mf.planet.max_zoom; sm--) {
+        try {
+          const t = await overzoom(env, ov.file, sm, z, x, y);
+          if (t) return send(t, WEBP);
+        } catch (e) {
+          console.log(
+            `overlay ${ov.file} overzoom z${sm} failed at ${z}/${x}/${y}: ${e}`,
+          );
+        }
       }
     }
-    // No overlay covers it: overzoom the planet, or transparent if even that's absent.
+    // Nothing in the cell: overzoom the planet, or transparent if even that's absent.
     const planetOz = await overzoom(
       env,
       "planet.pmtiles",

--- a/worker/src/overlay.test.mjs
+++ b/worker/src/overlay.test.mjs
@@ -1,0 +1,34 @@
+// Run: node src/overlay.test.mjs   (Node ≥22.18 strips the imported .ts)
+import assert from "node:assert/strict";
+import { overlayFor } from "./overlay.ts";
+
+const ov = {
+  split_z: 5,
+  cells: { "5-9-11": 14, "5-15-15": 11 },
+};
+
+// A deep tile routes to its z5 ancestor's archive: z14 (4919, 6087) >> 9 = (9, 11).
+assert.deepEqual(overlayFor(ov, 14, 4919, 6087), {
+  file: "overlay-5-9-11.pmtiles",
+  maxZoom: 14,
+});
+// The shallowest overlay zoom routes the same way: z9 (287, 380) >> 4 = (17, 23) → miss…
+assert.equal(overlayFor(ov, 9, 287, 380), null);
+// …while z9 (144, 176) >> 4 = (9, 11) lands in the populated cell.
+assert.deepEqual(overlayFor(ov, 9, 144, 176), {
+  file: "overlay-5-9-11.pmtiles",
+  maxZoom: 14,
+});
+// Every z14 descendant of an unpopulated cell misses (planet overzoom fallback).
+assert.equal(overlayFor(ov, 14, 0, 0), null);
+// A tile deeper than its cell's max still resolves (the caller overzooms within the cell).
+assert.deepEqual(overlayFor(ov, 13, 15 << 8, 15 << 8), {
+  file: "overlay-5-15-15.pmtiles",
+  maxZoom: 11,
+});
+// Cell corners: the LAST tile under (5,9,11) at z14 is ((9+1)<<9 - 1, (11+1)<<9 - 1)…
+assert.equal(overlayFor(ov, 14, (10 << 9) - 1, (12 << 9) - 1).file, "overlay-5-9-11.pmtiles");
+// …and one step east is the next cell over (unpopulated → null).
+assert.equal(overlayFor(ov, 14, 10 << 9, (12 << 9) - 1), null);
+
+console.log("overlay.ts ok — cell routing, misses, corners, over-max resolution");

--- a/worker/src/overlay.ts
+++ b/worker/src/overlay.ts
@@ -7,8 +7,8 @@ export interface OverlayIndex {
 }
 
 /** The overlay archive holding (z,x,y) and its max zoom, or null if the tile's
- * cell is unpopulated. Callers only ask for z above the planet cap, which is
- * always deeper than split_z. */
+ * cell is unpopulated. Callers only ask for z above the planet cap, which is at
+ * or deeper than split_z (bundle.py enforces split_z <= cap + 1). */
 export function overlayFor(
   overlay: OverlayIndex,
   z: number,

--- a/worker/src/overlay.ts
+++ b/worker/src/overlay.ts
@@ -1,0 +1,24 @@
+// Fixed-grid overlay routing. Overlay archives are one per populated cell of the
+// build's OVERLAY_SPLIT_Z grid (see pipelines/bundle.py), so the archive holding a
+// tile is computed from the tile address — no footprint search, no source identity.
+export interface OverlayIndex {
+  split_z: number;
+  cells: Record<string, number>; // "z-x-y" cell -> its deepest zoom
+}
+
+/** The overlay archive holding (z,x,y) and its max zoom, or null if the tile's
+ * cell is unpopulated. Callers only ask for z above the planet cap, which is
+ * always deeper than split_z. */
+export function overlayFor(
+  overlay: OverlayIndex,
+  z: number,
+  x: number,
+  y: number,
+): { file: string; maxZoom: number } | null {
+  const d = z - overlay.split_z;
+  const cell = `${overlay.split_z}-${x >> d}-${y >> d}`;
+  const maxZoom = overlay.cells[cell];
+  return maxZoom === undefined
+    ? null
+    : { file: `overlay-${cell}.pmtiles`, maxZoom };
+}


### PR DESCRIPTION
## Problem

The `bundle (noaa_s102)` job died with `ENOSPC` ([run 28545454560](https://github.com/openwatersio/seascape/actions/runs/28545454560/job/84636945360)). Per-source overlay grouping made each archive's size a function of a source's *bounding box*: `assign_source` handed every regional tile to the deepest source whose rectangle overlapped it, so noaa_s102 (z14, whole-US bbox) silently became the catch-all for all of North America's interior. Every new NA source grew it — CUDEM, Lake Tahoe, the estuarine DEMs — and the Great Lakes source (#6) pushed it past the runner's disk (4263 pmtiles). A bigger runner only defers the same failure.

## Scheme

Overlays are now **one archive per populated cell of a fixed `OVERLAY_SPLIT_Z` grid** (default z5): `overlay-{z}-{x}-{y}.pmtiles`, holding every overlay tile (z9+) under that cell from whatever sources are there.

- **Bounded by construction** — a cell is a fixed fraction of the globe; new sources add *cells*, never bytes-per-cell. If a cell ever outgrows a runner, raise `OVERLAY_SPLIT_Z` (fail-fast guard keeps it ≤ `PLANET_MAX_ZOOM + 1`).
- **O(1) serving route** — the Worker computes the owning cell from the tile address (`worker/src/overlay.ts`); the manifest's per-source bbox list and the deepest-first intersection scan are gone. On a direct miss it walks the cell's ancestor zooms down and overzooms the deepest present (preserves the "upscale regional detail, not the coarse planet" behaviour for mixed-depth cells), then falls back to planet overzoom. Old manifests degrade to planet-only.
- **Stable partition** — `bundle-plan` emits the partition *in* the matrix (comma-joined chunks of group names), so bundle jobs can't drift from the plan's store view; each job loops its chunk pull → bundle → push → clean **one group at a time**, so peak disk is the single biggest group no matter how many cells exist.
- Source identity leaves bundling entirely (`high_res_sources` / `assign_source` deleted); the manifest keeps a flat `source_ids` list for the viewer's provenance palette.

## Manifest (schema change)

```json
{
  "planet": { "file": "planet.pmtiles", "min_zoom": 0, "max_zoom": 8, "bbox": [...] },
  "overlay": { "split_z": 5, "cells": { "5-9-11": 14, "5-10-12": 13 } },
  "source_ids": ["cudem", "..."],
  "attribution": "..."
}
```

Worker + viewer + manifest ship together in a release, so no compatibility window; both sides also tolerate the old schema defensively.

## Rollout

No re-aggregation needed — `store/pmtiles` is untouched; the next dispatched build re-bundles the existing tiles into grid overlays and the release deploys the matching Worker.

## Verification

- `just test-engine` — new `check_grid_split` (stem routing + a coarse parent partitioned across 4 cells, no leaks/dupes); e2e now asserts the manifest cells and that group-keys partitions every pmtiles exactly once; completeness/orphan gates unchanged and green.
- `worker/src/overlay.test.mjs` (cell routing, corners, misses, over-max resolution) — wired into ci.yml alongside the terrarium check; `tsc --noEmit` clean; viewer builds.
- Adversarial review pass: partition math, the CI bash loop (simulated with mocked docker/aws), and walk-up loop bounds verified; its one finding (unguarded `OVERLAY_SPLIT_Z` misconfiguration) is fixed with the fail-fast guard.

Generated with [Claude Code](https://claude.com/claude-code)