### PR TITLE
Extract MapLibre style into @openwaters/seascape package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,16 @@ jobs:
         run: |
           npm ci
           npm run build
+      - name: Style package tests (validate against the MapLibre style spec)
+        run: npm test
       - name: Worker self-checks
         run: |
           # The .mjs checks import .ts directly — needs Node >= 22.18 (default type
           # stripping); "node-version: 22" above resolves the latest 22.x, which is past it.
           node worker/src/terrarium.test.mjs
           node worker/src/overlay.test.mjs
+      - name: Worker type-check (imports @openwaters/seascape across packages)
+        working-directory: worker
+        run: |
+          npm ci
+          npx tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with: { node-version: 22 }
+      - name: Build style package
+        # Root install runs the style workspace's prepare (tsc → style/dist);
+        # the worker's own `npm ci` only symlinks file:../style without building.
+        run: npm ci
       - name: wrangler deploy
         working-directory: worker
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,15 @@ archives on purpose: a cell is a fixed fraction of the globe, so a new source ad
 *cells* instead of growing any single archive (a per-source overlay's size tracked
 its footprint and outgrew CI runner disks). Reads all pmtiles from R2 over HTTP
 range. The viewer (`index.js`) points at the Worker; `VITE_TILES_BASE` selects the
-endpoint (empty → `localhost:8787` dev).
+endpoint (empty → `localhost:8787` dev). The MapLibre style itself lives in
+**`style/`** (`@openwaters/seascape`, an npm workspace): flavor + `sources()` /
+`layers()` / `depthRelief()` in the protomaps-basemaps shape, consumed by the
+viewer and served assembled by the Worker at `/style.json` (`?unit=`/`?safety=`
+bake mariner defaults). Sources point at the Worker's TileJSON, so the style
+needs no manifest. TypeScript: `tsc` emits `style/dist/` on install (prepare);
+Vite dev reads `index.ts` directly (development export condition), but wrangler
+dev and `vite build` read `dist/` — rebuild after style edits. Tests: `npm test`
+(vitest).
 
 ### Contours (the custom vector layer)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ sources/<id>/   →  pipelines/  →  store/bundle/        →  worker/        �
 | `pipelines/`                              | The Python engine (`uv` project) + `Justfile`. Stages: source → aggregation → downsampling → bundle.          |
 | `worker/`                                 | Cloudflare Worker (TypeScript) that serves the unified tile endpoint from R2.                                 |
 | `index.js`, `index.html`                  | Vite/MapLibre viewer (repo root).                                                                             |
+| `style/`                                  | `@openwaters/seascape` (npm workspace): the MapLibre style as a library — flavor + `sources()`/`layers()`; the Worker serves it assembled at `/style.json`. Tests: `npm test`. |
 | `data/`, `pipelines/store/`, `dist/`      | Build artifacts (gitignored). All pipeline stages write under `pipelines/store/`.                              |
 | `ROADMAP.md`                              | Roadmap: goal, workstreams, source/coverage, build scaling. Port plan lives in the Claude plan file referenced in commits. |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -426,6 +426,14 @@ need/effort justifies; the inline notes above point here):
   from the tree (recoverable at git `9f93ad3`). Revisit for the Milestone-4 **soundings** layer,
   where sparse Chart-Datum points fit naturally — that, plus a resilient harvester and tile-bbox
   (not pixel-exact) coverage, is what it would need.
+- **GEBCO false-land over inland water** — where GEBCO lacks lake bathymetry it leaves the
+  underlying land DEM in place, so open inland water reads *positive* (+15 to +135 m observed
+  over Lake Huron) and the ≥0 depth ramp paints it tan/grey. A dedicated hi-res source fixes it
+  by overriding (great_lakes did, for the Great Lakes), but any lake/reservoir without one shows
+  the same. Global fix: mirror the existing `land_clamp` (which clamps GEBCO/EMODnet *negative
+  land*→0 against the OSM mask) with the inverse — clamp GEBCO *positive elevations*→nodata where
+  the mask says water — so GEBCO can't paint false land over any water body. Low effort (one more
+  masked-clamp in `landmask.py`); revisit when an inland gap without a dedicated source matters.
 
 (Concrete source candidates — marine and inland, with resolution/license/datum and
 BUILD/SKIP verdicts — live in [Source expansion](#source-expansion--worldwide-coverage-candidates) above. GLOBathy and the

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 <body>
   <div id="map"></div>
   <details id="controls" class="maplibregl-ctrl">
-    <summary title="Settings">&#9881;</summary>
+    <summary title="Settings" aria-label="Settings" role="button">&#9881;</summary>
     <div id="controls-panel">
       <label>
         <input type="checkbox" id="toggle-depth" checked /> Depth shading

--- a/index.html
+++ b/index.html
@@ -16,15 +16,33 @@
     }
 
     #controls {
-      position: absolute;
-      top: 10px;
-      right: 10px;
       background: #fff;
       border-radius: 6px;
-      padding: 8px 12px;
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
       font: 13px/1.6 system-ui, sans-serif;
-      z-index: 1;
+    }
+
+    #controls summary {
+      list-style: none;
+      cursor: pointer;
+      width: 29px;
+      height: 29px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 22px;
+      margin-left: auto;
+    }
+
+    #controls summary::-webkit-details-marker {
+      display: none;
+    }
+
+    #controls-panel {
+      padding: 0 12px 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
     }
 
     #controls label {
@@ -35,40 +53,43 @@
 
 <body>
   <div id="map"></div>
-  <div id="controls">
-    <label>
-      <input type="checkbox" id="toggle-depth" checked /> Depth shading
-    </label><br />
-    <label>
-      <input type="checkbox" id="toggle-hillshade" /> Hillshade
-    </label><br />
-    <label>
-      <input type="checkbox" id="toggle-contours" checked /> Contours
-    </label><br />
-    <label>
-      <input type="checkbox" id="toggle-labels" checked /> Labels
-    </label><br />
-    <label>
-      <input type="checkbox" id="toggle-soundings" checked /> Soundings
-    </label><br />
-    <label>
-      <input type="checkbox" id="toggle-drying" checked /> Drying areas
-    </label><br />
-    <label>Units
-      <select id="unit-select">
-        <option value="m">metres</option>
-        <option value="ft">feet</option>
-        <option value="fm">fathoms</option>
-      </select>
-    </label><br />
-    <label title="Draft + margin; water shallower than this is shaded as a hazard (0 = off)">
-      Safety
-      <input type="number" id="safety-depth" min="0" step="1" value="2" style="width: 3.5em" /> m
-    </label><br />
-    <label>
-      <input type="checkbox" id="toggle-sources" /> Source coverage
-    </label>
-  </div>
+  <details id="controls" class="maplibregl-ctrl">
+    <summary title="Settings">&#9881;</summary>
+    <div id="controls-panel">
+      <label>
+        <input type="checkbox" id="toggle-depth" checked /> Depth shading
+      </label>
+      <label>
+        <input type="checkbox" id="toggle-hillshade" checked /> Hillshade
+      </label>
+      <label>
+        <input type="checkbox" id="toggle-contours" checked /> Contours
+      </label>
+      <label>
+        <input type="checkbox" id="toggle-labels" checked /> Labels
+      </label>
+      <label>
+        <input type="checkbox" id="toggle-soundings" checked /> Soundings
+      </label>
+      <label>
+        <input type="checkbox" id="toggle-drying" checked /> Drying areas
+      </label>
+      <label>Units
+        <select id="unit-select">
+          <option value="m">metres</option>
+          <option value="ft">feet</option>
+          <option value="fm">fathoms</option>
+        </select>
+      </label>
+      <label title="Draft + margin; water shallower than this is shaded as a hazard (0 = off)">
+        Safety
+        <input type="number" id="safety-depth" min="0" step="1" value="2" style="width: 3.5em" /> m
+      </label>
+      <label>
+        <input type="checkbox" id="toggle-sources" /> Source coverage
+      </label>
+    </div>
+  </details>
 
   <script type="module" async src="./index.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+import { applyState, readDepth, style } from "@openwaters/seascape";
 
-// ─── Tile sources ───────────────────────────────────────────────────────
-// The serving Worker (worker/) presents one unified XYZ endpoint per layer:
-//   {base}/{z}/{x}/{y}.webp   — Terrarium terrain raster (planet + overlays, overzoomed)
-//   {base}/{z}/{x}/{y}.pbf    — MVT vector (contours, more layers later)
+// The style itself (sources, layers, depth ramp, unit/safety expressions) lives
+// in the @openwaters/seascape package (style/) — this file is the demo app:
+// endpoint config, manifest fetch, UI controls, click-to-inspect.
+//
 // VITE_TILES_BASE is the full bathymetry endpoint base — it includes the
 // /seascape route prefix in prod (e.g. https://tiles.openwaters.io/seascape);
 // the dev default points at the worker root. VITE_BBOX sets the initial view.
@@ -14,384 +15,36 @@ const BBOX = import.meta.env.VITE_BBOX
 const tilesBase = (
   import.meta.env.VITE_TILES_BASE || "http://localhost:8787"
 ).replace(/\/$/, "");
