### PR TITLE
Fix support with MapLibre >= 5.6, <= 5.11

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,9 @@ const toggles = {
 
 map.on("load", () => {
   // Mariner settings — unit (m/ft/fm) and safety depth (metres, 0 = off; drives
-  // the hazard tint and black-sounding emphasis, S-52 style). applyState flips
-  // the global-state AND rebuilds the depth ramp together (the ramp can't read
-  // global-state), so the controls just forward their current values.
+  // the hazard tint and black-sounding emphasis, S-52 style). The style carries
+  // the settings as literals; applyState re-derives every dependent property
+  // from the full current values, so the controls just forward them.
   const applyControls = () =>
     applyState(map, {
       unit: document.getElementById("unit-select")?.value || "m",

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -201,8 +201,12 @@ def _per_zoom_filter():
     bands, lo = [], 0
     for hi, depths in CONTOUR_TIERS:
         min_abs = min(-d for d in depths)  # shallowest metre curve shown in this band
+        # Both bands test depth_m (gdal_contour's Real attribute): -j comparisons are
+        # type-strict, and the enriched int columns (depth_abs_m et al.) reach the filter
+        # as strings via the FlatGeobuf Integer64 path — a numeric test on them matches
+        # nothing, which silently dropped every ft curve below native zoom.
         bands.append(["all", [">=", "$zoom", lo], ["<", "$zoom", hi], ["==", "sys", "m"], ["in", "depth_m", *depths]])
-        bands.append(["all", [">=", "$zoom", lo], ["<", "$zoom", hi], ["==", "sys", "ft"], [">=", "depth_abs_m", min_abs]])
+        bands.append(["all", [">=", "$zoom", lo], ["<", "$zoom", hi], ["==", "sys", "ft"], ["<=", "depth_m", -min_abs]])
         lo = hi
     bands.append(["all", [">=", "$zoom", lo]])  # native+ zoom: every curve, both systems
     return json.dumps({"*": ["any", *bands]})
@@ -220,6 +224,8 @@ def _tippecanoe(fgbs, minz, maxz, out):
          # maxz, so maxz detail is untouched). Env-tunable to dial on a re-bundle.
          "--simplification", os.environ.get("CONTOUR_SIMPLIFICATION", "8"),
          "-y", "depth_m", "-y", "depth_abs_m", "-y", "sys", "-y", "depth_ft", "-y", "depth_fm",
+         # FlatGeobuf Integer64 attributes otherwise land in the MVT as strings.
+         "-T", "depth_abs_m:int", "-T", "depth_ft:int", "-T", "depth_fm:int",
          "-j", PER_ZOOM_FILTER, *fgbs],
         check=True)
 
@@ -255,9 +261,8 @@ def bundle_maxz(own_max):
 # ── source coverage (provenance) layer ───────────────────────────────────────
 # Tile each source's union footprint (store/polygon/<id>.gpkg, from the source stage)
 # into a `coverage` layer alongside `contours` in the same pmtiles, so the viewer can
-# show which source covers a clicked point — ROADMAP Milestone 5.3, "tile straight from
-# the coverage polygons." GEBCO (the global base) declares no max_zoom, so it's skipped;
-# only regional footprints get a polygon.
+# show which source covers a clicked point. GEBCO (the global base) declares no
+# max_zoom, so it's skipped; only regional footprints get a polygon.
 
 BASE_SOURCE = "gebco"  # the global fallback; its footprint is the whole planet, never an overlay
 
@@ -422,6 +427,8 @@ def _check():
     assert _chaikin_iters(NAV_SMOOTH_MAX_M + 1) == CHAIKIN_ITERATIONS
     # metre and feet/fathom isobaths each get their own per-zoom bands in the tippecanoe filter
     assert '["==", "sys", "m"]' in PER_ZOOM_FILTER and '["==", "sys", "ft"]' in PER_ZOOM_FILTER
+    # the filter must only compare depth_m — the int columns are string-typed at -j time
+    assert "depth_abs_m" not in PER_ZOOM_FILTER
     # every tier level must exist in the generated contour set (else it filters to nothing)
     assert all(d in config.CONTOUR_LEVELS for _, depths in CONTOUR_TIERS for d in depths)
     print("contour_run ring-drop + orphan-filter self-check ok")

--- a/style/README.md
+++ b/style/README.md
@@ -30,12 +30,11 @@ Composed into your own style (the protomaps-basemaps pattern — you own
 `sources`, the package provides layer groups):
 
 ```js
-import { day, sources, layers, state } from "@openwaters/seascape";
+import { day, sources, layers } from "@openwaters/seascape";
 
 const myStyle = {
   version: 8,
   glyphs: "...",
-  state, // global-state defaults for `unit` and `safety`
   sources: { ...myBasemapSources, ...sources({ tilesBase }) },
   layers: [...myBasemapLayers, ...layers(day)],
 };
@@ -46,13 +45,12 @@ Options: `style()` takes `unit` / `safety` (baked defaults, see below),
 
 ## Runtime parameters
 
-`unit` (`"m" | "ft" | "fm"`) and `safety` (metres, 0 = off) are MapLibre
-[global-state](https://maplibre.org/maplibre-style-spec/root/#state) variables
-(GL JS ≥ 5.6). Change them with `applyState`, which flips the state (every
-label, isobath filter, and unsafe-sounding emphasis re-evaluates) **and**
-rebuilds the depth-shading ramp — the one piece that can't read global-state
-(`interpolate` stops must be literals). Setting one without the other desyncs
-tint from labels, so don't:
+`unit` (`"m" | "ft" | "fm"`) and `safety` (metres, 0 = off) appear in the
+generated expressions as literals, so the style runs on any GL JS with the
+`color-relief` layer (MapLibre ≥ 5.6). Change them on a live map with
+`applyState`, which re-derives every dependent property (depth ramp, isobath
+filters, label text, unsafe-sounding emphasis) and sets them in place. Pass the
+full settings each call — nothing map-side remembers the previous values:
 
 ```js
 import { applyState } from "@openwaters/seascape";

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -3,7 +3,6 @@ import { validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
 import {
   applyState,
   day,
-  state,
   depthRelief,
   sources,
   layers,
@@ -44,9 +43,12 @@ test("sources reference the endpoint's TileJSON, encoding inline", () => {
   expect(src["seascape-vector"].url).toBe("https://t.example/vector.json");
 });
 
-test("unit/safety bake into both state defaults and the depth ramp", () => {
+test("unit/safety reach the layers as literals", () => {
   const s = style({ tilesBase: "https://t.example", unit: "fm", safety: 3 });
-  expect(s.state).toEqual({ unit: { default: "fm" }, safety: { default: 3 } });
+  // The compat contract: every expression is a literal, so the style runs on
+  // any GL JS with color-relief.
+  expect(JSON.stringify(s)).not.toContain("global-state");
+  expect(s).not.toHaveProperty("state");
   const shading = s.layers.find((l) => l.id === "depth-shading");
   const ramp = raw(
     (shading as { paint: Record<string, unknown> }).paint[
@@ -111,42 +113,45 @@ test("layer ids are stable — consumers key toggles/queries off them", () => {
   ]);
 });
 
-test("state defaults exist for every global-state key the expressions read", () => {
-  expect(Object.keys(state).sort()).toEqual(["safety", "unit"]);
-});
-
-test("applyState keeps global-state and the ramp in sync", () => {
-  const globals: Record<string, unknown> = { unit: "m", safety: 2 };
-  const paints: unknown[] = [];
+test("applyState re-derives every unit/safety-dependent property", () => {
+  type Call = { fn: string; layer: string; prop?: string; value: unknown };
+  const calls: Call[] = [];
   const map: ChartMap = {
-    setGlobalStateProperty: (k, v) => (globals[k] = v),
-    getGlobalState: () => globals,
-    setPaintProperty: (layer, prop, value) => paints.push({ layer, prop, value }),
-    getLayer: (id) => (id === "depth-shading" ? {} : undefined),
+    setFilter: (layer, value) => calls.push({ fn: "filter", layer, value }),
+    setLayoutProperty: (layer, prop, value) =>
+      calls.push({ fn: "layout", layer, prop, value }),
+    setPaintProperty: (layer, prop, value) =>
+      calls.push({ fn: "paint", layer, prop, value }),
+    getLayer: () => ({}),
   };
 
-  // Changing only safety must rebuild the ramp with the CURRENT unit.
-  applyState(map, { safety: 5 });
-  expect(globals.safety).toBe(5);
-  expect(paints).toHaveLength(1);
+  applyState(map, { unit: "fm", safety: 5 });
+  // Ramp: fathom-curve band edges active, hazard band folded.
   const ramp = raw(
-    (paints[0] as { layer: string; prop: string; value: unknown }).value,
+    calls.find((c) => c.fn === "paint" && c.layer === "depth-shading")!.value,
   );
-  expect(ramp).toContain(day.hazard); // safety > 0 folds the hazard band
-  expect(ramp).toContain(-10); // metric band edge → unit stayed "m"
+  expect(ramp).toContain(-30 * 1.8288);
+  expect(ramp).toContain(day.hazard);
+  // Isobath filters flip to the fathom-curve set — lines and labels together.
+  for (const id of ["contour-lines", "contour-labels"])
+    expect(calls.find((c) => c.fn === "filter" && c.layer === id)!.value)
+      .toEqual(["==", ["get", "sys"], "ft"]);
+  // Label text follows the unit.
+  expect(
+    JSON.stringify(
+      calls.find((c) => c.fn === "layout" && c.layer === "soundings")!.value,
+    ),
+  ).toContain("depth_fm");
+  // Unsafe-sounding emphasis carries the safety literal.
+  expect(
+    JSON.stringify(
+      calls.find((c) => c.fn === "paint" && c.layer === "soundings")!.value,
+    ),
+  ).toContain("5");
 
-  // Changing unit swaps the ramp onto the fathom curves.
-  applyState(map, { unit: "fm" });
-  expect(globals.unit).toBe("fm");
-  const fmRamp = raw(
-    (paints[1] as { layer: string; prop: string; value: unknown }).value,
-  );
-  expect(fmRamp).toContain(-30 * 1.8288); // 30 fm curve → ft/fm band edges
-  // Same-call values win over (possibly async) map state reads.
-  expect(fmRamp).toContain(day.hazard); // safety 5 still folded
-
-  // No depth-shading layer (composed style without it) → state set, no repaint.
+  // Layers absent from the map (composed subsets) are skipped entirely.
+  const before = calls.length;
   const bare: ChartMap = { ...map, getLayer: () => undefined };
-  applyState(bare, { safety: 0 });
-  expect(paints).toHaveLength(2);
+  applyState(bare, { unit: "m", safety: 0 });
+  expect(calls).toHaveLength(before);
 });

--- a/style/index.ts
+++ b/style/index.ts
@@ -13,12 +13,13 @@
  * Zooms, bounds, and attribution come from the endpoint's TileJSON documents
  * (raster.json / vector.json).
  *
- * Runtime parameters: the `unit` ("m" | "ft" | "fm") and `safety` (metres,
- * 0 = off) global-state variables drive every label, filter, and sounding-
- * emphasis expression — flip them with map.setGlobalStateProperty() and the
- * style re-evaluates, no per-layer restyle. The one exception is the
- * depth-shading ramp: interpolate stops must be literals, so on unit or safety
- * change rebuild it with depthRelief() and setPaintProperty (see below).
+ * Runtime parameters: `unit` ("m" | "ft" | "fm") and `safety` (metres, 0 = off)
+ * appear in the generated expressions as literals — every label, isobath
+ * filter, sounding emphasis, and the depth-shading ramp. Literal expressions
+ * run on any GL JS with color-relief (MapLibre >= 5.6). To change them on a
+ * live map, applyState() re-derives the handful of unit/safety-dependent
+ * properties and sets them in place; or fetch a regenerated style
+ * (`/style.json?unit=ft&safety=3`).
  */
 import type {
   ExpressionSpecification,
@@ -81,11 +82,9 @@ export const day: Flavor = {
   coverage: "#f58231",
 };
 
-// global-state defaults (the style root `state` object).
-export const state: { unit: { default: Unit }; safety: { default: number } } = {
-  unit: { default: "m" },
-  safety: { default: 2 },
-};
+// Mariner-setting defaults for layers()/style() when the caller omits them.
+const DEFAULT_UNIT: Unit = "m";
+const DEFAULT_SAFETY = 2;
 
 const DEFAULT_GLYPHS =
   "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf";
@@ -135,8 +134,8 @@ const rampColorAt = (ramp: RampStops, e: number): string => {
 };
 
 // The color-relief expression for the active unit system and safety depth.
-// Interpolate stops can't be live global-state values, so unit/safety changes
-// rebuild this and apply it with setPaintProperty("depth-shading", ...).
+// Unit/safety changes rebuild this and apply it with
+// setPaintProperty("depth-shading", ...) — applyState() does exactly that.
 export function depthRelief(
   flavor: Flavor = day,
   { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
@@ -208,10 +207,8 @@ export function layers(
   {
     dem = "seascape-dem",
     vector = "seascape-vector",
-    // Baked into the initial depth-shading ramp; keep in sync with the state
-    // defaults (runtime changes go through depthRelief() + setPaintProperty).
-    unit = state.unit.default,
-    safety = state.safety.default,
+    unit = DEFAULT_UNIT,
+    safety = DEFAULT_SAFETY,
   }: {
     dem?: string;
     vector?: string;
@@ -219,43 +216,36 @@ export function layers(
     safety?: number;
   } = {},
 ): LayerSpecification[] {
-  // One global-state variable — `unit` — drives every sounding/contour label
-  // and which isobaths show.
+  // `unit` picks every sounding/contour label and which isobath set shows;
+  // `safety` sets the unsafe-sounding emphasis. Everything is a literal, so
+  // runtime changes go through applyState(), which regenerates these.
   //
   // Soundings: props depth_m / depth_ft / depth_fm, all floored toward
   // shallower; depth_m already carries one decimal in the shoal band (<6 m)
   // and an integer deeper, so metres just print it.
-  const UNIT: ExpressionSpecification = ["global-state", "unit"];
   const soundingText: ExpressionSpecification = [
-    "case",
-    ["==", UNIT, "ft"],
-    ["to-string", ["get", "depth_ft"]],
-    ["==", UNIT, "fm"],
-    ["to-string", ["get", "depth_fm"]],
-    ["to-string", ["get", "depth_m"]], // metres (default; also covers unit unset)
+    "to-string",
+    [
+      "get",
+      unit === "ft" ? "depth_ft" : unit === "fm" ? "depth_fm" : "depth_m",
+    ],
   ];
   // Contours: metre isobaths (sys != "ft", also legacy no-sys tiles) vs the
   // fathom-curve set (sys == "ft"), which labels as feet or fathoms. Both
   // systems label every curve — the standard isobath sets are sparse enough
   // that GL collision thins the labels.
-  const IS_FEET: ExpressionSpecification = [
-    "any",
-    ["==", UNIT, "ft"],
-    ["==", UNIT, "fm"],
-  ];
-  const contourLineFilter: ExpressionSpecification = [
-    "case",
-    IS_FEET,
-    ["==", ["get", "sys"], "ft"],
-    ["!=", ["get", "sys"], "ft"],
-  ];
+  const contourLineFilter: ExpressionSpecification =
+    unit === "m" ? ["!=", ["get", "sys"], "ft"] : ["==", ["get", "sys"], "ft"];
   const contourLabelText: ExpressionSpecification = [
-    "case",
-    ["==", UNIT, "ft"],
-    ["concat", ["to-string", ["get", "depth_ft"]], "ft"],
-    ["==", UNIT, "fm"],
-    ["concat", ["to-string", ["get", "depth_fm"]], "fm"],
-    ["concat", ["to-string", ["get", "depth_abs_m"]], "m"],
+    "concat",
+    [
+      "to-string",
+      [
+        "get",
+        unit === "ft" ? "depth_ft" : unit === "fm" ? "depth_fm" : "depth_abs_m",
+      ],
+    ],
+    unit,
   ];
 
   // Shared label styling so soundings and contour labels read as one chart.
@@ -357,16 +347,10 @@ export function layers(
         // Soundings at or shoaler than the safety depth print black — S-52
         // shows unsafe-water soundings in black and lets the hazard tint carry
         // the alarm; safety=0 → all normal.
-        "text-color": [
-          "case",
-          [
-            "all",
-            [">", ["global-state", "safety"], 0],
-            ["<=", ["get", "depth_m"], ["global-state", "safety"]],
-          ],
-          "#000",
-          flavor.label,
-        ],
+        "text-color":
+          safety > 0
+            ? ["case", ["<=", ["get", "depth_m"], safety], "#000", flavor.label]
+            : flavor.label,
         "text-halo-color": flavor.labelHalo,
         "text-halo-width": 1,
       },
@@ -423,15 +407,15 @@ export function layers(
 // ─── Whole style ─────────────────────────────────────────────────────────────
 // A complete, drop-in StyleSpecification: OSM raster base (osm: false for
 // layers-only over your own basemap) + the bathymetry sources and layers.
-// `unit`/`safety` bake mariner defaults into both the depth ramp and the
-// style's global-state defaults, so labels and tint always agree.
+// `unit`/`safety` parameterize every layer, ramp included, so labels and tint
+// always agree.
 export function style({
   tilesBase,
   flavor = day,
   glyphs = DEFAULT_GLYPHS,
   osm = true,
-  unit = state.unit.default,
-  safety = state.safety.default,
+  unit = DEFAULT_UNIT,
+  safety = DEFAULT_SAFETY,
 }: {
   tilesBase: string;
   flavor?: Flavor;
@@ -458,53 +442,67 @@ export function style({
     version: 8,
     name: "Open Waters Seascape",
     glyphs,
-    state: { unit: { default: unit }, safety: { default: safety } },
     sources: { ...osmSource, ...sources({ tilesBase }) },
     layers: [...osmBase, ...layers(flavor, { unit, safety })],
   };
 }
 
 // ─── Runtime helpers ──────────────────────────────────────────────────────────
-// The style is not pure JSON: the depth ramp can't read global-state, and depth
-// readout decodes Terrarium pixels. These live here so consumers don't re-derive
-// either.
+// The unit/safety literals in the layers only change when the layers are
+// regenerated, and depth readout decodes Terrarium pixels. These live here so
+// consumers don't re-derive either.
 
 // The subset of maplibregl.Map that applyState touches (structural, so the
 // package needs no maplibre-gl dependency).
 export interface ChartMap {
-  setGlobalStateProperty(name: string, value: unknown): unknown;
-  getGlobalState(): Record<string, unknown>;
+  setFilter(layerId: string, filter: unknown): unknown;
+  setLayoutProperty(layerId: string, name: string, value: unknown): unknown;
   setPaintProperty(layerId: string, name: string, value: unknown): unknown;
   getLayer(id: string): unknown;
 }
 
-// Change the mariner settings on a live map. Flipping the `unit` / `safety`
-// global-state re-evaluates every label, filter, and sounding-emphasis
-// expression — but the depth-shading ramp's interpolate stops must be literals,
-// so it is rebuilt here with the SAME values. This pairing is the whole point:
-// setting the state without repainting the ramp (or vice versa) desyncs tint
-// from labels.
+// Change the mariner settings on a live map: re-derive the unit/safety-
+// dependent layer properties (depth ramp, isobath filters, label text, unsafe-
+// sounding emphasis) and set them in place — the in-place equivalent of
+// reloading a regenerated style. Takes the full settings each call: nothing
+// map-side stores the previous values, so callers pass what their controls
+// currently show. Layers absent from the map (composed subsets) are skipped.
 export function applyState(
   map: ChartMap,
-  changes: { unit?: Unit; safety?: number },
+  { unit, safety }: { unit: Unit; safety: number },
   flavor: Flavor = day,
 ): void {
-  if (changes.unit !== undefined)
-    map.setGlobalStateProperty("unit", changes.unit);
-  if (changes.safety !== undefined)
-    map.setGlobalStateProperty("safety", changes.safety);
-  const current = {
-    unit: state.unit.default,
-    safety: state.safety.default,
-    ...map.getGlobalState(),
-    ...changes,
-  } as { unit: Unit; safety: number };
+  const spec = Object.fromEntries(
+    layers(flavor, { unit, safety }).map((l) => [l.id, l]),
+  ) as Record<string, { filter?: unknown; layout?: any; paint?: any }>;
   if (map.getLayer("depth-shading"))
     map.setPaintProperty(
       "depth-shading",
       "color-relief-color",
-      depthRelief(flavor, current),
+      spec["depth-shading"].paint["color-relief-color"],
     );
+  if (map.getLayer("contour-lines"))
+    map.setFilter("contour-lines", spec["contour-lines"].filter);
+  if (map.getLayer("contour-labels")) {
+    map.setFilter("contour-labels", spec["contour-labels"].filter);
+    map.setLayoutProperty(
+      "contour-labels",
+      "text-field",
+      spec["contour-labels"].layout["text-field"],
+    );
+  }
+  if (map.getLayer("soundings")) {
+    map.setLayoutProperty(
+      "soundings",
+      "text-field",
+      spec["soundings"].layout["text-field"],
+    );
+    map.setPaintProperty(
+      "soundings",
+      "text-color",
+      spec["soundings"].paint["text-color"],
+    );
+  }
 }
 
 // Chart-datum elevation at a point, in metres — negative below datum (depth),

--- a/style/index.ts
+++ b/style/index.ts
@@ -76,7 +76,7 @@ export const day: Flavor = {
   contour: "#4a7a9c",
   label: "#036",
   labelHalo: "#fff",
-  font: ["Open Sans Regular"],
+  font: ["Noto Sans Regular"],
   hillshadeShadow: "#9adcfe",
   coverage: "#f58231",
 };

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -364,9 +364,8 @@ export default {
     // Drop-in MapLibre style for these tiles — the same style the viewer
     // renders (assembled by @openwaters/seascape); the endpoint base is derived
     // from the request. Point MapLibre's `style:` (or Maputnik) at this URL
-    // directly. ?unit=m|ft|fm and ?safety=<metres> bake mariner defaults into
-    // the served style (the depth ramp can't read runtime state, so zero-build
-    // consumers parameterize here instead).
+    // directly. ?unit=m|ft|fm and ?safety=<metres> set mariner defaults in the
+    // served style; on a live map the package's applyState changes them.
     if (rel === "/style.json") {
       // Uncacheable plain-text 400s: an intermediary must never cache an error
       // for a URL that would succeed once the param is fixed.


### PR DESCRIPTION
Users reported the style needing \"maplibre-gl > 5.19\". Bisecting with the live style across GL versions turned up two independent bugs plus a version floor, all addressed here. Verified by driving each affected version (5.5.0, 5.6.0, 5.7.3, 5.11.0, 5.19.0, 5.21.1) in a browser against the production endpoint.

## Use a glyph fontstack that exists on demotiles

The style's glyphs URL requested `Open Sans Regular`, which demotiles.maplibre.org doesn't serve. MapLibre ≥ 5.11 masks the 404 by rendering glyphs locally (so nobody on a current version noticed); before 5.11 a missing glyph PBF crashed tile parsing, which dropped labels **and** whole vector tiles — the \"broken map\" users were reporting. `Noto Sans Regular` exists on demotiles, and labels now use real PBF glyphs on new versions too.

## Generate unit/safety as literal expressions

`unit`/`safety` previously flowed through MapLibre global-state, which requires 5.6–5.7 and left runtime unit switching broken on 5.6.x (layout re-evaluation landed in 5.7). They now reach every label, isobath filter, sounding emphasis, and the depth ramp as literals at generation time; `applyState` re-derives the dependent properties from `layers()` and sets them in place, taking the full settings each call. The Worker's `?unit=`/`?safety=` params work unchanged.

**Net effect: the style and full runtime unit/safety switching work on MapLibre ≥ 5.6.0** (`color-relief` is the remaining floor; below 5.6 style validation rejects the layer and the map is blank).

API changes: the `state` export is gone, `applyState` takes required `{ unit, safety }`, and `ChartMap` swaps the global-state methods for `setFilter`/`setLayoutProperty`.

## Fix ft/fm isobaths vanishing below native zoom

Found while testing unit switching: ft/fm mode showed zero contour lines below native zoom on **every** GL version (0 `sys=ft` features at z10 Boston, 2 301 at z11). The per-zoom tippecanoe `-j` filter tested `depth_abs_m`, but FlatGeobuf Integer64 attributes reach `-j` (and the tiles) as strings, and `-j` comparisons are type-strict — the ft band matched nothing outside the native-zoom catch-all. The filter now tests `depth_m` (Real, always numeric), and `-T` coercions make the tiles carry real ints. Verified by bundling a local contour FGB and decoding z9/z10 tiles.

⚠️ Bundle-only change, but nothing marks the bundle dirty on a code-only edit — the contour bundle needs an explicit re-run after merge for prod tiles to pick it up.