### PR TITLE
Work-sized build fan-outs + single vector tile-join

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -554,8 +554,10 @@ jobs:
           aws s3 cp store/bundle/manifest.json "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/manifest.json" \
             --content-type application/json
 
-  # ─── Contours (sharded — one global tippecanoe blows the 6 h cap at planet scale) ─
-  # Size the fan-out to the work (no download — just an R2 listing).
+  # ── Vector layers (sharded — one global tippecanoe blows the 6 h cap at planet scale) ─
+  # Size the fan-out to the contour work — the dominant layer; soundings + drying
+  # slices ride the same shards for ~20% more per-shard time (no download — just an
+  # R2 listing).
   contour-plan:
     needs: aggregate
     if: ${{ !cancelled() && needs.aggregate.result == 'success' }}
@@ -573,7 +575,11 @@ jobs:
           echo "shards=$shards" >> "$GITHUB_OUTPUT"
           echo "contour FGBs: $count → matrix $shards"
 
-  # tippecanoe one strided FGB slice per runner → a per-shard contours pmtiles.
+  # tippecanoe one strided slice of every vector layer per runner → per-shard
+  # contours/soundings/drying pmtiles. Soundings + drying ride the contour shards
+  # (separately they held contour-bundle's tile-join back ~26 min while the rest of
+  # the build sat finished); the slices stride each layer's own sorted list — no
+  # geographic alignment needed, the merge unions everything per tile anyway.
   contours:
     needs: [aggregate, contour-plan]
     if: ${{ !cancelled() && needs.contour-plan.result == 'success' }}
@@ -586,35 +592,41 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/ghcr-login
-      # Pull ONLY this shard's FGB slice (not the whole set). List the FGB keys
-      # (sorted = the order Python globs), derive the global maxz (so every shard
-      # tiles to the same depth and tile-joins cleanly), and parallel-copy the
-      # strided slice this shard owns.
-      - name: Pull this shard's FGB slice from R2
+      # Pull ONLY this shard's slices (not the whole sets). List each layer's keys
+      # (sorted = the order Python globs), derive the global maxz from the contour
+      # list (so every shard and layer tiles to the same depth and tile-joins
+      # cleanly), and parallel-copy the strided slices this shard owns.
+      - name: Pull this shard's layer slices from R2
         run: |
-          mkdir -p store/contour store/bundle
-          aws s3 ls "s3://$DATA_BUCKET/bathymetry/contour/" --recursive | awk '{print $NF}' | grep '\.fgb$' | sort > /tmp/all.txt
-          sed 's#.*/##; s/\.fgb$//' /tmp/all.txt | awk -F- '{print $4}' | sort -n | tail -1 > store/contour-maxz.txt
+          mkdir -p store/contour store/soundings store/drying store/bundle
+          aws s3 ls "s3://$DATA_BUCKET/bathymetry/contour/" --recursive | awk '{print $NF}' | grep '\.fgb$' | sort > /tmp/all-contour.txt
+          sed 's#.*/##; s/\.fgb$//' /tmp/all-contour.txt | awk -F- '{print $4}' | sort -n | tail -1 > store/contour-maxz.txt
+          aws s3 ls "s3://$DATA_BUCKET/bathymetry/soundings/" --recursive | awk '{print $NF}' | grep '\.geojson$' | sort > /tmp/all-soundings.txt
+          aws s3 ls "s3://$DATA_BUCKET/bathymetry/drying/" --recursive | awk '{print $NF}' | grep '\.fgb$' | sort > /tmp/all-drying.txt
           # Bounded outer retry + visible errors — see the downsample pull above.
-          awk -v i="${{ matrix.shard.i }}" -v n="${{ matrix.shard.n }}" 'NR % n == (i + 1) % n' /tmp/all.txt \
-            | xargs -P 8 -I{} sh -c 'for a in 1 2 3 4 5; do aws s3 cp "s3://$DATA_BUCKET/$1" store/contour/ --only-show-errors && exit 0; sleep "$a"; done; echo "giving up on $1 after 5 attempts" >&2; exit 1' _ {}
-          echo "shard ${{ matrix.shard.i }}/${{ matrix.shard.n }}: $(ls store/contour/*.fgb 2>/dev/null | wc -l) FGBs, global maxz $(cat store/contour-maxz.txt)"
-      - name: Contour shard ${{ matrix.shard.i }}
+          for spec in "/tmp/all-contour.txt store/contour" "/tmp/all-soundings.txt store/soundings" "/tmp/all-drying.txt store/drying"; do
+            set -- $spec
+            awk -v i="${{ matrix.shard.i }}" -v n="${{ matrix.shard.n }}" 'NR % n == (i + 1) % n' "$1" \
+              | xargs -P 8 -I{} sh -c 'for a in 1 2 3 4 5; do aws s3 cp "s3://$DATA_BUCKET/$1" "$2/" --only-show-errors && exit 0; sleep "$a"; done; echo "giving up on $1 after 5 attempts" >&2; exit 1' _ {} "$2"
+          done
+          echo "shard ${{ matrix.shard.i }}/${{ matrix.shard.n }}: $(ls store/contour/*.fgb 2>/dev/null | wc -l) contour FGBs, $(ls store/soundings/*.geojson 2>/dev/null | wc -l) soundings, $(ls store/drying/*.fgb 2>/dev/null | wc -l) drying, global maxz $(cat store/contour-maxz.txt)"
+      - name: Vector shard ${{ matrix.shard.i }}
         run: |
           docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" \
-            "$IMAGE:$IMAGE_TAG" just contour-shard ${{ matrix.shard.i }}
+            "$IMAGE:$IMAGE_TAG" just vector-shard ${{ matrix.shard.i }}
       - name: Push shard pmtiles to R2
         run: |
           aws s3 cp store/bundle "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-shards/" \