-const terrainTiles = `${tilesBase}/{z}/{x}/{y}.webp`;
-const contourTiles = `${tilesBase}/{z}/{x}/{y}.pbf`;
-const MAX_ZOOM = 13; // fallback deepest zoom when the manifest is unreachable
-
-// Fetch the manifest with no-store: it's a tiny, mutable pointer that decides the served max
-// zoom, and the Worker serves it with stale-while-revalidate + a per-release ETag (constant
-// "dev" locally), so a cached copy would silently pin an old max zoom across builds/releases.
-const manifest = await fetch(`${tilesBase}/manifest.json`, {
-  cache: "no-store",
-})
-  .then((r) => r.json())
-  .catch(() => null);
-// Deepest zoom with real data — the deepest overlay cell (vectors are baked to this; the raster
-// has native tiles to here).
-const contourMax = manifest
-  ? Math.max(
-      manifest.planet.max_zoom,
-      ...Object.values(manifest.overlay?.cells ?? {}),
-    )
-  : MAX_ZOOM;
-// Raster DEM: the Worker cubic-B-spline-overzooms the Terrarium raster PAST native data — that's
-// its whole purpose (smooth iso-depth band edges + shorelines at high zoom). Advertise the source
-// a few levels past the real-data ceiling so MapLibre fetches those smooth server tiles. Left to
-// its own overzoom MapLibre bilinearly stretches the last native tile, and bilinear is only C0, so
-// iso-depth band edges + shorelines facet into steps the further it is stretched; the Worker's
-// cubic B-spline is C2 (no faceting). Beyond a few levels it only blurs, so keep the margin small.
-const RASTER_MAX_ZOOM = contourMax + 3;
-
-// ─── Source coverage (provenance) ───────────────────────────────────────────
-// The `coverage` layer baked into vector.pmtiles (source footprints, props
-// source_id / source_name / source_maxzoom). Drawn as polygons and queried on click to
-// report which source a depth came from. Colour each source by id off the manifest's
-// source_ids (a match expression); ids not in the manifest fall back to grey.
-const COVERAGE_PALETTE = [
-  "#e6194b",
-  "#3cb44b",
-  "#f032e6",
-  "#4363d8",
-  "#f58231",
-  "#911eb4",
-  "#008080",
-  "#9a6324",
-  "#800000",
-  "#000075",
-];
-const coverageColor =
-  manifest && (manifest.source_ids ?? []).length
-    ? [
-        "match",
-        ["get", "source_id"],
-        ...manifest.source_ids.flatMap((id, i) => [
-          id,
-          COVERAGE_PALETTE[i % COVERAGE_PALETTE.length],
-        ]),
-        "#888",
-      ]
-    : "#f58231";
-
-// ─── Unit-aware chart expressions (driven by the `unit` global state) ─────────
-// One global-state variable — `unit` ("m" | "ft" | "fm") — drives every sounding/contour
-// label and which isobaths show. The Units control flips it with a single
-// setGlobalStateProperty call; MapLibre re-evaluates the expressions below (filters included),
-// so there's no per-layer setFilter/setLayoutProperty on change.
-//
-// Soundings (`soundings` layer): props depth_m / depth_ft / depth_fm, all floored toward
-// shallower; depth_m already carries one decimal in the shoal band (<6 m) and an integer deeper,
-// so metres just print it. symbol-sort-key = depth_m places the shoalest first, so GL collision
-// keeps the most dangerous sounding when labels clash.
-const UNIT = ["global-state", "unit"];
-const soundingText = [
-  "case",
-  ["==", UNIT, "ft"],
-  ["to-string", ["get", "depth_ft"]],
-  ["==", UNIT, "fm"],
-  ["to-string", ["get", "depth_fm"]],
-  ["to-string", ["get", "depth_m"]], // metres (default; also covers unit unset)
-];
-// Contours: metre isobaths (sys != "ft", also legacy no-sys tiles) vs the fathom-curve set
-// (sys == "ft"), which labels as feet or fathoms. Both systems label every curve — the
-// standard isobath sets are sparse enough that GL collision thins the labels.
-const IS_FEET = ["any", ["==", UNIT, "ft"], ["==", UNIT, "fm"]]; // metres is the fallback (unit unset)
-const contourLineFilter = [
-  "case",
-  IS_FEET,
-  ["==", ["get", "sys"], "ft"],
-  ["!=", ["get", "sys"], "ft"],
-];
-const contourLabelText = [
-  "case",
-  ["==", UNIT, "ft"],
-  ["concat", ["to-string", ["get", "depth_ft"]], "ft"],
-  ["==", UNIT, "fm"],
-  ["concat", ["to-string", ["get", "depth_fm"]], "fm"],
-  ["concat", ["to-string", ["get", "depth_abs_m"]], "m"],
-];
-
-// Shared label styling so soundings and contour labels read as one chart (same font, size,
-// colour, halo). Soundings at/shoaler than the safety depth print black (S-52).
-const LABEL_FONT = ["Open Sans Regular"];
-const LABEL_SIZE = ["interpolate", ["linear"], ["zoom"], 8, 9, 13, 12];
-const LABEL_COLOR = "#036";
-const LABEL_HALO = "#fff";
-
-// Depth-shading colour ramp (elevation → colour), chart-convention tints: shoal-dark →
-// deep-white (INT/NOAA), flat white beyond the deepest edge so tint stays monotonic in depth.
-// Bands are perceptually spaced (adjacent ΔE ≥ 7 after 0.85-opacity compositing), weighted
-// toward the shoal bands where depth discrimination matters. Band edges sit on isobaths the
-// chart draws — metric levels, or the classic fathom curves in ft/fm mode — so tint boundaries
-// land on contour lines rather than between them (paper-chart practice). The hazard tint folds
-// into THIS one color-relief ramp: two color-relief layers on one DEM source don't composite
-// (only the first renders), so water shallower than the safety depth is painted into the ramp
-// itself as HAZARD_COLOR. Rebuilt in JS on safety or unit change — an interpolate stop can't
-// be a live global-state value, so unlike the unit/safety filters this one uses setPaintProperty.
-const BAND_COLORS = [
-  "#e9f7ff", // deepest band
-  "#c9e9fd",
-  "#a5d9fb",
-  "#7fc7f8",
-  "#5db5f0",
-  "#3fa2e4", // shoalest band
-];
-const BAND_EDGES = {
-  m: [50, 20, 10, 5, 2],
-  ft: [30, 10, 5, 3, 1].map((fm) => fm * 1.8288), // fathom curves 30/10/5/3/1 fm
-};
-// Land above datum: translucent buff wash (paper-chart figure-ground — white stays
-// unambiguously "deep water"); OSM streets/names read through it.
-const LAND_COLOR = "rgba(247,240,221,0.66)";
-// Drying areas (INT-1 foreshore green): seabed above chart datum, seaward of the land line,
-// that covers/uncovers with the tide. A vector fill from the `drying` layer (the DEM ramp can't
-// tell it from dry land); sits above depth-shading, below the contour lines, at partial opacity
-// so it reads green over the buff land wash without hiding the OSM base.
-const DRYING_COLOR = "#a8d5ba";
-const depthRamp = (edges) => {
-  const stops = [-10000, BAND_COLORS[0]];
-  edges.forEach((d, i) =>
-    stops.push(-d - 0.1, BAND_COLORS[i], -d, BAND_COLORS[i + 1]),
-  );
-  stops.push(-0.01, BAND_COLORS[5], 0, LAND_COLOR);
-  return stops;
-};
-let DEPTH_RAMP = depthRamp(BAND_EDGES.m); // swapped by applyUnit on unit change
-const HAZARD_COLOR = "#1f86cb"; // one perceptual step darker than the shoalest band
-// Colour of the depth ramp at elevation e (linear-interpolated). Used to pin a normal-coloured
-// stop right at the safety depth so the flip to HAZARD_COLOR is a crisp ~0.01 m edge at ANY safety
-// value — otherwise the blend feathers by however far −safety lands from the nearest ramp stop.
-const rampColorAt = (e) => {
-  for (let i = 2; i < DEPTH_RAMP.length; i += 2)
-    if (e <= DEPTH_RAMP[i]) {
-      const e0 = DEPTH_RAMP[i - 2],
-        c0 = DEPTH_RAMP[i - 1];
-      const e1 = DEPTH_RAMP[i],
-        c1 = DEPTH_RAMP[i + 1];
-      if (c0[0] !== "#" || c1[0] !== "#") return c0;
-      const t = (e - e0) / (e1 - e0);
-      const p = (c) => [1, 3, 5].map((k) => parseInt(c.slice(k, k + 2), 16));
-      const a = p(c0),
-        b = p(c1);
-      return `rgb(${a.map((v, k) => Math.round(v + t * (b[k] - v))).join(",")})`;
-    }
-  return DEPTH_RAMP[1];
-};
-const depthReliefColor = (safety) => {
-  const s = -safety;
-  const stops = [];
-  for (let i = 0; i < DEPTH_RAMP.length; i += 2)
-    if (!(safety > 0) || DEPTH_RAMP[i] < s)
-      stops.push(DEPTH_RAMP[i], DEPTH_RAMP[i + 1]);
-  // Crisp edge: normal colour pinned at the safety depth, hazard from just shallower up to shore.
-  if (safety > 0)
-    stops.push(
-      s,
-      rampColorAt(s),
-      s + 0.01,
-      HAZARD_COLOR,
-      -0.01,
-      HAZARD_COLOR,
-      0,
-      LAND_COLOR,
-    );
-  return ["interpolate", ["linear"], ["elevation"], ...stops];
-};
-
-// ─── Map style ────────────────────────────────────────────────────────────
-const style = {
-  version: 8,
-  name: "GEBCO Bathymetry",
-  glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-  sources: {
-    osm: {
-      type: "raster",
-      tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-      tileSize: 256,
-      attribution:
-        "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>",
-    },
-    "terrain-dem": {
-      type: "raster-dem",
-      tiles: [terrainTiles],
-      tileSize: 512,
-      maxzoom: RASTER_MAX_ZOOM, // request the Worker's cubic overzoom, not client block-upsampling
-      encoding: "terrarium",
-      attribution: "&copy; <a href='https://www.gebco.net'>GEBCO</a>",
-    },
-    contours: {
-      type: "vector",
-      tiles: [contourTiles],
-      maxzoom: contourMax,
-    },
-  },
-  layers: [
-    {
-      id: "osm-base",
-      type: "raster",
-      source: "osm",
-      paint: { "raster-opacity": 1 },
-    },
-    {
-      id: "depth-shading",
-      type: "color-relief",
-      source: "terrain-dem",
-      paint: {
-        // One color-relief ramp for both depth-shading and the hazard tint (see DEPTH_RAMP /
-        // depthReliefColor); the JS override on load / safety-change folds in the hazard band.
-        "color-relief-color": [
-          "interpolate",
-          ["linear"],
-          ["elevation"],
-          ...DEPTH_RAMP,
-        ],
-        "color-relief-opacity": 0.85,
-      },
-    },
-    {
-      id: "hillshade",
-      type: "hillshade",
-      source: "terrain-dem",
-      layout: { visibility: "none" },
-      paint: {
-        "hillshade-exaggeration": 0.5,
-        "hillshade-shadow-color": "#9adcfe",
-        "hillshade-highlight-color": "#ffffff",
-        "hillshade-illumination-direction": 315,
-      },
-    },
-    {
-      // Green foreshore fill, above depth-shading and below the contour lines. Where no drying
-      // polygon covers a >=0 pixel the DEM ramp still paints LAND_COLOR, so a mask miss degrades
-      // to today's land rendering, never to water-over-land. Below ~z10 the polygons speckle, so
-      // the layer only shows from z10 (generation stays full-range; this is the cheap viewer cap).
-      id: "drying-areas",
-      type: "fill",
-      source: "contours",
-      "source-layer": "drying",
-      paint: { "fill-color": DRYING_COLOR, "fill-opacity": 0.55 },
-    },
-    {
-      id: "contour-lines",
-      type: "line",
-      source: "contours",
-      "source-layer": "contours",
-      filter: contourLineFilter,
-      paint: {
-        "line-color": "#4a7a9c",
-        "line-width": 0.5,
-        "line-opacity": 0.6,
-      },
-    },
-    {
-      id: "contour-labels",
-      type: "symbol",
-      source: "contours",
-      "source-layer": "contours",
-      filter: contourLineFilter,
-      minzoom: 8,
-      layout: {
-        "symbol-placement": "line",
-        "text-field": contourLabelText,
-        "text-size": LABEL_SIZE,
-        "text-font": LABEL_FONT,
-        "text-letter-spacing": 0.1,
-        "text-max-angle": 30,
-        "text-padding": 50,
-      },
-      paint: {
-        "text-color": LABEL_COLOR,
-        "text-halo-color": LABEL_HALO,
-        "text-halo-width": 1,
-      },
-    },
-    {
-      id: "soundings",
-      type: "symbol",
-      source: "contours",
-      "source-layer": "soundings",
-      minzoom: 7,
-      layout: {
-        "text-field": soundingText,
-        "text-font": LABEL_FONT,
-        "text-size": LABEL_SIZE,
-        "symbol-sort-key": ["get", "depth_m"], // shoalest first → wins collisions
-        "text-padding": 8,
-      },
-      paint: {
-        // Soundings at or shoaler than the safety depth print black — S-52 shows unsafe-water
-        // soundings in black and lets the hazard tint carry the alarm; safety=0 → all normal.
-        "text-color": [
-          "case",
-          [
-            "all",
-            [">", ["global-state", "safety"], 0],
-            ["<=", ["get", "depth_m"], ["global-state", "safety"]],
-          ],
-          "#000",
-          LABEL_COLOR,
-        ],
-        "text-halo-color": LABEL_HALO,
-        "text-halo-width": 1,
-      },
-    },
-    {
-      id: "source-fill",
-      type: "fill",
-      source: "contours",
-      "source-layer": "coverage",
-      // Hidden by default (the toggle starts unchecked); turning it on enables click-to-identify.
-      layout: { visibility: "none" },
-      paint: { "fill-color": coverageColor, "fill-opacity": 0.12 },
-    },
-    {
-      // Brightened fill of the source a click landed in; filter set on click.
-      id: "source-highlight",
-      type: "fill",
-      source: "contours",
-      "source-layer": "coverage",
-      filter: ["==", ["get", "source_id"], "__none__"],
-      layout: { visibility: "none" },
-      paint: { "fill-color": coverageColor, "fill-opacity": 0.4 },
-    },
-    {
-      id: "source-outline",
-      type: "line",
-      source: "contours",
-      "source-layer": "coverage",
-      layout: { visibility: "none" },
-      paint: { "line-color": coverageColor, "line-width": 1.5 },
-    },
-    {
-      id: "source-labels",
-      type: "symbol",
-      source: "contours",
-      "source-layer": "coverage",
-      layout: {
-        visibility: "none",
-        "text-field": ["get", "source_name"],
-        "text-size": 11,
-        "text-font": ["Open Sans Regular"],
-      },
-      paint: {
-        "text-color": coverageColor,
-        "text-halo-color": "#fff",
-        "text-halo-width": 1.2,
-      },
-    },
-  ],
-};
+const MAX_ZOOM = 13; // deepest zoom readDepth fetches (the Worker overzooms past it)
 
 // ─── Create map ───────────────────────────────────────────────────────────
