### PR TITLE
Keep shallow-water detail at and above a region's native zoom

### DIFF
--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -228,6 +228,29 @@ def _global_maxz(fgbs):
     return max(int(f.split("/")[-1].replace(".fgb", "").split("-")[3]) for f in fgbs)
 
 
+def _stems_maxz(stems):
+    """Max child_z across covering stems ({z}-{x}-{y}-{child_z})."""
+    return max(int(s.rsplit("-", 1)[1]) for s in stems)
+
+
+def bundle_maxz(own_max):
+    """The tileset maxzoom EVERY vector layer bundles to (contours, soundings,
+    drying). They tile-join into one vector.pmtiles, whose maxzoom is the max
+    across layers — a layer bundled only to its own regional max silently
+    vanishes from deeper tiles (drying stopped at z11 while contours ran to
+    z14, so the Æbelø flats rendered as bare land above z11). Use the shared
+    global contour maxz (store/contour-maxz.txt, written by the CI shard jobs)
+    when present, else the current covering's max child_z, else the caller's
+    own files' max."""
+    maxzfile = "store/contour-maxz.txt"
+    if os.path.isfile(maxzfile):
+        return max(int(open(maxzfile).read().strip()), own_max)
+    stems = _current_stems()
+    if stems:
+        return max(own_max, _stems_maxz(stems))
+    return own_max
+
+
 # ── source coverage (provenance) layer ───────────────────────────────────────
 # Tile each source's union footprint (store/polygon/<id>.gpkg, from the source stage)
 # into a `coverage` layer alongside `contours` in the same pmtiles, so the viewer can
@@ -344,8 +367,7 @@ def bundle(shard=None):
     if not fgbs:
         print("contour bundle: no contour FGBs")
         return
-    maxzfile = "store/contour-maxz.txt"
-    maxz = int(open(maxzfile).read().strip()) if os.path.isfile(maxzfile) else _global_maxz(fgbs)
+    maxz = bundle_maxz(_global_maxz(fgbs))
     utils.create_folder("store/bundle")
     if shard is not None:  # CI: lines only; coverage joins once at the merge step
         out = f"store/bundle/contours-shard-{shard}.pmtiles"
@@ -392,6 +414,8 @@ def _check():
     fgbs = ["store/contour/4-5-6-8.fgb", "store/contour/11-300-400-13.fgb"]
     assert _live_fgbs(fgbs, {"11-300-400-13"}) == ["store/contour/11-300-400-13.fgb"]
     assert _live_fgbs(fgbs, None) == fgbs
+    # the shared bundle maxzoom reads child_z off covering stems
+    assert _stems_maxz({"4-5-6-8", "11-300-400-13"}) == 13
     # navigable-band contours skip Chaikin (never bow a shoal deeper); deeper ones smooth
     assert _chaikin_iters(10) == 0 and _chaikin_iters(NAV_SMOOTH_MAX_M) == 0
     assert _chaikin_iters(NAV_SMOOTH_MAX_M + 1) == CHAIKIN_ITERATIONS

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -244,7 +244,8 @@ def bundle_maxz(own_max):
     own files' max."""
     maxzfile = "store/contour-maxz.txt"
     if os.path.isfile(maxzfile):
-        return max(int(open(maxzfile).read().strip()), own_max)
+        with open(maxzfile) as f:
+            return max(int(f.read().strip()), own_max)
     stems = _current_stems()
     if stems:
         return max(own_max, _stems_maxz(stems))

--- a/pipelines/drying_run.py
+++ b/pipelines/drying_run.py
@@ -159,7 +159,10 @@ def bundle():
     if not fgbs:
         print("drying bundle: no drying FGBs")
         return