-            --recursive --exclude '*' --include 'contours-shard-*.pmtiles' --content-type application/octet-stream
+            --recursive --exclude '*' --include '*-shard-*.pmtiles' --content-type application/octet-stream
           # Global contour maxz (identical from every shard) — contour-bundle's merge needs
           # it to tile the coverage layer to the same depth as the contours.
           aws s3 cp store/contour-maxz.txt "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-maxz.txt"
 
-  # tile-join the per-shard pmtiles + soundings + drying + coverage into one vector.pmtiles,
-  # in ONE join: tile-join rewrites every tile of the whole archive, so the old
-  # merge-then-fold-per-layer shape re-paid the planet-wide join per layer (~90 min each,
-  # serial, as the only job left running — the last 2 h 40 of the build).
+  # tile-join the per-shard pmtiles (contours + soundings + drying slices) + coverage
+  # into one vector.pmtiles, in ONE join: tile-join rewrites every tile of the whole
+  # archive, so the old merge-then-fold-per-layer shape re-paid the planet-wide join
+  # per layer (~90 min each, serial, as the only job left running — the last 2 h 40
+  # of the build).
   contour-bundle:
     needs: contours
     if: ${{ !cancelled() && needs.contours.result == 'success' }}
@@ -623,20 +635,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/ghcr-login
-      - name: Pull shard pmtiles + soundings + drying from R2
+      - name: Pull shard pmtiles from R2
         run: |
-          mkdir -p store/bundle store/soundings store/drying
+          mkdir -p store/bundle
           aws s3 sync "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-shards" store/bundle
           aws s3 cp "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-maxz.txt" store/contour-maxz.txt
-          aws s3 sync "s3://$DATA_BUCKET/bathymetry/soundings" store/soundings
-          aws s3 sync "s3://$DATA_BUCKET/bathymetry/drying" store/drying
-      # Soundings + drying aren't sharded (sparse); their pmtiles must exist before the
-      # merge so its tile-join folds them in.
-      - name: Bundle soundings + drying
-        run: |
-          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just soundings
-          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just drying
-      - name: Merge contours + fold layers
+      - name: Merge shards + fold coverage
         run: docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just contour-merge
       - name: Push vector.pmtiles to R2 build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,8 +456,17 @@ jobs:
           # The tail is finished here on one runner from the full store; the matrix jobs
           # below each pull only one group's slice at a time. Contours are bundled by the
           # separate sharded jobs, so store/contour is NOT pulled here.
+          # Outer retry, same reason as the per-key pulls elsewhere: one mid-body
+          # connection reset (after aws's internal retries) exits the whole ~50 GiB
+          # sync 1; sync is incremental, so a retry only re-fetches what's missing.
           mkdir -p store/pmtiles
-          aws s3 sync "s3://$DATA_BUCKET/bathymetry/pmtiles" store/pmtiles
+          for a in 1 2 3; do
+            aws s3 sync "s3://$DATA_BUCKET/bathymetry/pmtiles" store/pmtiles && exit 0
+            echo "pmtiles sync attempt $a failed; retrying in $((a * 10))s" >&2
+            sleep $((a * 10))
+          done
+          echo "pmtiles sync failed after 3 attempts" >&2
+          exit 1
       - name: Coarse tail + bundle matrix
         id: g
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
         required: false
         default: ""
       shards:
-        description: "Aggregate matrix shards (<= 256)"
+        description: "Fan-out ceiling (<= 256): aggregate shard count; the other phases self-size to their work below it"
         required: false
         default: "24"
       force:
@@ -378,10 +378,13 @@ jobs:
           aws s3 sync store/aggregation "s3://$DATA_BUCKET/bathymetry/aggregation" --exclude '*' --include '*.done'
 
   # Overview pyramid, sharded. The deep levels partition into read-closed subtrees
-  # (one per ancestor at the covering's seed zoom) so they fan out with no
-  # coordination, exactly like aggregate; the coarse global tail (a few cheap levels
-  # whose tiles span subtrees) is finished on the single bundle runner below. The
-  # level barrier stays inside each runner. A clean rebuild still spins one no-op shard.
+  # (one per ancestor at the covering's seed zoom), bin-packed by work into the shards
+  # (a shard ≈ the heaviest single subtree — sizing to ancestor *count* left one
+  # 77-minute straggler blocking bundle-plan next to hundreds of spin-up-only shards),
+  # so they fan out with no coordination, exactly like aggregate; the coarse global
+  # tail (a few cheap levels whose tiles span subtrees) is finished on the single
+  # bundle runner below. The level barrier stays inside each runner. A clean rebuild
+  # still spins one no-op shard.
   downsample:
     needs: [image, aggregate, plan]
     if: ${{ !cancelled() && needs.aggregate.result == 'success' }}
@@ -431,9 +434,11 @@ jobs:
   # whose footprint-sized archives outgrew a runner as sources accumulated. bundle-plan
   # finishes the coarse pyramid tail (it spans ancestors, so it can't be a deep shard),
   # verifies the pyramid is whole, and emits the matrix: each entry is a comma-joined