+// The style is self-contained: zooms/bounds/attribution come from the
+// endpoint's TileJSON, so there's nothing to fetch before creating the map.
 const map = new maplibregl.Map({
   container: "map",
-  style,
+  style: style({ tilesBase }),
   bounds: BBOX,
   hash: true,
+  dragRotate: false,
+  pitchWithRotate: false,
   attributionControl: { compact: true },
 });
 window.map = map; // exposed for debugging / verification
 
+// MapLibre keeps compact attribution expanded until the first map interaction;
+// collapse it once the style (and its attributions) have loaded.
+map.on("load", () =>
+  map
+    .getContainer()
+    .querySelector(".maplibregl-ctrl-attrib")
+    ?.classList.remove("maplibregl-compact-show"),
+);
+
 map.addControl(new maplibregl.NavigationControl());
+map.addControl({
+  onAdd: () => document.getElementById("controls"),
+  onRemove: () => {},
+});
 
 // No setTerrain(): enabling 3D terrain drapes the DEM layers (depth-shading, hillshade)
 // over MapLibre's terrain mesh, which resamples the land+water DEM coarsely below native
@@ -399,7 +52,7 @@ map.addControl(new maplibregl.NavigationControl());
 // cutoff, so narrow/shallow water (bays, sounds, shoals) renders transparent at z<8 —
 // leaving only the deep open water, which then looks like coarse GEBCO. color-relief reads
 // the tiles at native resolution instead. Click-depth reads the DEM tile directly