-    maxz = max(int(f.split("/")[-1].replace(".fgb", "").split("-")[3]) for f in fgbs)
+    # Shared tileset maxzoom (see contour_run.bundle_maxz): tiling only to this
+    # layer's own regional max would truncate it out of deeper joined tiles.
+    maxz = contour_run.bundle_maxz(
+        max(int(f.split("/")[-1].replace(".fgb", "").split("-")[3]) for f in fgbs))
     utils.create_folder("store/bundle")
     subprocess.run(
         ["tippecanoe", "-o", "store/bundle/drying.pmtiles", "-f", "-l", "drying",

--- a/pipelines/encode.py
+++ b/pipelines/encode.py
@@ -40,9 +40,10 @@ step shallow bias, which is sub-perceptual at the zoom each step is applied
 One exception to the pure rounding: water never quantizes to 0. Elevation 0 is
 the land value (the land mask clamps land pixels to it, and the depth ramp
 draws it as land), so a negative input that would round to >= 0 — water
-shallower than the local step, i.e. shallower than SHALLOW_MIN_STEP — is
-capped at -LSB instead. Still shoal-biased; the only inputs it deepens are
-true depths shallower than the ~4 mm LSB, which are noise.
+shallower than its local per-pixel step, i.e. min(zoom step, depth cap), at
+most SHALLOW_MIN_STEP and smaller still at fine zooms — is capped at -LSB
+instead. Still shoal-biased; the only inputs it deepens are true depths
+shallower than the ~4 mm LSB, which are noise.
 """
 
 import numpy as np

--- a/pipelines/encode.py
+++ b/pipelines/encode.py
@@ -19,6 +19,16 @@ so coarse zooms (deep abyssal plains, viewed small) cost few bits while fine
 zooms (shallow coastal detail) keep full precision. At z<=19 the rounded value
 is an exact multiple of the 1/256 LSB, so the RGB packing is lossless.
 
+Bathymetry adaptation — *depth-aware step cap*. The zoom schedule alone was
+tuned for terrain (kilometres of relief); applied to a shelf it terraces the
+shallows: a region whose best source tops out at z10 bakes 2 m steps into
+water that is itself only a few metres deep, and on a gentle seabed (1:1000)
+every step is a plateau hundreds of metres wide — blocky shorelines at the
+very zooms mariners use. So the step is capped per-pixel at SHALLOW_REL of the
+local depth (floored at SHALLOW_MIN_STEP, snapped up to a power of two so it
+stays a multiple of the LSB): deep water keeps the byte-saving coarse steps,
+shallow water keeps chart detail at every zoom.
+
 Bathymetry adaptation — *conservative rounding*. A chart must bias shallow:
 charted depth <= true depth. So by default we round the height
 *toward shallower* (ceil, i.e. toward the surface / less-negative), guaranteeing
@@ -29,10 +39,10 @@ step shallow bias, which is sub-perceptual at the zoom each step is applied
 
 One exception to the pure rounding: water never quantizes to 0. Elevation 0 is
 the land value (the land mask clamps land pixels to it, and the depth ramp
-draws it as land), so a negative input that would round to >= 0 — at z9 the
-step is 4 m, so that is ALL water shallower than 4 m — is capped at -LSB
-instead. Still shoal-biased; the only inputs it deepens are true depths
-shallower than the ~4 mm LSB, which are noise.
+draws it as land), so a negative input that would round to >= 0 — water
+shallower than the local step, i.e. shallower than SHALLOW_MIN_STEP — is
+capped at -LSB instead. Still shoal-biased; the only inputs it deepens are
+true depths shallower than the ~4 mm LSB, which are noise.
 """
 
 import numpy as np
@@ -41,6 +51,13 @@ FULL_RESOLUTION_ZOOM = 19
 TERRARIUM_OFFSET = 32768.0
 LSB = 1.0 / 256.0  # Terrarium's vertical resolution (metres)
 
+# Depth-aware step cap: never quantize coarser than this fraction of the local
+# depth, floored at SHALLOW_MIN_STEP. 1/16 keeps the step within one ramp band
+# everywhere (band edges 2/5/10/20/50 m); 0.25 m matches the shoal-band label
+# precision (one decimal below 6 m).
+SHALLOW_REL = 1.0 / 16.0
+SHALLOW_MIN_STEP = 0.25  # metres; a power of two, so an exact multiple of LSB
+
 
 def quantization_factor(z):
     """Vertical step (metres) at zoom ``z``."""
@@ -48,7 +65,9 @@ def quantization_factor(z):
 
 
 def quantize(data, z, conservative=True):
-    """Round elevations (metres) to the per-zoom vertical step.
+    """Round elevations (metres) to the per-zoom vertical step, capped per-pixel
+    at SHALLOW_REL of the local depth (see module docstring) so shallow water
+    never terraces at coarse zooms.
 
     conservative=True rounds toward shallower (never deepens); False is
     round-to-nearest. Water stays water either way: a negative input that
@@ -56,8 +75,12 @@ def quantize(data, z, conservative=True):
     """
     factor = quantization_factor(z)
     data = np.asarray(data, dtype=np.float64)
-    scaled = data / factor
-    rounded = (np.ceil(scaled) if conservative else np.round(scaled)) * factor
+    # Snap the depth cap UP to a power of two so every step is a power-of-two
+    # multiple of the LSB and the RGB packing stays lossless.
+    depth_cap = 2.0 ** np.ceil(np.log2(np.maximum(np.abs(data) * SHALLOW_REL, SHALLOW_MIN_STEP)))
+    step = np.minimum(factor, depth_cap)
+    scaled = data / step
+    rounded = (np.ceil(scaled) if conservative else np.round(scaled)) * step
     return np.where((data < 0) & (rounded >= 0), -LSB, rounded)
 
 
@@ -123,14 +146,19 @@ def _check():
         assert np.all(back2[rnd < 0] < 0), z
 
     # Non-conservative round-to-nearest CAN deepen — confirms the modes differ.
-    e = np.array([-7.0])  # z9 step = 4 m; nearest -> -8 (deeper), ceil -> -4 (shallower)
+    e = np.array([-100.0 - 3.0])  # z9 step 4 m at ~100 m depth (cap 8 m > factor 4 m)
     assert decode(encode(e, 9, conservative=False))[0] < e[0]
     assert decode(encode(e, 9, conservative=True))[0] >= e[0]
 
-    # The water floor: shallow water that would round to 0 (land) caps at -LSB
-    # and survives the RGB round-trip exactly. -2.4 at z9 (4 m step) is the
-    # GEBCO shallow-shelf case; -0.001 is the sub-LSB deepen exception.
-    assert decode(encode(np.array([-2.4]), 9))[0] == -LSB
+    # Depth-aware cap: shallow water keeps fine steps at coarse zooms instead of
+    # terracing. -3.7 m at z10 (zoom step 2 m) quantizes at the 0.25 m floor;
+    # deep water is untouched by the cap (-1000 m at z6: 32 m zoom step wins).
+    assert decode(encode(np.array([-3.7]), 10))[0] == -3.5
+    assert decode(encode(np.array([-1000.0]), 6))[0] == -992.0  # ceil(-1000/32)*32
+
+    # The water floor: water shallower than the local step, which would round to
+    # 0 (land), caps at -LSB and survives the RGB round-trip exactly.
+    assert decode(encode(np.array([-0.2]), 9))[0] == -LSB
     assert decode(encode(np.array([-0.001]), 12))[0] == -LSB
 
     print("encode.py self-check ok")

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -45,6 +45,17 @@ SOUND_CELL_PX = int(os.environ.get("SOUND_CELL_PX", "64"))
 SOUND_MIN_DEPTH_M = float(os.environ.get("SOUND_MIN_DEPTH_M", "1.0"))
 
 
+def _tc(minz, child_z):
+    """Per-feature tippecanoe zoom placement. Coarser levels swap out as the next
+    finer field arrives (maxzoom == their own zoom). The finest level (minz ==
+    child_z) declares NO maxzoom so it persists to the tileset max: child_z is the
+    LOCAL best-source ceiling (z10 in Danish waters, z13+ where CUDEM reaches),
+    and the global tileset tiles past it wherever any region goes deeper — capping
+    at child_z blanked the layer there (soundings gone at z11+ over Denmark while
+    contours carried on)."""
+    return {"minzoom": minz} if minz == child_z else {"minzoom": minz, "maxzoom": minz}
+
+
 def _depths(depth_pos):
     """Depth (metres, positive down) → chart labels, each floored toward shallower so the printed
     number is never deeper than the surface. Metres carry one decimal in the shoal band (< 6 m,
@@ -155,9 +166,9 @@ def generate(filepath):
     feats = []
     for d, x3857, y3857, minz in pts:
         lon, lat = to4326.transform(x3857, y3857)
-        # minzoom==maxzoom: each level shows at exactly one zoom, so every zoom is one clean
-        # staggered field (the deepest level, minz==child_z, overzooms above).
-        feats.append({"type": "Feature", "tippecanoe": {"minzoom": minz, "maxzoom": minz},
+        # Each level shows at exactly one zoom (one clean staggered field per zoom);
+        # the finest level rides uncapped to the tileset max — see _tc.
+        feats.append({"type": "Feature", "tippecanoe": _tc(minz, child_z),
                       "properties": _depths(d),
                       "geometry": {"type": "Point", "coordinates": [round(lon, 6), round(lat, 6)]}})
 
@@ -184,7 +195,10 @@ def bundle():
     if not gj:
         print("soundings bundle: no soundings")
         return
-    maxz = max(int(g.split("/")[-1].replace(".geojson", "").split("-")[3]) for g in gj)
+    # Shared tileset maxzoom (see contour_run.bundle_maxz): tiling only to this
+    # layer's own regional max would truncate it out of deeper joined tiles.
+    maxz = contour_run.bundle_maxz(
+        max(int(g.split("/")[-1].replace(".geojson", "").split("-")[3]) for g in gj))
     utils.create_folder("store/bundle")
     subprocess.run(
         ["tippecanoe", "-o", "store/bundle/soundings.pmtiles", "-f", "-l", "soundings",
@@ -256,6 +270,11 @@ def _check():
     paths = ["store/soundings/4-5-6-8.geojson", "store/soundings/11-300-400-13.geojson"]
     assert _live(paths, {"11-300-400-13"}) == ["store/soundings/11-300-400-13.geojson"]
     assert _live(paths, None) == paths
+
+    # zoom placement: coarser levels swap out at their own zoom; the finest level
+    # (minz == child_z) is uncapped so it persists above the local source ceiling
+    assert _tc(8, 10) == {"minzoom": 8, "maxzoom": 8}
+    assert _tc(10, 10) == {"minzoom": 10}
     print("soundings_run self-check ok")
 
 


### PR DESCRIPTION
## Problem

Comparing the seascape bathymetry against the maptoolkit EMODnet source in the seamap viewer at [Æbelø, Denmark](http://127.0.0.1:8931/seamap.html?bathymetry=seascape#11.78/55.63005/10.26364), the shore was strikingly rough: giant terraced depth bands, no spot soundings, and the walkable drying flat south of the island rendered as bare land wash.

Danish waters' best sources (DDM ~97 Mercator-m, EMODnet ~115 m) put the local aggregation ceiling at `child_z` 10, while the global tileset runs to z14 (CUDEM regions). Three things degraded past that local ceiling:

1. **2 m quantization terraces.** `encode.py`'s zoom-only schedule (`2^(19−z)/256`) quantizes z10 tiles to 2 m vertical steps; on a ~1:1000 shelf each step is a plateau hundreds of metres wide. Decoding the published tiles confirmed it: 86–91% of z11/z12 pixel mass sits on even metres (they are overzooms of terraced z10 data).
2. **Soundings vanish above z10.** Every point was written with tippecanoe `minzoom==maxzoom`. The intended "finest level overzooms above" only happens where the whole tileset ends — Danish z11–14 tiles still exist (contours), so their soundings layer was simply empty.
3. **Drying vanishes above z11.** `drying_run.bundle()` derived `-z` from drying FGBs alone, below `vector.pmtiles`' max; after `tile-join` the layer ends while the tileset continues.

## Fixes

- **`encode.py`** — depth-aware quantization cap: step = `min(zoom step, depth/16)`, floored at 0.25 m, snapped up to a power of two so every step stays an exact multiple of the Terrarium LSB (lossless RGB packing, conservative shoal-bias preserved). Deep water keeps the coarse byte-saving steps.
- **`soundings_run.py`** — the finest pyramid level (`minz == child_z`) no longer declares a per-feature `maxzoom`, so it persists to the tileset max, thinning geometrically as tiles quarter.
- **`contour_run.py` / `drying_run.py` / `soundings_run.py`** — new shared `bundle_maxz()`: every vector layer bundles to the same tileset maxzoom (`store/contour-maxz.txt` written by the CI contour shards, else the covering's max `child_z`), so no layer truncates out of joined tiles.

## Verification

`just preview "10.1,55.55,10.45,55.75"` (Æbelø, sources streamed from R2), then re-bundled with a simulated global maxz 14:

- z10 raster shallow band (0…−10 m): **4 → 26 distinct depths**; bands follow the coast instead of plateauing (coastal tile 9.9 → 18.9 KB; deep-ocean tiles unaffected).
- drying persists z12–z14 over the flats (was gone above z11).
- soundings persist z11–z14 (7 at z11, 3 at z12, 1–2 per z13 tile — correct geometric thinning).
- Self-checks extended and passing: `encode.py`, `soundings_run.py check`, `contour_run.py check`, `drying_run.py check`, `test_engine.py`.

## Deployment note

Requires a **forced full rebuild**: the quantization is baked into every raster tile, and the vector forks read merged DEMs deleted after aggregation — `.done`-marked tiles won't regenerate on an incremental run.

Separate issue, not addressed here: the Worker's error responses lack CORS headers and intermittently 404 on cache miss, which makes MapLibre hold coarse ancestor tiles and amplified this visually.