-  # CHUNK of group names (the partition rides in the matrix, so jobs can't drift from the
-  # plan's store view). A matrix job loops its chunk pull→bundle→push→clean one group at
-  # a time; bundle-merge stitches the fragments. Contours are built separately (below).
+  # CHUNK of group names, bin-packed by pmtiles bytes so a chunk ≈ the biggest single
+  # group (one-group chunks spent more runner time on setup than bundling). The
+  # partition rides in the matrix, so jobs can't drift from the plan's store view. A
+  # matrix job loops its chunk pull→bundle→push→clean one group at a time;
+  # bundle-merge stitches the fragments. Contours are built separately (below).
   bundle-plan:
     needs: downsample
     if: ${{ !cancelled() && needs.downsample.result == 'success' }}
@@ -550,7 +555,7 @@ jobs:
             --content-type application/json
 
   # ─── Contours (sharded — one global tippecanoe blows the 6 h cap at planet scale) ─
-  # Size the fan-out to the FGB count (no download — just an R2 listing).
+  # Size the fan-out to the work (no download — just an R2 listing).
   contour-plan:
     needs: aggregate
     if: ${{ !cancelled() && needs.aggregate.result == 'success' }}
@@ -561,7 +566,10 @@ jobs:
       - id: m
         run: |
           count=$(aws s3 ls "s3://$DATA_BUCKET/bathymetry/contour/" --recursive | grep -c '\.fgb$' || true)
-          shards=$(python3 -c "import json,sys; c=int(sys.argv[1]); n=min(${AGG_SHARDS}, max(c,1)); print(json.dumps([{'i':i,'n':n} for i in range(n)]))" "$count")
+          # ~200 FGBs ≈ 10 min of tippecanoe per shard (observed ~3 s/FGB planet-wide);
+          # sizing to the raw count spun one runner per ~1 min of work. Retune the divisor
+          # if shard runtimes drift past ~30 min. AGG_SHARDS stays the ceiling.
+          shards=$(python3 -c "import json,sys; c=int(sys.argv[1]); n=min(${AGG_SHARDS}, max((c + 199) // 200, 1)); print(json.dumps([{'i':i,'n':n} for i in range(n)]))" "$count")
           echo "shards=$shards" >> "$GITHUB_OUTPUT"
           echo "contour FGBs: $count → matrix $shards"
 
@@ -603,7 +611,10 @@ jobs:
           # it to tile the coverage layer to the same depth as the contours.
           aws s3 cp store/contour-maxz.txt "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-maxz.txt"
 
-  # tile-join the per-shard pmtiles into one vector.pmtiles.
+  # tile-join the per-shard pmtiles + soundings + drying + coverage into one vector.pmtiles,
+  # in ONE join: tile-join rewrites every tile of the whole archive, so the old
+  # merge-then-fold-per-layer shape re-paid the planet-wide join per layer (~90 min each,
+  # serial, as the only job left running — the last 2 h 40 of the build).
   contour-bundle:
     needs: contours
     if: ${{ !cancelled() && needs.contours.result == 'success' }}
@@ -619,13 +630,14 @@ jobs:
           aws s3 cp "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-maxz.txt" store/contour-maxz.txt
           aws s3 sync "s3://$DATA_BUCKET/bathymetry/soundings" store/soundings
           aws s3 sync "s3://$DATA_BUCKET/bathymetry/drying" store/drying
-      - name: Merge contours
+      # Soundings + drying aren't sharded (sparse); their pmtiles must exist before the
+      # merge so its tile-join folds them in.
+      - name: Bundle soundings + drying
+        run: |
+          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just soundings
+          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just drying
+      - name: Merge contours + fold layers
         run: docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just contour-merge
-      # Soundings + drying aren't sharded (sparse) — bundle them here and fold into vector.pmtiles.
-      - name: Fold in soundings
-        run: docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just soundings
-      - name: Fold in drying
-        run: docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just drying
       - name: Push vector.pmtiles to R2 build
         run: |
           aws s3 cp store/bundle/vector.pmtiles "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/vector.pmtiles" \

--- a/Justfile
+++ b/Justfile
@@ -24,14 +24,16 @@ sources:
         just ../sources/"$id"/
     done
 
-# Planet build: cover -> aggregate -> downsample -> bundle -> contours (BBOX="W,S,E,N" for a region).
+# Planet build: cover -> aggregate -> downsample -> bundle -> vector layers (BBOX="W,S,E,N"
+# for a region). Soundings + drying bundle BEFORE contours: the contours tile-join folds
+# their pmtiles into vector.pmtiles in the same single pass.
 planet:
     just cover
     uv run python aggregation_run.py
     just combine
-    just contours
     just soundings
     just drying
+    just contours
 
 # Plan the covering: slice the planet into aggregation tiles (BBOX="W,S,E,N" for a region).
 cover:
@@ -94,26 +96,28 @@ bundle-group name:
 bundle-merge:
     uv run python bundle.py merge
 
-# Contours, whole set (local/regional). CI shards these across runners — see below.
+# Contours, whole set (local/regional); the final tile-join also folds in any
+# soundings/drying pmtiles already bundled. CI shards these across runners — see below.
 contours:
     uv run python contour_run.py bundle
 
-# Soundings: bundle the per-tile points, then fold them into vector.pmtiles (one vector source).
+# Soundings: bundle the per-tile points into soundings.pmtiles. Run BEFORE the contours
+# bundle/merge — its single tile-join folds the layer into vector.pmtiles (a separate
+# fold re-joined the whole planet archive per layer).
 soundings:
     uv run python soundings_run.py bundle
-    uv run python soundings_run.py fold
 