-// (readElevation), so terrain isn't needed for it. Re-add behind a toggle for 3D seafloor.
+// (readDepth), so terrain isn't needed for it. Re-add behind a toggle for 3D seafloor.
 
 // ─── Layer toggles ────────────────────────────────────────────────────────
 const toggles = {
@@ -418,32 +71,22 @@ const toggles = {
 };
 
 map.on("load", () => {
-  // Safety depth (metres, default 2): drives the hazard tint (via the depth-shading ramp) and
-  // the red-sounding emphasis (via the `safety` state var). 0 = off.
-  let safetyMetres = 2;
-  const applySafety = () => {
-    map.setGlobalStateProperty("safety", safetyMetres); // red-sounding emphasis
-    // Hazard tint lives in the depth-shading ramp (one color-relief per source), rebuilt here.
-    map.setPaintProperty(
-      "depth-shading",
-      "color-relief-color",
-      depthReliefColor(safetyMetres),
-    );
-  };
-  // Unit change swaps the ramp's band edges to the active system's isobaths and repaints (via
-  // applySafety); every other unit-aware expression re-evaluates off the `unit` state variable.
-  const applyUnit = (u) => {
-    map.setGlobalStateProperty("unit", u);
-    DEPTH_RAMP = depthRamp(BAND_EDGES[u === "m" ? "m" : "ft"]);
-    applySafety();
-  };
-  const safetyInput = document.getElementById("safety-depth");
-  if (safetyInput) safetyInput.value = safetyMetres;
-  applyUnit(document.getElementById("unit-select")?.value || "m");
-  safetyInput?.addEventListener("input", (e) => {
-    safetyMetres = parseFloat(e.target.value) || 0;
-    applySafety();
-  });
+  // Mariner settings — unit (m/ft/fm) and safety depth (metres, 0 = off; drives
+  // the hazard tint and black-sounding emphasis, S-52 style). applyState flips
+  // the global-state AND rebuilds the depth ramp together (the ramp can't read
+  // global-state), so the controls just forward their current values.
+  const applyControls = () =>
+    applyState(map, {
+      unit: document.getElementById("unit-select")?.value || "m",
+      safety: parseFloat(document.getElementById("safety-depth")?.value) || 0,
+    });
+  applyControls();
+  document
+    .getElementById("safety-depth")
+    ?.addEventListener("input", applyControls);
+  document
+    .getElementById("unit-select")
+    ?.addEventListener("change", applyControls);
   for (const [inputId, layerIds] of Object.entries(toggles)) {
     document.getElementById(inputId)?.addEventListener("change", (e) => {
       const vis = e.target.checked ? "visible" : "none";
@@ -452,35 +95,9 @@ map.on("load", () => {
       });
     });
   }
-  document
-    .getElementById("unit-select")
-    ?.addEventListener("change", (e) => applyUnit(e.target.value));
 });
 
 // ─── Click to inspect ─────────────────────────────────────────────────────
-// Decode the elevation straight from the DEM tile pixel (Terrarium). This reads the tile
-// at native resolution — unlike queryTerrainElevation, which needs 3D terrain enabled and
-// samples the coarse terrain mesh (it reads land over deep water near the coast).
-async function readElevation(lngLat) {
-  const z = Math.min(Math.round(map.getZoom()), MAX_ZOOM);
-  const n = 2 ** z;
-  const fx = ((lngLat.lng + 180) / 360) * n;
-  const fy =
-    ((1 - Math.asinh(Math.tan((lngLat.lat * Math.PI) / 180)) / Math.PI) / 2) *
-    n;
-  const X = Math.floor(fx);
-  const Y = Math.floor(fy);
-  const px = Math.min(511, Math.floor((fx - X) * 512));
-  const py = Math.min(511, Math.floor((fy - Y) * 512));
-  const r = await fetch(`${tilesBase}/${z}/${X}/${Y}.webp`);
-  if (!r.ok) return null;
-  const bmp = await createImageBitmap(await r.blob());
-  const cx = new OffscreenCanvas(512, 512).getContext("2d");
-  cx.drawImage(bmp, 0, 0);
-  const [r8, g8, b8] = cx.getImageData(px, py, 1, 1).data;
-  return r8 * 256 + g8 + b8 / 256 - 32768; // Terrarium decode → metres
-}
-
 // Which source covers a clicked point: the deepest footprint wins (lex-first id on a
 // tie), matching the build's merge rule, so this names the source the depth came from.
 // undefined → coverage layer hidden (skip the line); null → no footprint here = GEBCO.
@@ -499,7 +116,11 @@ function sourceAt(point) {
 }
 
 map.on("click", async (e) => {
-  const ele = await readElevation(e.lngLat);
+  const ele = await readDepth(
+    tilesBase,
+    e.lngLat,
+    Math.min(map.getZoom(), MAX_ZOOM),
+  );
   const src = sourceAt(e.point);
   if (map.getLayer("source-highlight"))
     map.setFilter("source-highlight", [

--- a/index.js
+++ b/index.js
@@ -87,13 +87,20 @@ map.on("load", () => {
   document
     .getElementById("unit-select")
     ?.addEventListener("change", applyControls);
+  // Layer toggles: the checkboxes are the source of truth — sync once on load
+  // (the style's own defaults may differ, e.g. hillshade ships hidden) and on
+  // every change.
   for (const [inputId, layerIds] of Object.entries(toggles)) {
-    document.getElementById(inputId)?.addEventListener("change", (e) => {
-      const vis = e.target.checked ? "visible" : "none";
+    const input = document.getElementById(inputId);
+    if (!input) continue;
+    const sync = () => {
+      const vis = input.checked ? "visible" : "none";
       layerIds.forEach((id) => {
         if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", vis);
       });
-    });
+    };
+    sync();
+    input.addEventListener("change", sync);
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,12 @@
   "packages": {
     "": {
       "name": "seascape",
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "style"
+      ],
       "devDependencies": {
+        "@openwaters/seascape": "^0.1.0",
         "maplibre-gl": "^5.21.1",
         "pmtiles": "^4.4.0",
         "vite": "^8.0.2"
@@ -45,13 +50,20 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -177,6 +189,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@openwaters/seascape": {
+      "resolved": "style",
+      "link": true
     },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
@@ -450,6 +466,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -460,6 +483,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -478,6 +526,146 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -494,6 +682,33 @@
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -546,7 +761,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/kdbush": {
@@ -817,6 +1031,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/maplibre-gl": {
       "version": "5.21.1",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.21.1.tgz",
@@ -856,7 +1080,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -888,6 +1111,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pbf": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
@@ -914,7 +1158,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -979,7 +1222,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/resolve-protobuf-schema": {
@@ -1033,6 +1275,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1043,6 +1292,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -1051,6 +1314,23 @@
       "license": "ISC",
       "dependencies": {
         "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1074,8 +1354,17 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -1085,12 +1374,27 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -1161,6 +1465,150 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "style": {
+      "name": "@openwaters/seascape",
+      "version": "0.1.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^25.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.0",
+        "vitest": "^4.1.9"
+      }
+    },
+    "style/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "style/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-25.0.1.tgz",
+      "integrity": "sha512-cppei6MsmpZnBgtZoHwQu8Ioie6LcHC+ME8/wcLDwzdLi6eWnMgoryiWnd00qQ5ZNTmFcAnw5EMZIqZxMamEBQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "style"
       ],
       "devDependencies": {
-        "@openwaters/seascape": "^0.1.0",
+        "@openwaters/seascape": "*",
         "maplibre-gl": "^5.21.1",
         "pmtiles": "^4.4.0",
         "vite": "^8.0.2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm test --workspaces --if-present"
   },
   "devDependencies": {
-    "@openwaters/seascape": "^0.1.0",
+    "@openwaters/seascape": "*",
     "maplibre-gl": "^5.21.1",
     "pmtiles": "^4.4.0",
     "vite": "^8.0.2"

--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
   "private": true,
   "license": "BSD-3-Clause",
   "type": "module",
+  "workspaces": [
+    "style"
+  ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "npm run build --workspace style && vite build",
+    "test": "npm test --workspaces --if-present"
   },
   "devDependencies": {
+    "@openwaters/seascape": "^0.1.0",
     "maplibre-gl": "^5.21.1",
     "pmtiles": "^4.4.0",
     "vite": "^8.0.2"

--- a/style/README.md
+++ b/style/README.md
@@ -1,0 +1,103 @@
+# @openwaters/seascape
+
+MapLibre GL style for the [Open Waters](https://openwaters.io) bathymetry
+tiles: chart-convention depth shading, isobath contours + labels, spot
+soundings, drying areas, and source-provenance overlays.
+
+The zero-build path — the tile Worker serves the assembled style at
+`/style.json` (e.g. `https://tiles.openwaters.io/seascape/style.json`); pass
+that URL straight to MapLibre's `style:` option or open it in Maputnik.
+`?unit=m|ft|fm` and `?safety=<metres>` bake mariner defaults into the served
+style.
+
+## Usage
+
+Whole style (OSM raster base + bathymetry). Zooms, bounds, and attribution
+come from the endpoint's TileJSON (`raster.json` / `vector.json`) — no other
+fetch needed:
+
+```js
+import maplibregl from "maplibre-gl";
+import { style } from "@openwaters/seascape";
+
+new maplibregl.Map({
+  container: "map",
+  style: style({ tilesBase: "https://tiles.openwaters.io/seascape" }),
+});
+```
+
+Composed into your own style (the protomaps-basemaps pattern — you own
+`sources`, the package provides layer groups):
+
+```js
+import { day, sources, layers, state } from "@openwaters/seascape";
+
+const myStyle = {
+  version: 8,
+  glyphs: "...",
+  state, // global-state defaults for `unit` and `safety`
+  sources: { ...myBasemapSources, ...sources({ tilesBase }) },
+  layers: [...myBasemapLayers, ...layers(day)],
+};
+```
+
+Options: `style()` takes `unit` / `safety` (baked defaults, see below),
+`flavor`, `glyphs`, and `osm: false` to skip the base map.
+
+## Runtime parameters
+
+`unit` (`"m" | "ft" | "fm"`) and `safety` (metres, 0 = off) are MapLibre
+[global-state](https://maplibre.org/maplibre-style-spec/root/#state) variables
+(GL JS ≥ 5.6). Change them with `applyState`, which flips the state (every
+label, isobath filter, and unsafe-sounding emphasis re-evaluates) **and**
+rebuilds the depth-shading ramp — the one piece that can't read global-state
+(`interpolate` stops must be literals). Setting one without the other desyncs
+tint from labels, so don't:
+
+```js
+import { applyState } from "@openwaters/seascape";
+applyState(map, { unit: "ft", safety: 3 });
+```
+
+`depthRelief(flavor, { unit, safety })` remains exported as the low-level ramp
+builder if you manage the paint property yourself.
+
+## Depth readout
+
+`readDepth(tilesBase, lngLat, zoom)` → chart-datum elevation in metres
+(negative below datum, positive above; `null` on a tile miss), decoded from
+the Terrarium DEM tile pixel at native resolution. Use it instead of
+`queryTerrainElevation`, which needs 3D terrain enabled and samples a coarse
+mesh that reads land over deep water near coasts. Browser-only.
+
+```js
+map.on("click", async (e) => {
+  const ele = await readDepth(tilesBase, e.lngLat, map.getZoom());
+});
+```
+
+## Flavors
+
+A flavor is a plain object of colors/fonts (`day` is the only built-in so
+far); custom looks are spread-overrides:
+
+```js
+layers({ ...day, hazard: "#c00", font: ["Noto Sans Regular"] });
+```
+
+## Versioning
+
+Semver against the *tile schema* (protomaps' policy): renaming or removing a
+vector layer or feature property the style reads is a major; additive tile or
+style changes are minor; visual-only tweaks are patch.
+
+## Development
+
+TypeScript; `tsc` emits `dist/` on install (`prepare`) and via `npm run
+build`. The `development` export condition points Vite dev straight at
+`index.ts`, so style edits hot-reload without a build step — but bundlers
+without that condition (wrangler dev, `vite build`) read `dist/`, so rebuild
+after edits.
+
+`npm test` (vitest) validates the generated style against the MapLibre style
+spec and checks the ramp/hazard math and layer-id stability.

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "vitest";
+import { validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
+import {
+  applyState,
+  day,
+  state,
+  depthRelief,
+  sources,
+  layers,
+  style,
+  type ChartMap,
+} from "./index";
+
+// Expressions are opaque tuple unions; tests poke at their raw stops.
+const raw = (e: unknown) => e as (number | string)[];
+
+test("generated style validates against the MapLibre style spec", () => {
+  const variants = [
+    style({ tilesBase: "https://t.example/seascape" }),
+    style({
+      tilesBase: "https://t.example",
+      osm: false,
+      unit: "ft",
+      safety: 3,
+    }),
+  ];
+  for (const s of variants) expect(validateStyleMin(s)).toEqual([]);
+});
+
+test("sources reference the endpoint's TileJSON, encoding inline", () => {
+  const src = sources({ tilesBase: "https://t.example" }) as Record<
+    string,
+    { url?: string; encoding?: string }
+  >;
+  expect(src["seascape-dem"].url).toBe("https://t.example/raster.json");
+  // MapLibre doesn't read `encoding` from TileJSON — it must be inline.
+  expect(src["seascape-dem"].encoding).toBe("terrarium");
+  expect(src["seascape-vector"].url).toBe("https://t.example/vector.json");
+});
+
+test("unit/safety bake into both state defaults and the depth ramp", () => {
+  const s = style({ tilesBase: "https://t.example", unit: "fm", safety: 3 });
+  expect(s.state).toEqual({ unit: { default: "fm" }, safety: { default: 3 } });
+  const shading = s.layers.find((l) => l.id === "depth-shading");
+  const ramp = raw(
+    (shading as { paint: Record<string, unknown> }).paint[
+      "color-relief-color"
+    ],
+  );
+  expect(ramp).toContain(day.hazard);
+  // Fathom-curve band edges are active; the 3 fm edge is deeper than the 3 m
+  // safety depth so it survives the hazard fold (shoaler stops are dropped).
+  expect(ramp).toContain(-3 * 1.8288);
+  expect(ramp).not.toContain(-1 * 1.8288);
+});
+
+test("depthRelief folds a crisp hazard edge at the safety depth", () => {
+  expect(raw(depthRelief(day, { unit: "m", safety: 0 }))).not.toContain(
+    day.hazard,
+  );
+  const on = raw(depthRelief(day, { unit: "m", safety: 2 }));
+  const hz = on.indexOf(day.hazard);
+  expect(hz).toBeGreaterThan(0);
+  expect(on[hz - 1]).toBe(-2 + 0.01); // normal colour pinned just below…
+  expect(on[hz + 1]).toBe(-0.01); // …hazard up to the shore
+  expect(on[on.length - 1]).toBe(day.land); // land wash still terminates the ramp
+});
+
+test("layers reference only the caller's source names", () => {
+  const named = layers(day, { dem: "bathy-dem", vector: "bathy" });
+  expect(
+    [...new Set(named.map((l) => (l as { source: string }).source))].sort(),
+  ).toEqual(["bathy", "bathy-dem"]);
+});
+
+test("layer ids are stable — consumers key toggles/queries off them", () => {
+  expect(layers().map((l) => l.id)).toEqual([
+    "depth-shading",
+    "hillshade",
+    "drying-areas",
+    "contour-lines",
+    "contour-labels",
+    "soundings",
+    "source-fill",
+    "source-highlight",
+    "source-outline",
+    "source-labels",
+  ]);
+});
+
+test("state defaults exist for every global-state key the expressions read", () => {
+  expect(Object.keys(state).sort()).toEqual(["safety", "unit"]);
+});
+
+test("applyState keeps global-state and the ramp in sync", () => {
+  const globals: Record<string, unknown> = { unit: "m", safety: 2 };
+  const paints: unknown[] = [];
+  const map: ChartMap = {
+    setGlobalStateProperty: (k, v) => (globals[k] = v),
+    getGlobalState: () => globals,
+    setPaintProperty: (layer, prop, value) => paints.push({ layer, prop, value }),
+    getLayer: (id) => (id === "depth-shading" ? {} : undefined),
+  };
+
+  // Changing only safety must rebuild the ramp with the CURRENT unit.
+  applyState(map, { safety: 5 });
+  expect(globals.safety).toBe(5);
+  expect(paints).toHaveLength(1);
+  const ramp = raw(
+    (paints[0] as { layer: string; prop: string; value: unknown }).value,
+  );
+  expect(ramp).toContain(day.hazard); // safety > 0 folds the hazard band
+  expect(ramp).toContain(-10); // metric band edge → unit stayed "m"
+
+  // Changing unit swaps the ramp onto the fathom curves.
+  applyState(map, { unit: "fm" });
+  expect(globals.unit).toBe("fm");
+  const fmRamp = raw(
+    (paints[1] as { layer: string; prop: string; value: unknown }).value,
+  );
+  expect(fmRamp).toContain(-30 * 1.8288); // 30 fm curve → ft/fm band edges
+  // Same-call values win over (possibly async) map state reads.
+  expect(fmRamp).toContain(day.hazard); // safety 5 still folded
+
+  // No depth-shading layer (composed style without it) → state set, no repaint.
+  const bare: ChartMap = { ...map, getLayer: () => undefined };
+  applyState(bare, { safety: 0 });
+  expect(paints).toHaveLength(2);
+});

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -33,6 +33,12 @@ test("sources reference the endpoint's TileJSON, encoding inline", () => {
     { url?: string; encoding?: string }
   >;
   expect(src["seascape-dem"].url).toBe("https://t.example/raster.json");
+  // A trailing slash on tilesBase must not produce double-slash URLs.
+  const slashed = sources({ tilesBase: "https://t.example/" }) as Record<
+    string,
+    { url?: string }
+  >;
+  expect(slashed["seascape-dem"].url).toBe("https://t.example/raster.json");
   // MapLibre doesn't read `encoding` from TileJSON — it must be inline.
   expect(src["seascape-dem"].encoding).toBe("terrarium");
   expect(src["seascape-vector"].url).toBe("https://t.example/vector.json");

--- a/style/index.ts
+++ b/style/index.ts
@@ -174,6 +174,7 @@ export function sources({
   dem?: string;
   vector?: string;
 }): Record<string, SourceSpecification> {
+  tilesBase = tilesBase.replace(/\/+$/, ""); // tolerate a trailing slash
   return {
     [dem]: {
       type: "raster-dem",
@@ -503,6 +504,7 @@ export async function readDepth(
   lngLat: { lng: number; lat: number },
   zoom: number,
 ): Promise<number | null> {
+  tilesBase = tilesBase.replace(/\/+$/, ""); // tolerate a trailing slash
   const z = Math.max(0, Math.round(zoom));
   const n = 2 ** z;
   const fx = ((lngLat.lng + 180) / 360) * n;

--- a/style/index.ts
+++ b/style/index.ts
@@ -1,0 +1,523 @@
+/**
+ * @openwaters/seascape — MapLibre GL style for the Open Waters bathymetry tiles.
+ *
+ * Follows the protomaps-basemaps split: layer *structure* lives in these
+ * functions, appearance lives in a plain "flavor" object, and the consumer owns
+ * the style — either assembled piecemeal (`sources()` + `layers()` concat with
+ * other layer groups) or whole via `style()` (what the tile Worker serves at
+ * /style.json).
+ *
+ *   import { style } from "@openwaters/seascape";
+ *   new maplibregl.Map({ style: style({ tilesBase }) });
+ *
+ * Zooms, bounds, and attribution come from the endpoint's TileJSON documents
+ * (raster.json / vector.json).
+ *
+ * Runtime parameters: the `unit` ("m" | "ft" | "fm") and `safety` (metres,
+ * 0 = off) global-state variables drive every label, filter, and sounding-
+ * emphasis expression — flip them with map.setGlobalStateProperty() and the
+ * style re-evaluates, no per-layer restyle. The one exception is the
+ * depth-shading ramp: interpolate stops must be literals, so on unit or safety
+ * change rebuild it with depthRelief() and setPaintProperty (see below).
+ */
+import type {
+  ExpressionSpecification,
+  LayerSpecification,
+  SourceSpecification,
+  StyleSpecification,
+} from "@maplibre/maplibre-gl-style-spec";
+
+export type Unit = "m" | "ft" | "fm";
+
+export interface Flavor {
+  bandColors: string[]; // deepest → shoalest (6 entries)
+  bandEdges: { m: number[]; ft: number[] }; // band-edge depths, metres
+  hazard: string;
+  land: string;
+  drying: string;
+  contour: string;
+  label: string;
+  labelHalo: string;
+  font: string[];
+  hillshadeShadow: string;
+  coverage: string;
+}
+
+// ─── Flavor (appearance only — custom looks are spread-overrides) ────────────
+// Depth-shading tints follow chart convention: shoal-dark → deep-white
+// (INT/NOAA), flat white beyond the deepest edge so tint stays monotonic in
+// depth. Bands are perceptually spaced (adjacent ΔE ≥ 7 after 0.85-opacity
+// compositing), weighted toward the shoal bands where depth discrimination
+// matters. Band edges sit on isobaths the chart draws — metric levels, or the
+// classic fathom curves in ft/fm mode — so tint boundaries land on contour
+// lines rather than between them (paper-chart practice).
+export const day: Flavor = {
+  bandColors: [
+    "#e9f7ff", // deepest band
+    "#c9e9fd",
+    "#a5d9fb",
+    "#7fc7f8",
+    "#5db5f0",
+    "#3fa2e4", // shoalest band
+  ],
+  bandEdges: {
+    m: [50, 20, 10, 5, 2],
+    ft: [30, 10, 5, 3, 1].map((fm) => fm * 1.8288), // fathom curves 30/10/5/3/1 fm
+  },
+  // One perceptual step darker than the shoalest band — water shallower than
+  // the safety depth.
+  hazard: "#1f86cb",
+  // Land above datum: translucent buff wash (paper-chart figure-ground — white
+  // stays unambiguously "deep water"); a raster base reads through it.
+  land: "rgba(247,240,221,0.66)",
+  // Drying areas (INT-1 foreshore green): seabed above chart datum that covers
+  // and uncovers with the tide.
+  drying: "#a8d5ba",
+  contour: "#4a7a9c",
+  label: "#036",
+  labelHalo: "#fff",
+  font: ["Open Sans Regular"],
+  hillshadeShadow: "#9adcfe",
+  coverage: "#f58231",
+};
+
+// global-state defaults (the style root `state` object).
+export const state: { unit: { default: Unit }; safety: { default: number } } = {
+  unit: { default: "m" },
+  safety: { default: 2 },
+};
+
+const DEFAULT_GLYPHS =
+  "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf";
+
+// ─── Depth-shading ramp (elevation → colour) ─────────────────────────────────
+// The hazard tint folds into this one color-relief ramp: two color-relief
+// layers on one DEM source don't composite (only the first renders), so water
+// shallower than the safety depth is painted into the ramp itself.
+type RampStops = (number | string)[]; // alternating elevation, colour
+
+const depthRamp = (flavor: Flavor, edges: number[]): RampStops => {
+  const stops: RampStops = [-10000, flavor.bandColors[0]];
+  edges.forEach((d, i) =>
+    stops.push(-d - 0.1, flavor.bandColors[i], -d, flavor.bandColors[i + 1]),
+  );
+  stops.push(-0.01, flavor.bandColors[5], 0, flavor.land);
+  return stops;
+};
+
+// Colour of the ramp at elevation e (linear-interpolated). Used to pin a
+// normal-coloured stop right at the safety depth so the flip to the hazard
+// colour is a crisp ~0.01 m edge at ANY safety value — otherwise the blend
+// feathers by however far −safety lands from the nearest ramp stop.
+const rampColorAt = (ramp: RampStops, e: number): string => {
+  for (let i = 2; i < ramp.length; i += 2)
+    if (e <= (ramp[i] as number)) {
+      const e0 = ramp[i - 2] as number,
+        c0 = ramp[i - 1] as string;
+      const e1 = ramp[i] as number,
+        c1 = ramp[i + 1] as string;
+      if (c0[0] !== "#" || c1[0] !== "#") return c0;
+      const t = (e - e0) / (e1 - e0);
+      const p = (c: string) =>
+        [1, 3, 5].map((k) => parseInt(c.slice(k, k + 2), 16));
+      const a = p(c0),
+        b = p(c1);
+      return `rgb(${a.map((v, k) => Math.round(v + t * (b[k] - v))).join(",")})`;
+    }
+  return ramp[1] as string;
+};
+
+// The color-relief expression for the active unit system and safety depth.
+// Interpolate stops can't be live global-state values, so unit/safety changes
+// rebuild this and apply it with setPaintProperty("depth-shading", ...).
+export function depthRelief(
+  flavor: Flavor = day,
+  { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
+): ExpressionSpecification {
+  const ramp = depthRamp(flavor, flavor.bandEdges[unit === "m" ? "m" : "ft"]);
+  const s = -safety;
+  const stops: RampStops = [];
+  for (let i = 0; i < ramp.length; i += 2)
+    if (!(safety > 0) || (ramp[i] as number) < s)
+      stops.push(ramp[i], ramp[i + 1]);
+  // Crisp edge: normal colour pinned at the safety depth, hazard from just
+  // shallower up to shore.
+  if (safety > 0)
+    stops.push(
+      s,
+      rampColorAt(ramp, s),
+      s + 0.01,
+      flavor.hazard,
+      -0.01,
+      flavor.hazard,
+      0,
+      flavor.land,
+    );
+  return [
+    "interpolate",
+    ["linear"],
+    ["elevation"],
+    ...stops,
+  ] as unknown as ExpressionSpecification;
+}
+
+// ─── Sources ─────────────────────────────────────────────────────────────────
+// tilesBase is the Worker endpoint; the sources reference its TileJSON docs
+// (raster.json / vector.json), which carry the tile URLs, zoom range, bounds,
+// and the combined per-source attribution.
+export function sources({
+  tilesBase,
+  dem = "seascape-dem",
+  vector = "seascape-vector",
+}: {
+  tilesBase: string;
+  dem?: string;
+  vector?: string;
+}): Record<string, SourceSpecification> {
+  return {
+    [dem]: {
+      type: "raster-dem",
+      url: `${tilesBase}/raster.json`,
+      tileSize: 512,
+      // MapLibre doesn't read `encoding` from TileJSON — it must be inline.
+      encoding: "terrarium",
+    },
+    [vector]: {
+      type: "vector",
+      url: `${tilesBase}/vector.json`,
+    },
+  };
+}
+
+// ─── Layers ──────────────────────────────────────────────────────────────────
+export function layers(
+  flavor: Flavor = day,
+  {
+    dem = "seascape-dem",
+    vector = "seascape-vector",
+    // Baked into the initial depth-shading ramp; keep in sync with the state
+    // defaults (runtime changes go through depthRelief() + setPaintProperty).
+    unit = state.unit.default,
+    safety = state.safety.default,
+  }: {
+    dem?: string;
+    vector?: string;
+    unit?: Unit;
+    safety?: number;
+  } = {},
+): LayerSpecification[] {
+  // One global-state variable — `unit` — drives every sounding/contour label
+  // and which isobaths show.
+  //
+  // Soundings: props depth_m / depth_ft / depth_fm, all floored toward
+  // shallower; depth_m already carries one decimal in the shoal band (<6 m)
+  // and an integer deeper, so metres just print it.
+  const UNIT: ExpressionSpecification = ["global-state", "unit"];
+  const soundingText: ExpressionSpecification = [
+    "case",
+    ["==", UNIT, "ft"],
+    ["to-string", ["get", "depth_ft"]],
+    ["==", UNIT, "fm"],
+    ["to-string", ["get", "depth_fm"]],
+    ["to-string", ["get", "depth_m"]], // metres (default; also covers unit unset)
+  ];
+  // Contours: metre isobaths (sys != "ft", also legacy no-sys tiles) vs the
+  // fathom-curve set (sys == "ft"), which labels as feet or fathoms. Both
+  // systems label every curve — the standard isobath sets are sparse enough
+  // that GL collision thins the labels.
+  const IS_FEET: ExpressionSpecification = [
+    "any",
+    ["==", UNIT, "ft"],
+    ["==", UNIT, "fm"],
+  ];
+  const contourLineFilter: ExpressionSpecification = [
+    "case",
+    IS_FEET,
+    ["==", ["get", "sys"], "ft"],
+    ["!=", ["get", "sys"], "ft"],
+  ];
+  const contourLabelText: ExpressionSpecification = [
+    "case",
+    ["==", UNIT, "ft"],
+    ["concat", ["to-string", ["get", "depth_ft"]], "ft"],
+    ["==", UNIT, "fm"],
+    ["concat", ["to-string", ["get", "depth_fm"]], "fm"],
+    ["concat", ["to-string", ["get", "depth_abs_m"]], "m"],
+  ];
+
+  // Shared label styling so soundings and contour labels read as one chart.
+  const labelSize: ExpressionSpecification = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    8,
+    9,
+    13,
+    12,
+  ];
+
+  const coverageColor = flavor.coverage;
+
+  return [
+    {
+      id: "depth-shading",
+      type: "color-relief",
+      source: dem,
+      paint: {
+        "color-relief-color": depthRelief(flavor, { unit, safety }),
+        "color-relief-opacity": 0.85,
+      },
+    },
+    {
+      id: "hillshade",
+      type: "hillshade",
+      source: dem,
+      layout: { visibility: "none" },
+      paint: {
+        "hillshade-exaggeration": 0.5,
+        "hillshade-shadow-color": flavor.hillshadeShadow,
+        "hillshade-highlight-color": "#ffffff",
+        "hillshade-illumination-direction": 315,
+      },
+    },
+    {
+      // Green foreshore fill, above depth-shading and below the contour lines.
+      // Where no drying polygon covers a >=0 pixel the DEM ramp still paints
+      // the land wash, so a mask miss degrades to plain land rendering, never
+      // to water-over-land.
+      id: "drying-areas",
+      type: "fill",
+      source: vector,
+      "source-layer": "drying",
+      paint: { "fill-color": flavor.drying, "fill-opacity": 0.55 },
+    },
+    {
+      id: "contour-lines",
+      type: "line",
+      source: vector,
+      "source-layer": "contours",
+      filter: contourLineFilter,
+      paint: {
+        "line-color": flavor.contour,
+        "line-width": 0.5,
+        "line-opacity": 0.6,
+      },
+    },
+    {
+      id: "contour-labels",
+      type: "symbol",
+      source: vector,
+      "source-layer": "contours",
+      filter: contourLineFilter,
+      minzoom: 8,
+      layout: {
+        "symbol-placement": "line",
+        "text-field": contourLabelText,
+        "text-size": labelSize,
+        "text-font": flavor.font,
+        "text-letter-spacing": 0.1,
+        "text-max-angle": 30,
+        "text-padding": 50,
+      },
+      paint: {
+        "text-color": flavor.label,
+        "text-halo-color": flavor.labelHalo,
+        "text-halo-width": 1,
+      },
+    },
+    {
+      id: "soundings",
+      type: "symbol",
+      source: vector,
+      "source-layer": "soundings",
+      minzoom: 7,
+      layout: {
+        "text-field": soundingText,
+        "text-font": flavor.font,
+        "text-size": labelSize,
+        "symbol-sort-key": ["get", "depth_m"], // shoalest first → wins collisions
+        "text-padding": 8,
+      },
+      paint: {
+        // Soundings at or shoaler than the safety depth print black — S-52
+        // shows unsafe-water soundings in black and lets the hazard tint carry
+        // the alarm; safety=0 → all normal.
+        "text-color": [
+          "case",
+          [
+            "all",
+            [">", ["global-state", "safety"], 0],
+            ["<=", ["get", "depth_m"], ["global-state", "safety"]],
+          ],
+          "#000",
+          flavor.label,
+        ],
+        "text-halo-color": flavor.labelHalo,
+        "text-halo-width": 1,
+      },
+    },
+    // Source coverage (provenance): footprint polygons with props source_id /
+    // source_name / source_maxzoom. Hidden by default; a viewer can toggle
+    // them on for click-to-identify.
+    {
+      id: "source-fill",
+      type: "fill",
+      source: vector,
+      "source-layer": "coverage",
+      layout: { visibility: "none" },
+      paint: { "fill-color": coverageColor, "fill-opacity": 0.12 },
+    },
+    {
+      // Brightened fill of one source (filter set by the consumer on click).
+      id: "source-highlight",
+      type: "fill",
+      source: vector,
+      "source-layer": "coverage",
+      filter: ["==", ["get", "source_id"], "__none__"],
+      layout: { visibility: "none" },
+      paint: { "fill-color": coverageColor, "fill-opacity": 0.4 },
+    },
+    {
+      id: "source-outline",
+      type: "line",
+      source: vector,
+      "source-layer": "coverage",
+      layout: { visibility: "none" },
+      paint: { "line-color": coverageColor, "line-width": 1.5 },
+    },
+    {
+      id: "source-labels",
+      type: "symbol",
+      source: vector,
+      "source-layer": "coverage",
+      layout: {
+        visibility: "none",
+        "text-field": ["get", "source_name"],
+        "text-size": 11,
+        "text-font": flavor.font,
+      },
+      paint: {
+        "text-color": coverageColor,
+        "text-halo-color": "#fff",
+        "text-halo-width": 1.2,
+      },
+    },
+  ];
+}
+
+// ─── Whole style ─────────────────────────────────────────────────────────────
+// A complete, drop-in StyleSpecification: OSM raster base (osm: false for
+// layers-only over your own basemap) + the bathymetry sources and layers.
+// `unit`/`safety` bake mariner defaults into both the depth ramp and the
+// style's global-state defaults, so labels and tint always agree.
+export function style({
+  tilesBase,
+  flavor = day,
+  glyphs = DEFAULT_GLYPHS,
+  osm = true,
+  unit = state.unit.default,
+  safety = state.safety.default,
+}: {
+  tilesBase: string;
+  flavor?: Flavor;
+  glyphs?: string;
+  osm?: boolean;
+  unit?: Unit;
+  safety?: number;
+}): StyleSpecification {
+  const osmSource: Record<string, SourceSpecification> = osm
+    ? {
+        osm: {
+          type: "raster",
+          tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+          tileSize: 256,
+          attribution:
+            "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>",
+        },
+      }
+    : {};
+  const osmBase: LayerSpecification[] = osm
+    ? [{ id: "osm-base", type: "raster", source: "osm" }]
+    : [];
+  return {
+    version: 8,
+    name: "Open Waters Seascape",
+    glyphs,
+    state: { unit: { default: unit }, safety: { default: safety } },
+    sources: { ...osmSource, ...sources({ tilesBase }) },
+    layers: [...osmBase, ...layers(flavor, { unit, safety })],
+  };
+}
+
+// ─── Runtime helpers ──────────────────────────────────────────────────────────
+// The style is not pure JSON: the depth ramp can't read global-state, and depth
+// readout decodes Terrarium pixels. These live here so consumers don't re-derive
+// either.
+
+// The subset of maplibregl.Map that applyState touches (structural, so the
+// package needs no maplibre-gl dependency).
+export interface ChartMap {
+  setGlobalStateProperty(name: string, value: unknown): unknown;
+  getGlobalState(): Record<string, unknown>;
+  setPaintProperty(layerId: string, name: string, value: unknown): unknown;
+  getLayer(id: string): unknown;
+}
+
+// Change the mariner settings on a live map. Flipping the `unit` / `safety`
+// global-state re-evaluates every label, filter, and sounding-emphasis
+// expression — but the depth-shading ramp's interpolate stops must be literals,
+// so it is rebuilt here with the SAME values. This pairing is the whole point:
+// setting the state without repainting the ramp (or vice versa) desyncs tint
+// from labels.
+export function applyState(
+  map: ChartMap,
+  changes: { unit?: Unit; safety?: number },
+  flavor: Flavor = day,
+): void {
+  if (changes.unit !== undefined)
+    map.setGlobalStateProperty("unit", changes.unit);
+  if (changes.safety !== undefined)
+    map.setGlobalStateProperty("safety", changes.safety);
+  const current = {
+    unit: state.unit.default,
+    safety: state.safety.default,
+    ...map.getGlobalState(),
+    ...changes,
+  } as { unit: Unit; safety: number };
+  if (map.getLayer("depth-shading"))
+    map.setPaintProperty(
+      "depth-shading",
+      "color-relief-color",
+      depthRelief(flavor, current),
+    );
+}
+
+// Chart-datum elevation at a point, in metres — negative below datum (depth),
+// positive above (land / drying foreshore); null if the tile is unavailable.
+// Decodes the Terrarium DEM tile pixel directly, at native resolution — unlike
+// queryTerrainElevation, which needs 3D terrain enabled and samples the coarse
+// terrain mesh (it reads land over deep water near the coast). Browser-only
+// (createImageBitmap / OffscreenCanvas).
+export async function readDepth(
+  tilesBase: string,
+  lngLat: { lng: number; lat: number },
+  zoom: number,
+): Promise<number | null> {
+  const z = Math.max(0, Math.round(zoom));
+  const n = 2 ** z;
+  const fx = ((lngLat.lng + 180) / 360) * n;
+  const fy =
+    ((1 - Math.asinh(Math.tan((lngLat.lat * Math.PI) / 180)) / Math.PI) / 2) *
+    n;
+  const X = Math.floor(fx);
+  const Y = Math.floor(fy);
+  const px = Math.min(511, Math.floor((fx - X) * 512));
+  const py = Math.min(511, Math.floor((fy - Y) * 512));
+  const r = await fetch(`${tilesBase}/${z}/${X}/${Y}.webp`);
+  if (!r.ok) return null;
+  const bmp = await createImageBitmap(await r.blob());
+  const cx = new OffscreenCanvas(512, 512).getContext("2d")!;
+  cx.drawImage(bmp, 0, 0);
+  const [r8, g8, b8] = cx.getImageData(px, py, 1, 1).data;
+  return r8 * 256 + g8 + b8 / 256 - 32768; // Terrarium decode → metres
+}

--- a/style/package.json
+++ b/style/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openwaters/seascape",
+  "version": "0.1.0",
+  "description": "MapLibre GL style for Open Waters bathymetry tiles — depth shading, contours, soundings, drying areas",
+  "license": "BSD-3-Clause",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "development": "./index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "index.ts"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openwatersio/seascape.git",
+    "directory": "style"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepare": "tsc -p tsconfig.build.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@maplibre/maplibre-gl-style-spec": "^25.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.9"
+  }
+}

--- a/style/tsconfig.build.json
+++ b/style/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts"]
+}

--- a/style/tsconfig.json
+++ b/style/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["index.ts", "index.test.ts"]
+}

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -5,14 +5,24 @@
   "packages": {
     "": {
       "name": "seascape-worker",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@jsquash/webp": "^1.5.0",
+        "@openwaters/seascape": "file:../style",
         "pmtiles": "^4.4.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240909.0",
         "typescript": "^5.6.0",
         "wrangler": "^3.80.0"
+      }
+    },
+    "../style": {
+      "name": "@openwaters/seascape",
+      "version": "0.1.0",
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^25.0.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -986,6 +996,10 @@
         "wasm-feature-detect": "^1.2.11"
       }
     },
+    "node_modules/@openwaters/seascape": {
+      "resolved": "../style",
+      "link": true
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1541,6 +1555,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/worker/package.json
+++ b/worker/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@jsquash/webp": "^1.5.0",
+    "@openwaters/seascape": "file:../style",
     "pmtiles": "^4.4.0"
   },
   "devDependencies": {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -25,6 +25,7 @@
  */
 
 import { PMTiles, Source, RangeResponse } from "pmtiles";
+import { style as seascapeStyle } from "@openwaters/seascape";
 import { unpackTerrarium, packTerrariumInto, cubicBSpline } from "./terrarium";
 import { OverlayIndex, overlayFor } from "./overlay";
 // jSquash on Workers: WASM must be imported as a module and passed to init()
@@ -283,9 +284,49 @@ export default {
       base !== "" && (path === base || path.startsWith(base + "/"));
     const rel = mounted ? path.slice(base.length) : path;
     const mount = mounted ? base : "";
+    // Absolute endpoint base echoed into TileJSON/style URLs. `wrangler dev`
+    // rewrites the request URL *and* Host header to the configured route host
+    // (tiles.openwaters.io), leaving no truthful origin in a local request —
+    // so dev pins localhost at the port the dev script binds
+    // (worker/package.json); prod trusts the request origin.
+    const tilesBase = dev
+      ? `http://localhost:8787${mount}`
+      : `${url.origin}${mount}`;
 
     if (rel === "/manifest.json") {
       return json(await manifest(env));
+    }
+    // Drop-in MapLibre style for these tiles — the same style the viewer
+    // renders (assembled by @openwaters/seascape); the endpoint base is derived
+    // from the request. Point MapLibre's `style:` (or Maputnik) at this URL
+    // directly. ?unit=m|ft|fm and ?safety=<metres> bake mariner defaults into
+    // the served style (the depth ramp can't read runtime state, so zero-build
+    // consumers parameterize here instead).
+    if (rel === "/style.json") {
+      const unitParam = url.searchParams.get("unit");
+      const unit =
+        unitParam === null
+          ? undefined
+          : (["m", "ft", "fm"] as const).find((u) => u === unitParam);
+      if (unitParam !== null && unit === undefined)
+        return new Response("unit must be m, ft, or fm", {
+          status: 400,
+          headers: CORS,
+        });
+      const safetyParam = url.searchParams.get("safety");
+      const safety = safetyParam === null ? undefined : Number(safetyParam);
+      if (safety !== undefined && !(Number.isFinite(safety) && safety >= 0))
+        return new Response("safety must be a non-negative number (metres)", {
+          status: 400,
+          headers: CORS,
+        });
+      return json(
+        seascapeStyle({
+          tilesBase,
+          ...(unit !== undefined ? { unit } : {}),
+          ...(safety !== undefined ? { safety } : {}),
+        }),
+      );
     }
     // TileJSON per representation — point MapLibre/Mapbox at these directly.
     // A TileJSON is single-format, so raster and vector get separate docs.
@@ -294,13 +335,17 @@ export default {
       return json({
         tilejson: "3.0.0",
         name: "Open Waters Bathymetry (raster)",
-        tiles: [`${url.origin}${mount}/{z}/{x}/{y}.webp`],
+        tiles: [`${tilesBase}/{z}/{x}/{y}.webp`],
         minzoom: mf.planet.min_zoom,
-        // Worker overzooms past native data, so the served ceiling is the deepest cell.
-        maxzoom: Math.max(
-          mf.planet.max_zoom,
-          ...Object.values(mf.overlay.cells),
-        ),
+        // Advertise a few levels past the deepest real data: the Worker
+        // cubic-B-spline-overzooms the Terrarium raster PAST native tiles —
+        // its whole purpose (smooth iso-depth band edges + shorelines at high
+        // zoom). A renderer left to its own overzoom bilinearly stretches the
+        // last native tile, and bilinear is only C0, so band edges facet into
+        // steps; the Worker's B-spline is C2. Beyond a few levels it only
+        // blurs, so the margin stays small.
+        maxzoom:
+          Math.max(mf.planet.max_zoom, ...Object.values(mf.overlay.cells)) + 3,
         bounds: mf.planet.bbox,
         encoding: "terrarium",
         attribution: mf.attribution ?? "",
@@ -312,7 +357,7 @@ export default {
       return json({
         tilejson: "3.0.0",
         name: "Open Waters Bathymetry",
-        tiles: [`${url.origin}${mount}/{z}/{x}/{y}.pbf`],
+        tiles: [`${tilesBase}/{z}/{x}/{y}.pbf`],
         minzoom: h.minZoom,
         maxzoom: h.maxZoom,
         bounds: [h.minLon, h.minLat, h.maxLon, h.maxLat],

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -303,23 +303,28 @@ export default {
     // the served style (the depth ramp can't read runtime state, so zero-build
     // consumers parameterize here instead).
     if (rel === "/style.json") {
+      // Uncacheable plain-text 400s: an intermediary must never cache an error
+      // for a URL that would succeed once the param is fixed.
+      const bad = (msg: string) =>
+        new Response(msg, {
+          status: 400,
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+            "cache-control": "no-store",
+            ...CORS,
+          },
+        });
       const unitParam = url.searchParams.get("unit");
       const unit =
         unitParam === null
           ? undefined
           : (["m", "ft", "fm"] as const).find((u) => u === unitParam);
       if (unitParam !== null && unit === undefined)
-        return new Response("unit must be m, ft, or fm", {
-          status: 400,
-          headers: CORS,
-        });
+        return bad("unit must be m, ft, or fm");
       const safetyParam = url.searchParams.get("safety");
       const safety = safetyParam === null ? undefined : Number(safetyParam);
       if (safety !== undefined && !(Number.isFinite(safety) && safety >= 0))
-        return new Response("safety must be a non-negative number (metres)", {
-          status: 400,
-          headers: CORS,
-        });
+        return bad("safety must be a non-negative number (metres)");
       return json(
         seascapeStyle({
           tilesBase,


### PR DESCRIPTION
## Summary
- Extracts the viewer's inline MapLibre style into `style/` (`@openwaters/seascape`), a publishable TypeScript npm workspace in the protomaps-basemaps shape: a plain `day` flavor object for appearance, `sources()` / `layers()` / `style()` for structure, and runtime helpers (`applyState`, `readDepth`, `depthRelief`) for the parts a nautical style can't express as JSON.
- Sources point at the Worker's TileJSON (`raster.json` / `vector.json`) for zooms, bounds, and attribution — the style is fully self-contained (`style({ tilesBase })`), and the `+3` cubic-overzoom margin moves into `raster.json`'s advertised maxzoom so every TileJSON consumer gets the Worker's smooth overzoom.
- The Worker serves the assembled style at `/style.json` for zero-build consumers (MapLibre `style:` URL, Maputnik); `?unit=m|ft|fm` and `?safety=<metres>` bake mariner defaults, invalid params return 400.
- Coverage/provenance layers use a single flavor colour (per-source palette dropped), which removed the last manifest read from the style path — the viewer fetches nothing before map creation.
- Build/tooling: `tsc` emits `dist/` on install via `prepare`; the `development` export condition keeps Vite dev HMR on the TS source; vitest suite wired into CI plus a worker type-check; the release worker deploy builds `style/dist` before wrangler bundles it.

## Test plan
- [x] `npm test` — 8 vitest tests: style-spec validation (`validateStyleMin`), manifest-free sources, ramp hazard-fold edges, unit/safety state+ramp sync, source renaming, layer-id stability
- [x] `tsc --noEmit` for the package (source + tests) and the worker
- [x] `npm run build` (style tsc + vite build) and `wrangler deploy --dry-run`
- [x] Live NY-harbor preview (`just preview` + wrangler dev + Vite): rendering pixel-equivalent, click popup depth via `readDepth`, unit flip to fathoms re-banded the ramp, coverage toggle + click-to-identify intact, `/style.json` params verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)