-# Drying areas (green foreshore): bundle the per-tile polygons, then fold into vector.pmtiles.
+# Drying areas (green foreshore): bundle the per-tile polygons into drying.pmtiles
+# (folded into vector.pmtiles by the contours tile-join, same as soundings).
 drying:
     uv run python drying_run.py bundle
-    uv run python drying_run.py fold
 
 # tippecanoe this shard's local FGBs -> contours-shard-{i}.pmtiles (CI pulls only the
 # shard's slice + writes store/contour-maxz.txt; merged by contour-merge).
 contour-shard i:
     uv run python contour_run.py bundle-shard {{i}}
 
-# tile-join the per-shard contour pmtiles into vector.pmtiles.
+# tile-join the per-shard contour pmtiles + coverage + soundings/drying into vector.pmtiles.
 contour-merge:
     uv run python contour_run.py bundle-merge
 

--- a/Justfile
+++ b/Justfile
@@ -112,12 +112,17 @@ soundings:
 drying:
     uv run python drying_run.py bundle
 
-# tippecanoe this shard's local FGBs -> contours-shard-{i}.pmtiles (CI pulls only the
-# shard's slice + writes store/contour-maxz.txt; merged by contour-merge).
-contour-shard i:
+# tippecanoe this shard's local slice of every vector layer -> {contours,soundings,
+# drying}-shard-{i}.pmtiles (CI pulls only the shard's slices + writes
+# store/contour-maxz.txt so all layers tile to one depth; merged by contour-merge).
+# Three invocations, not one -L run: the layers need different tippecanoe flags
+# (soundings -r1, drying --drop-densest-as-needed, contours' per-zoom filter).
+vector-shard i:
     uv run python contour_run.py bundle-shard {{i}}
+    uv run python soundings_run.py bundle-shard {{i}}
+    uv run python drying_run.py bundle-shard {{i}}
 
-# tile-join the per-shard contour pmtiles + coverage + soundings/drying into vector.pmtiles.
+# tile-join the per-shard pmtiles (all layers) + coverage into vector.pmtiles.
 contour-merge:
     uv run python contour_run.py bundle-merge
 

--- a/pipelines/bundle.py
+++ b/pipelines/bundle.py
@@ -226,16 +226,19 @@ def _manifest_from_fragments(frags):
 
 
 def groups_matrix(maxn):
-    """Verify the pyramid is whole, then print the CI bundle matrix: <= maxn chunks,
-    each a comma-joined strided slice of the group names. The partition rides IN the
-    matrix (not re-derived per job from a live R2 listing), so every job bundles the
-    exact set this full-store runner saw — the same freeze-the-plan reasoning as the
-    aggregate/downsample shards."""
+    """Verify the pyramid is whole, then print the CI bundle matrix: <= maxn chunks
+    of comma-joined group names, bin-packed by each group's local pmtiles bytes so
+    every chunk carries about the biggest single group (one-group chunks meant 235
+    runners each spending longer on spin-up than on bundling). The partition rides
+    IN the matrix (not re-derived per job from a live R2 listing), so every job
+    bundles the exact set this full-store runner saw — the same freeze-the-plan
+    reasoning as the aggregate/downsample shards."""
     aggregation_id = utils.get_aggregation_ids()[-1]
     verify_complete(aggregation_id)
-    names = sorted(group_filepaths(aggregation_id))
-    n = min(maxn, max(len(names), 1))
-    print(json.dumps([{"cells": ",".join(names[i::n])} for i in range(n)]))
+    groups = group_filepaths(aggregation_id)
+    weights = {name: sum(os.path.getsize(fp) for fp in fps) for name, fps in groups.items()}
+    n = min(maxn, math.ceil(sum(weights.values()) / max(max(weights.values()), 1))) if weights else 1
+    print(json.dumps([{"cells": ",".join(sorted(chunk))} for chunk in utils.lpt_bins(weights, n)]))
 
 
 def group_keys(name):

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -324,9 +324,10 @@ def _coverage_pmtiles(maxz):
     return out
 
 
-def _finalize_contours(contour_pmtiles, maxz):
-    """tile-join the contour pmtiles (one local build or the CI shards) + the coverage
-    layer + the prebuilt soundings/drying pmtiles (when their bundles ran first) into
+def _finalize_contours(archives, maxz):
+    """tile-join the layer archives (a local build's contour pmtiles, or the CI shards —
+    which carry contours, soundings, AND drying slices) + the coverage layer + the
+    whole-set soundings/drying pmtiles (local path, when their bundles ran first) into
     store/bundle/vector.pmtiles. ONE join: tile-join rewrites every tile of the whole
     archive, so folding each sparse layer in afterwards re-paid the planet-wide join
     per layer (~90 min each in CI). -pk keeps every feature of every layer; a layer
@@ -335,7 +336,7 @@ def _finalize_contours(contour_pmtiles, maxz):
     layers = [p for p in [cov, "store/bundle/soundings.pmtiles", "store/bundle/drying.pmtiles"]
               if p and os.path.isfile(p)]
     subprocess.run(["tile-join", "-o", "store/bundle/vector.pmtiles", "-f", "-pk",
-                    *contour_pmtiles, *layers], check=True)
+                    *archives, *layers], check=True)
     return cov is not None
 
 
@@ -389,10 +390,10 @@ def bundle(shard=None):
 
 
 def bundle_merge():
-    """tile-join the per-shard contour pmtiles + the coverage layer into one
-    vector.pmtiles (-pk keeps every feature; the shards are disjoint FGB slices
-    unioned per tile)."""
-    shards = sorted(glob("store/bundle/contours-shard-*.pmtiles"))
+    """tile-join the per-shard pmtiles — contours, soundings, drying (each shard job
+    bundles its slice of all three) — + the coverage layer into one vector.pmtiles
+    (-pk keeps every feature; the shards are disjoint file slices unioned per tile)."""
+    shards = sorted(glob("store/bundle/*-shard-*.pmtiles"))
     if not shards:
         print("contour merge: no shard pmtiles")
         return
@@ -400,7 +401,7 @@ def bundle_merge():
     if not os.path.isfile(maxzfile):
         raise SystemExit("contour merge: store/contour-maxz.txt missing (the shard jobs write it)")
     cov = _finalize_contours(shards, int(open(maxzfile).read().strip()))
-    print(f"contour merge: store/bundle/vector.pmtiles ({len(shards)} shards"
+    print(f"contour merge: store/bundle/vector.pmtiles ({len(shards)} shard archives"
           f"{', + coverage layer' if cov else ''})")
 
 

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -326,12 +326,16 @@ def _coverage_pmtiles(maxz):
 
 def _finalize_contours(contour_pmtiles, maxz):
     """tile-join the contour pmtiles (one local build or the CI shards) + the coverage
-    layer into store/bundle/vector.pmtiles. -pk keeps every feature of both layers;
-    coverage is dropped from the join when no footprints are present locally."""
+    layer + the prebuilt soundings/drying pmtiles (when their bundles ran first) into
+    store/bundle/vector.pmtiles. ONE join: tile-join rewrites every tile of the whole
+    archive, so folding each sparse layer in afterwards re-paid the planet-wide join
+    per layer (~90 min each in CI). -pk keeps every feature of every layer; a layer
+    whose pmtiles isn't present locally is simply not joined."""
     cov = _coverage_pmtiles(maxz)
-    inputs = list(contour_pmtiles) + ([cov] if cov else [])
-    subprocess.run(["tile-join", "-o", "store/bundle/vector.pmtiles", "-f", "-pk", *inputs],
-                   check=True)
+    layers = [p for p in [cov, "store/bundle/soundings.pmtiles", "store/bundle/drying.pmtiles"]
+              if p and os.path.isfile(p)]
+    subprocess.run(["tile-join", "-o", "store/bundle/vector.pmtiles", "-f", "-pk",
+                    *contour_pmtiles, *layers], check=True)
     return cov is not None
 
 

--- a/pipelines/downsampling.py
+++ b/pipelines/downsampling.py
@@ -17,6 +17,7 @@ Usage (from pipelines/):
 """
 
 import json
+import math
 import os
 import shutil
 import sys
@@ -199,12 +200,27 @@ def shard_ancestor(filepath):
     return ancestor_id(z, x, y)
 
 
+def ancestor_weights():
+    """Dirty deep work per SHARD_ROOT_Z ancestor: each -downsampling.csv at extent z
+    builds 4**(parent_zoom - z) parent webps of uniform cost. Striding by ancestor
+    *count* ignored this and put a deep hi-res subtree (77 min) next to hundreds of
+    couple-of-overview shards (~2 min, all runner spin-up)."""
+    weights = {}
+    for fp in work_list():
+        a = shard_ancestor(fp)
+        if a is None:
+            continue
+        z, _, _, parent_zoom = (int(v) for v in fp.split("/")[-1]
+                                .replace("-downsampling.csv", "").split("-"))
+        weights[a] = weights.get(a, 0) + 4 ** (parent_zoom - z)
+    return weights
+
+
 def owned_ancestors(i, n):
-    """The strided slice of dirty deep ancestors shard i of n owns (the same split
-    run() and matrix() use), so shard-keys and run agree on what a shard touches.
+    """The dirty deep ancestors shard i of n owns — the same weighted bin-packing
+    run() and matrix() use, so shard-keys and run agree on what a shard touches.
     Derived from the frozen work list, so every shard computes the identical split."""
-    ancestors = sorted({a for fp in work_list() if (a := shard_ancestor(fp)) is not None})
-    return set(ancestors[i::n])
+    return set(utils.lpt_bins(ancestor_weights(), n)[i])
 
 
 def shard_keys(i, n):
@@ -366,7 +382,7 @@ def run(shard=None, tail=False):
     """Build the dirty overview pyramid. Default = everything on one machine.
 
     Across CI runners (the cut keeps the level barrier inside one machine):
-      ``shard=(i, n)`` — only the deep levels under the i-th strided slice of
+      ``shard=(i, n)`` — only the deep levels under the i-th work-weighted bin of
         SHARD_ROOT_Z ancestors; each shard's subtree is read-closed, so they run
         concurrently with no coordination and push disjoint tiles.
       ``tail=True``    — only the coarse levels whose archives span ancestors
@@ -382,10 +398,11 @@ def run(shard=None, tail=False):
 
 
 def matrix(maxn):
-    """Print the CI deep-shard matrix JSON: <= maxn shards, >= 1, sized to the
-    number of distinct ancestors in the dirty deep set."""
-    ancestors = {a for fp in work_list() if (a := shard_ancestor(fp)) is not None}
-    n = min(maxn, max(len(ancestors), 1))
+    """Print the CI deep-shard matrix JSON: <= maxn shards, >= 1, with n sized so
+    each shard carries about the heaviest single ancestor — the wall-clock floor
+    anyway, since an ancestor's read-closed subtree can't split across shards."""
+    weights = ancestor_weights()
+    n = min(maxn, math.ceil(sum(weights.values()) / max(weights.values()))) if weights else 1
     print(json.dumps([{"i": i, "n": n} for i in range(n)]))
 
 

--- a/pipelines/drying_run.py
+++ b/pipelines/drying_run.py
@@ -152,10 +152,13 @@ def generate(filepath):
 
 # ── bundle ───────────────────────────────────────────────────────────────────
 
-def bundle():
+def bundle(shard=None):
     """tippecanoe the per-tile drying FGBs into store/bundle/drying.pmtiles (layer `drying`).
-    Sparse coastal polygons (not sharded, like soundings); the orphan filter drops FGBs left
-    from a re-tiled covering, same as contours/soundings."""
+    The orphan filter drops FGBs left from a re-tiled covering, same as contours/soundings.
+    With a shard index → drying-shard-{shard}.pmtiles from this shard's local slice, tiled
+    to the shared global maxz (store/contour-maxz.txt, like the contour shards): a slice's
+    own max child_z can undershoot it, and the join would then drop the layer from tiles
+    deeper than the slice."""
     fgbs = contour_run._live_fgbs(sorted(glob("store/drying/*.fgb")), contour_run._current_stems())
     if not fgbs:
         print("drying bundle: no drying FGBs")
@@ -165,13 +168,15 @@ def bundle():
     maxz = contour_run.bundle_maxz(
         max(int(f.split("/")[-1].replace(".fgb", "").split("-")[3]) for f in fgbs))
     utils.create_folder("store/bundle")
+    out = "store/bundle/drying.pmtiles" if shard is None \
+        else f"store/bundle/drying-shard-{shard}.pmtiles"
     subprocess.run(
-        ["tippecanoe", "-o", "store/bundle/drying.pmtiles", "-f", "-l", "drying",
+        ["tippecanoe", "-o", out, "-f", "-l", "drying",
          "-n", "Drying areas", "-A", utils.ATTRIBUTION, "-Z", "0", "-z", str(maxz),
          "-P", "-q", "--drop-densest-as-needed",
          "--simplification", os.environ.get("DRYING_SIMPLIFICATION", "8"), *fgbs],
         check=True)
-    print(f"drying bundle: store/bundle/drying.pmtiles (z0-{maxz}, {len(fgbs)} FGBs)")
+    print(f"drying bundle: {out} (z0-{maxz}, {len(fgbs)} FGBs)")
 
 
 def _check():
@@ -269,7 +274,9 @@ if __name__ == "__main__":
     a = sys.argv[1:]
     if a[:1] == ["bundle"]:
         bundle()
+    elif a[:1] == ["bundle-shard"]:
+        bundle(int(a[1]))
     elif a[:1] == ["check"]:
         _check()
     else:
-        sys.exit("usage: drying_run.py bundle | check")
+        sys.exit("usage: drying_run.py bundle | bundle-shard <i> | check")

--- a/pipelines/drying_run.py
+++ b/pipelines/drying_run.py
@@ -13,7 +13,8 @@ land-mask raster the reproject clamp already rasterized for this tile. Per tile:
 drying mask off (DEM, land mask) -> polygonize -> clip to the unbuffered tile bbox -> 4326 ->
 store/drying/{stem}.fgb. Same seam contract as contours: the mask and DEM are deterministic on
 the buffered grid, so neighbouring tiles' halos polygonize identically and polygon edges meet at
-the clip. bundle() tippecanoes them into a `drying` layer; fold() joins it into vector.pmtiles.
+the clip. bundle() tippecanoes them into a `drying` layer pmtiles; the contour merge's single
+tile-join folds it into vector.pmtiles (run bundle before the merge).
 """
 
 import os
@@ -173,20 +174,6 @@ def bundle():
     print(f"drying bundle: store/bundle/drying.pmtiles (z0-{maxz}, {len(fgbs)} FGBs)")
 
 
-def fold():
-    """Fold drying.pmtiles into vector.pmtiles as the `drying` layer, so the Worker serves it
-    from the one vector source. tile-join -pk keeps every layer's features. Runs after both
-    bundles; no-op if either is missing."""
-    cont, dry = "store/bundle/vector.pmtiles", "store/bundle/drying.pmtiles"
-    if not (os.path.isfile(cont) and os.path.isfile(dry)):
-        print("drying fold: need both vector.pmtiles and drying.pmtiles")
-        return
-    tmp = "store/bundle/vector-with-drying.pmtiles"  # tile-join can't -o over an input
-    subprocess.run(["tile-join", "-o", tmp, "-f", "-pk", cont, dry], check=True)
-    os.replace(tmp, cont)
-    print("drying fold: folded drying layer into vector.pmtiles")
-
-
 def _check():
     """Drying mask + polygonize on a synthetic DEM/mask grid: only foreshore (0<=elev<=cap,
     seaward of land) turns 1; land, deep water, and above-cap topo stay 0; and the mask is
@@ -282,9 +269,7 @@ if __name__ == "__main__":
     a = sys.argv[1:]
     if a[:1] == ["bundle"]:
         bundle()
-    elif a[:1] == ["fold"]:
-        fold()
     elif a[:1] == ["check"]:
         _check()
     else:
-        sys.exit("usage: drying_run.py bundle | fold | check")
+        sys.exit("usage: drying_run.py bundle | check")

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -208,20 +208,6 @@ def bundle():
     print(f"soundings bundle: store/bundle/soundings.pmtiles (z0-{maxz}, {len(gj)} tiles)")
 
 
-def fold():
-    """Fold soundings.pmtiles into vector.pmtiles as the `soundings` layer, so the Worker
-    serves it from the one vector source (contours + coverage + soundings). tile-join -pk keeps
-    every feature of every layer. Runs after both bundles; no-op if either is missing."""
-    cont, snd = "store/bundle/vector.pmtiles", "store/bundle/soundings.pmtiles"
-    if not (os.path.isfile(cont) and os.path.isfile(snd)):
-        print("soundings fold: need both vector.pmtiles and soundings.pmtiles")
-        return
-    tmp = "store/bundle/vector-with-soundings.pmtiles"  # tile-join can't -o over an input
-    subprocess.run(["tile-join", "-o", tmp, "-f", "-pk", cont, snd], check=True)
-    os.replace(tmp, cont)
-    print("soundings fold: folded soundings layer into vector.pmtiles")
-
-
 def _check():
     """Grid shoalest per cell; <min_depth dropped; 2x2 reduction keeps the shoalest; the pyramid
     staggers each zoom into a quincunx and carries a block's shoal up to coarse zoom; depth floors
@@ -282,9 +268,7 @@ if __name__ == "__main__":
     a = sys.argv[1:]
     if a[:1] == ["bundle"]:
         bundle()
-    elif a[:1] == ["fold"]:
-        fold()
     elif a[:1] == ["check"]:
         _check()
     else:
-        sys.exit("usage: soundings_run.py bundle | fold | check")
+        sys.exit("usage: soundings_run.py bundle | check")

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -187,10 +187,13 @@ def _live(paths, stems):
     return [p for p in paths if p.split("/")[-1].rsplit(".", 1)[0] in stems]
 
 
-def bundle():
+def bundle(shard=None):
     """tippecanoe the per-tile soundings into store/bundle/soundings.pmtiles (layer `soundings`).
     Per-feature tippecanoe.minzoom places each point from the zoom the grid decimation assigned,
-    so no density dropping is needed (-r1 keeps every surviving point)."""
+    so no density dropping is needed (-r1 keeps every surviving point). With a shard index →
+    soundings-shard-{shard}.pmtiles from this shard's local slice, tiled to the shared global
+    maxz (store/contour-maxz.txt, like the contour shards): a slice's own max child_z can
+    undershoot it, and the join would then drop the layer from tiles deeper than the slice."""
     gj = _live(sorted(glob("store/soundings/*.geojson")), contour_run._current_stems())
     if not gj:
         print("soundings bundle: no soundings")
@@ -200,12 +203,14 @@ def bundle():
     maxz = contour_run.bundle_maxz(
         max(int(g.split("/")[-1].replace(".geojson", "").split("-")[3]) for g in gj))
     utils.create_folder("store/bundle")
+    out = "store/bundle/soundings.pmtiles" if shard is None \
+        else f"store/bundle/soundings-shard-{shard}.pmtiles"
     subprocess.run(
-        ["tippecanoe", "-o", "store/bundle/soundings.pmtiles", "-f", "-l", "soundings",
+        ["tippecanoe", "-o", out, "-f", "-l", "soundings",
          "-n", "Bathymetric soundings", "-A", utils.ATTRIBUTION, "-Z", "0", "-z", str(maxz),
          "-P", "-q", "-r1", "-y", "depth_m", "-y", "depth_ft", "-y", "depth_fm",
          *gj], check=True)
-    print(f"soundings bundle: store/bundle/soundings.pmtiles (z0-{maxz}, {len(gj)} tiles)")
+    print(f"soundings bundle: {out} (z0-{maxz}, {len(gj)} tiles)")
 
 
 def _check():
@@ -268,7 +273,9 @@ if __name__ == "__main__":
     a = sys.argv[1:]
     if a[:1] == ["bundle"]:
         bundle()
+    elif a[:1] == ["bundle-shard"]:
+        bundle(int(a[1]))
     elif a[:1] == ["check"]:
         _check()
     else:
-        sys.exit("usage: soundings_run.py bundle | check")
+        sys.exit("usage: soundings_run.py bundle | bundle-shard <i> | check")

--- a/pipelines/test_engine.py
+++ b/pipelines/test_engine.py
@@ -16,6 +16,7 @@ Run from pipelines/:  uv run python test_engine.py
 """
 
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -144,6 +145,46 @@ def check_shard_partition():
         shutil.rmtree(tmp, ignore_errors=True)
         if env_force is not None:
             os.environ["FORCE_REBUILD"] = env_force
+
+
+def check_weighted_shards():
+    """Downsample deep shards bin-pack ancestors by work (parent-webp count), not
+    ancestor count: the count-sized stride left a 77-minute straggler shard next to
+    hundreds of spin-up-only ones. The partition must stay complete + disjoint (every
+    consumer derives the same bins from the frozen list), n must self-size to
+    total/heaviest, and no bin may exceed 2x the heaviest ancestor (the LPT bound)."""
+    import downsampling
+    import utils
+    tmp = tempfile.mkdtemp()
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp)
+        aid = "01CCCCCCCCCCCCCCCCCCCCCCCC"
+        os.makedirs(f"store/aggregation/{aid}")
+        rz = downsampling.SHARD_ROOT_Z
+        # 3 deep subtrees (extent -> extent+3: 4**3 = 64 parent webps each) among 40
+        # couple-of-overview ancestors (weight 1) — the planet build's shape in miniature.
+        heavies = [f"store/aggregation/{aid}/{rz}-{x}-0-{rz + 3}-downsampling.csv" for x in range(3)]
+        lights = [f"store/aggregation/{aid}/{rz}-{x}-{y}-{rz}-downsampling.csv"
+                  for x in range(8) for y in range(1, 6)]
+        with open(f"store/aggregation/{aid}/{downsampling.FROZEN}", "w") as f:
+            f.write("".join(fp + "\n" for fp in heavies + lights))
+        w = downsampling.ancestor_weights()
+        assert len(w) == 43 and sorted(w.values(), reverse=True)[:3] == [64, 64, 64], w
+        # matrix sizing: enough bins that each ~= the heaviest subtree — not one per ancestor
+        n = math.ceil(sum(w.values()) / max(w.values()))
+        assert n == 4, f"expected 4 work-sized bins for 43 ancestors, got {n}"
+        owned = [downsampling.owned_ancestors(i, n) for i in range(n)]
+        flat = [a for s in owned for a in s]
+        assert len(flat) == len(set(flat)) == len(w), "bins must partition the ancestors"
+        loads = [sum(w[a] for a in s) for s in owned]
+        assert max(loads) < 2 * max(w.values()), f"a bin exceeds the LPT bound: {loads}"
+        # the pure packer (also chunks the bundle groups): heaviest first into lightest bin
+        assert utils.lpt_bins({"a": 5, "b": 3, "c": 3, "d": 1}, 2) == [["a", "d"], ["b", "c"]]
+        print(f"weighted-shards ok — {len(w)} ancestors -> {n} bins, loads {sorted(loads, reverse=True)}")
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
 def check_stale_overview():
@@ -532,6 +573,7 @@ if __name__ == "__main__":
     drying_run._check()
     check_priority()
     check_shard_partition()
+    check_weighted_shards()
     check_stale_overview()
     check_grid_split()
     check_land_clamp()

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -166,6 +166,20 @@ def get_dirty_aggregation_filenames(current_aggregation_id, last_aggregation_id)
     return dirty_filenames
 
 
+def lpt_bins(weights, n):
+    """Deterministically bin-pack {name: weight} into n bins, heaviest item first
+    into the lightest bin (LPT greedy). Callers size n to ceil(total / max), so each
+    bin carries about the heaviest single item — the floor any partition has, since
+    one item can't split across shards. Guarantees a complete, disjoint partition and
+    (for n <= len(weights), all weights > 0) no empty bins."""
+    bins, loads = [[] for _ in range(n)], [0] * n
+    for name in sorted(weights, key=lambda k: (-weights[k], k)):
+        j = min(range(n), key=lambda k: (loads[k], k))
+        bins[j].append(name)
+        loads[j] += weights[name]
+    return bins
+
+
 def get_pmtiles_folder(x, y, z):
     if z < 7:
         return 'store/pmtiles'


### PR DESCRIPTION
Follow-up to the timing review of the last full planet build ([run 28716639288](https://github.com/openwatersio/seascape/actions/runs/28716639288): 9h37 wall, 1035 jobs, runner concurrency pinned at 20 throughout).

## What was wrong

- **contour-bundle ran alone for the build's last 2h40.** Its 4h48 broke down as: tile-join shards 80m → tippecanoe soundings 26m → *re-join whole planet* 84m → tippecanoe drying 5m → *re-join whole planet again* 87m. Each `fold` rewrote every tile of the archive to add one sparse layer.
- **downsample (256 shards):** p50 1.8m, max 76.9m — count-strided ancestors put one deep hi-res subtree behind ~250 spin-up-only jobs, and bundle-plan waited ~45m on the straggler while the runner pool sat idle.
- **bundle (235 jobs) and contours (256 jobs):** ~5m and ~1.5m of per-job setup for ~4m and ~1m of work — every phase saturated the shared 256 ceiling regardless of its workload.

## Changes

1. **One tile-join.** Soundings + drying bundle first; `_finalize_contours` folds their pmtiles (+ coverage) into `vector.pmtiles` in the same join that merges the contour shards. `fold()` deleted; CI job and local `just planet` reordered to match. contour-bundle: 4h48 → ~2h.
2. **Work-weighted downsample shards.** Ancestors bin-pack by parent-webp count (`4**(parent_zoom−z)` per CSV) via a new `utils.lpt_bins`; the matrix self-sizes to `ceil(total/heaviest)` — a shard ≈ the heaviest subtree, which is the floor anyway (read-closed subtrees can't split).
3. **Byte-packed bundle chunks.** Groups bin-pack by local pmtiles bytes with the same self-sizing rule (~30 chunks ≈ planet-sized each, instead of 235 one-group jobs).
4. **Contours sized to work.** ~200 FGBs ≈ 10 min of tippecanoe per shard, `AGG_SHARDS` stays the ceiling.

**Aggregate is deliberately untouched** — its high shard count is headroom against the 6h per-job cap, and the phase is bound by the 20-runner concurrency limit either way. The `shards` dispatch input is re-documented as the ceiling the other phases self-size under.

## Validation

- `just test-engine` passes, including a new `check_weighted_shards` (partition complete + disjoint across consumers, self-sized n, LPT makespan bound, and the pure packer used for bundle chunks).
- soundings/contour/drying self-checks pass; workflow YAML validated.
- Tile content is unchanged (orchestration only), so the next ordinary `workflow_dispatch` build validates end-to-end — **no `force` rebuild needed**. Expected ~9h40 → ~7h wall, with auto-release moving ~2.5h earlier (it gates on contour-bundle).