### PR TITLE
Vector depth-band polygons (ENC DEPARE) alongside the contour lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,9 +260,9 @@ jobs:
               aws s3 rm "s3://$DATA_BUCKET/bathymetry/aggregation/$id" --recursive
             }
           done
-      - name: Prune orphaned contour FGBs + soundings + drying (covering re-tiled)
+      - name: Prune orphaned contour FGBs + soundings + drying + depare (covering re-tiled)
         run: |
-          # store/contour FGBs (and store/soundings geojson, store/drying FGBs) are keyed {z}-{x}-{y}-{child_z},
+          # store/contour FGBs (and store/soundings geojson, store/drying + store/depare FGBs) are keyed {z}-{x}-{y}-{child_z},
           # same as the covering's aggregation tiles. A source's footprint/maxzoom shift
           # re-tiles its area, but the sync (line ~270) has no --delete, so the superseded
           # file lingers in R2 and bundle globs EVERY one → two sets overlap. Drop any R2
@@ -293,6 +293,14 @@ jobs:
               aws s3 rm "s3://$DATA_BUCKET/$key"
             }
           done < /tmp/r2-dry.txt
+          aws s3 ls "s3://$DATA_BUCKET/bathymetry/depare/" --recursive | awk '{print $NF}' | grep '\.fgb$' > /tmp/r2-dep.txt || true
+          while read -r key; do
+            [ -n "$key" ] || continue
+            grep -qx "$(basename "$key" .fgb)" /tmp/valid-stems.txt || {
+              echo "pruning orphan depare $key"
+              aws s3 rm "s3://$DATA_BUCKET/$key"
+            }
+          done < /tmp/r2-dep.txt
       - name: Prune orphaned pmtiles (covering re-tiled)
         run: |
           # Same orphan class as the contour prune: a re-tiled covering leaves the old
@@ -350,7 +358,7 @@ jobs:
           # No R2 listing here: the shard reads its work from the plan's frozen dirty list
           # (shipped in the covering tarball, pulled above), so every shard partitions the
           # SAME list. Reproject range-reads sources via /vsicurl, so no pmtiles are pulled.
-          mkdir -p store/pmtiles store/contour store/soundings store/drying
+          mkdir -p store/pmtiles store/contour store/soundings store/drying store/depare
       - name: Aggregate shard ${{ matrix.shard.i }}/${{ matrix.shard.n }}
         run: |
           # SOURCE_VSI_BASE → reproject resolves each source tile to a public /vsicurl
@@ -373,6 +381,7 @@ jobs:
           aws s3 sync store/contour "s3://$DATA_BUCKET/bathymetry/contour"
           aws s3 sync store/soundings "s3://$DATA_BUCKET/bathymetry/soundings"
           aws s3 sync store/drying "s3://$DATA_BUCKET/bathymetry/drying"
+          aws s3 sync store/depare "s3://$DATA_BUCKET/bathymetry/depare"
           # Markers only — the covering tarball is immutable (plan owns it) and the
           # untarred CSVs must not be re-uploaded as the loose files we just collapsed.
           aws s3 sync store/aggregation "s3://$DATA_BUCKET/bathymetry/aggregation" --exclude '*' --include '*.done'
@@ -585,7 +594,7 @@ jobs:
           echo "contour FGBs: $count → matrix $shards"
 
   # tippecanoe one strided slice of every vector layer per runner → per-shard
-  # contours/soundings/drying pmtiles. Soundings + drying ride the contour shards
+  # contours/soundings/drying/depare pmtiles. The sparse layers ride the contour shards
   # (separately they held contour-bundle's tile-join back ~26 min while the rest of
   # the build sat finished); the slices stride each layer's own sorted list — no
   # geographic alignment needed, the merge unions everything per tile anyway.
@@ -607,18 +616,19 @@ jobs:
       # cleanly), and parallel-copy the strided slices this shard owns.
       - name: Pull this shard's layer slices from R2
         run: |
-          mkdir -p store/contour store/soundings store/drying store/bundle
+          mkdir -p store/contour store/soundings store/drying store/depare store/bundle
           aws s3 ls "s3://$DATA_BUCKET/bathymetry/contour/" --recursive | awk '{print $NF}' | grep '\.fgb$' | sort > /tmp/all-contour.txt
           sed 's#.*/##; s/\.fgb$//' /tmp/all-contour.txt | awk -F- '{print $4}' | sort -n | tail -1 > store/contour-maxz.txt
           aws s3 ls "s3://$DATA_BUCKET/bathymetry/soundings/" --recursive | awk '{print $NF}' | grep '\.geojson$' | sort > /tmp/all-soundings.txt
           aws s3 ls "s3://$DATA_BUCKET/bathymetry/drying/" --recursive | awk '{print $NF}' | grep '\.fgb$' | sort > /tmp/all-drying.txt
+          aws s3 ls "s3://$DATA_BUCKET/bathymetry/depare/" --recursive | awk '{print $NF}' | grep '\.fgb$' | sort > /tmp/all-depare.txt
           # Bounded outer retry + visible errors — see the downsample pull above.
-          for spec in "/tmp/all-contour.txt store/contour" "/tmp/all-soundings.txt store/soundings" "/tmp/all-drying.txt store/drying"; do
+          for spec in "/tmp/all-contour.txt store/contour" "/tmp/all-soundings.txt store/soundings" "/tmp/all-drying.txt store/drying" "/tmp/all-depare.txt store/depare"; do
             set -- $spec
             awk -v i="${{ matrix.shard.i }}" -v n="${{ matrix.shard.n }}" 'NR % n == (i + 1) % n' "$1" \
               | xargs -P 8 -I{} sh -c 'for a in 1 2 3 4 5; do aws s3 cp "s3://$DATA_BUCKET/$1" "$2/" --only-show-errors && exit 0; sleep "$a"; done; echo "giving up on $1 after 5 attempts" >&2; exit 1' _ {} "$2"
           done
-          echo "shard ${{ matrix.shard.i }}/${{ matrix.shard.n }}: $(ls store/contour/*.fgb 2>/dev/null | wc -l) contour FGBs, $(ls store/soundings/*.geojson 2>/dev/null | wc -l) soundings, $(ls store/drying/*.fgb 2>/dev/null | wc -l) drying, global maxz $(cat store/contour-maxz.txt)"
+          echo "shard ${{ matrix.shard.i }}/${{ matrix.shard.n }}: $(ls store/contour/*.fgb 2>/dev/null | wc -l) contour FGBs, $(ls store/soundings/*.geojson 2>/dev/null | wc -l) soundings, $(ls store/drying/*.fgb 2>/dev/null | wc -l) drying, $(ls store/depare/*.fgb 2>/dev/null | wc -l) depare, global maxz $(cat store/contour-maxz.txt)"
       - name: Vector shard ${{ matrix.shard.i }}
         run: |
           docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The toolchain is heavy native tooling. There are two routes to get it running:
 2. **Local dependencies**: This is faster for iterative development but requires a lot of local setup, could be brittle, and is subject to change. You'll need:
    - **[uv](https://docs.astral.sh/uv/)** — Python env for `pipelines/` (synced automatically on the first `uv run`).
    - **[just](https://github.com/casey/just)** — task runner.
-   - **GDAL CLI** — `gdalwarp`, `gdal_translate`, `gdal_contour`, `ogr2ogr`, `gdalbuildvrt`, `ogrinfo`.
+   - **GDAL CLI** — `gdalwarp`, `gdal_translate`, `gdal_contour`, `ogr2ogr`, `gdalbuildvrt`, `ogrinfo`. Use a recent release (the container pins 3.13): 3.8-era polygon-contour mode mis-writes the deepest depth-area bucket's `amin`.
    - **tippecanoe** + **tile-join** — contour vector tiles.
    - **Node + npm** — the viewer, style, and Worker are one npm workspace; a single `npm install` at the root covers all three (including `wrangler`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Key knobs (env vars, read by `pipelines/utils.py` / `bundle.py`):
 - `OVERLAY_SPLIT_Z` - overlay grid cell zoom (default 5 — raise it if a cell's bundle ever outgrows a CI runner)
 - `NUM_OVERVIEWS` - overview pyramid levels below each source's native maxzoom
 - `SMOOTH_DEM_SIGMA` / `SMOOTH_SLOPE_LOW` / `SMOOTH_SLOPE_HIGH` - slope-adaptive DEM smoothing (Gaussian sigma + the slope band it fades across)
-- `SKIP_SMOOTH`, `SKIP_CONTOURS`, `SKIP_SOUNDINGS`, `SKIP_DRYING` - skip that step
+- `SKIP_SMOOTH`, `SKIP_CONTOURS`, `SKIP_SOUNDINGS`, `SKIP_DRYING`, `SKIP_DEPARE` - skip that step
 - `CONTOUR_NAV_SMOOTH_MAX` - navigable-band contour-smoothing gate (replaces the retired `SKIP_CONTOUR_SMOOTH`)
 - `SOUND_CELL_PX` / `SOUND_MIN_DEPTH_M` - sounding spacing / min charted depth
 - `DRYING_CAP` - max elevation (m) tinted as drying foreshore
@@ -89,15 +89,15 @@ flowchart LR
 Four stages — `source → aggregation → downsampling → bundle` — all writing under `pipelines/store/` (gitignored), one subdir per stage (`store/source`, `store/aggregation`, `store/pmtiles`, `store/contour`, `store/bundle`, …).
 
 - **source** (`source_*.py`, per `sources/<id>/`): fetch → datum offset → normalize to a 4326 COG → `bounds.csv` → coverage polygon → tarball. Each source owns its recipe (`sources/<id>/Justfile`) composing the shared steps. Priority derives from `(maxzoom, id)` — GEBCO loses (smallest maxzoom), so regional sources win in overlap.
-- **aggregation** (`aggregation_*.py`): `cover` slices the planet into source-aware aggregation tiles (one CSV each); `run` reprojects each source by priority into a merged Float32 DEM (Gaussian seam feather), slope-smooths it (`smooth.py`), encodes Terrarium raster tiles, and forks contours (`contour_run.py`) and soundings (`soundings_run.py`) off the same merged DEM. Sources flagged `land_clamp` (GEBCO/EMODnet — coarse, no land/water concept) get their negative land pixels clamped to 0 against the OSM land mask (`landmask.py`, prep once with `just landmask`) right after warp, so shoreline cells don't paint false water/contours/soundings over land. The same mask feeds a `drying_run.py` fork: it polygonizes the green foreshore (elevation in `[0, DRYING_CAP]` seaward of the land line — chart drying areas) into the `drying` layer.
+- **aggregation** (`aggregation_*.py`): `cover` slices the planet into source-aware aggregation tiles (one CSV each); `run` reprojects each source by priority into a merged Float32 DEM (Gaussian seam feather), slope-smooths it (`smooth.py`), encodes Terrarium raster tiles, and forks contours (`contour_run.py`) and soundings (`soundings_run.py`) off the same merged DEM. Sources flagged `land_clamp` (GEBCO/EMODnet — coarse, no land/water concept) get their negative land pixels clamped to 0 against the OSM land mask (`landmask.py`, prep once with `just landmask`) right after warp, so shoreline cells don't paint false water/contours/soundings over land. The same mask feeds a `drying_run.py` fork: it polygonizes the green foreshore (elevation in `[0, DRYING_CAP]` seaward of the land line — chart drying areas) into the `drying` layer. A `depare_run.py` fork buckets the same merged DEM into depth-area partitions (ENC DEPARE: water between charted isobaths, `drval1`/`drval2` depth bounds) — the vector twin of the raster depth shading.
 - **downsampling**: 2×2-average overview pyramid below each source's native maxzoom.
-- **bundle** (`bundle.py`): concat single-zoom pmtiles into `planet.pmtiles` + one overlay archive per populated grid cell + `manifest.json`; contours, soundings, and drying/coverage layers bundle into `vector.pmtiles` via tippecanoe.
+- **bundle** (`bundle.py`): concat single-zoom pmtiles into `planet.pmtiles` + one overlay archive per populated grid cell + `manifest.json`; contours, soundings, and drying/depare/coverage layers bundle into `vector.pmtiles` via tippecanoe.
 
 A full build (`planet`) lands in `pipelines/store/bundle/`:
 
 - `planet.pmtiles` — the all-sources-merged base (Terrarium-encoded raster, per-zoom quantized), z0–`macrotile_z` (z8 = GEBCO native, no upsampling).
 - `overlay-{z}-{x}-{y}.pmtiles` — one per populated `OVERLAY_SPLIT_Z` grid cell (default z5), z`macrotile_z+1`→cell-max, carrying the GEBCO-filled merged mosaic under that cell.
-- `vector.pmtiles` — MVT vector source: `contours` (GEBCO baked to the deepest zoom by tippecanoe) plus the folded-in `soundings`, `drying` (green-foreshore polygons), and `coverage` layers.
+- `vector.pmtiles` — MVT vector source: `contours` (GEBCO baked to the deepest zoom by tippecanoe) plus the folded-in `soundings`, `drying` (green-foreshore polygons), `depare` (depth-band partitions, z6+), and `coverage` layers.
 - `manifest.json` — planet metadata + `overlay.cells` ({cell: max_zoom}) for the Worker.
 
 ### Why a planet cap + grid overlays
@@ -118,7 +118,7 @@ The Worker presents one endpoint per layer and resolves per tile:
 
 ```
 GET /seascape/{z}/{x}/{y}.webp   raster: z≤8 → planet · z>8 in a populated grid cell → that cell's overlay · else → overzoom the planet · miss → transparent
-GET /seascape/{z}/{x}/{y}.pbf    vector: vector.pmtiles passthrough (contours, soundings, drying, coverage layers)
+GET /seascape/{z}/{x}/{y}.pbf    vector: vector.pmtiles passthrough (contours, soundings, drying, depare, coverage layers)
 GET /seascape/raster.json        TileJSON (terrarium raster)
 GET /seascape/vector.json        TileJSON (vector layers)
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM ubuntu:24.04
+# Use Official OSGeo image (Ubuntu 24.04 + current GDAL with the HDF5/BAG drivers)
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.13.1
 
 LABEL org.opencontainers.image.source="https://github.com/openwatersio/seascape"
 LABEL org.opencontainers.image.description="Bathymetry → tile pipeline)"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# GDAL CLI (invoked as a subprocess by the pipeline) + build deps for tippecanoe.
+# Build deps for tippecanoe (GDAL CLI comes with the base image).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gdal-bin \
     ca-certificates curl git \
     build-essential libsqlite3-dev zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*

--- a/Justfile
+++ b/Justfile
@@ -25,14 +25,15 @@ sources:
     done
 
 # Planet build: cover -> aggregate -> downsample -> bundle -> vector layers (BBOX="W,S,E,N"
-# for a region). Soundings + drying bundle BEFORE contours: the contours tile-join folds
-# their pmtiles into vector.pmtiles in the same single pass.
+# for a region). Soundings + drying + depare bundle BEFORE contours: the contours tile-join
+# folds their pmtiles into vector.pmtiles in the same single pass.
 planet:
     just cover
     uv run python aggregation_run.py
     just combine
     just soundings
     just drying
+    just depare
     just contours
 
 # Plan the covering: slice the planet into aggregation tiles (BBOX="W,S,E,N" for a region).
@@ -112,15 +113,22 @@ soundings:
 drying:
     uv run python drying_run.py bundle
 
+# Depth areas (ENC DEPARE bands): bundle the per-tile partitions into depare.pmtiles
+# (folded into vector.pmtiles by the contours tile-join, same as soundings/drying).
+depare:
+    uv run python depare_run.py bundle
+
 # tippecanoe this shard's local slice of every vector layer -> {contours,soundings,
-# drying}-shard-{i}.pmtiles (CI pulls only the shard's slices + writes
+# drying,depare}-shard-{i}.pmtiles (CI pulls only the shard's slices + writes
 # store/contour-maxz.txt so all layers tile to one depth; merged by contour-merge).
-# Three invocations, not one -L run: the layers need different tippecanoe flags
-# (soundings -r1, drying --drop-densest-as-needed, contours' per-zoom filter).
+# Four invocations, not one -L run: the layers need different tippecanoe flags
+# (soundings -r1, drying --drop-densest-as-needed, depare --detect-shared-borders,
+# contours' per-zoom filter).
 vector-shard i:
     uv run python contour_run.py bundle-shard {{i}}
     uv run python soundings_run.py bundle-shard {{i}}
     uv run python drying_run.py bundle-shard {{i}}
+    uv run python depare_run.py bundle-shard {{i}}
 
 # tile-join the per-shard pmtiles (all layers) + coverage into vector.pmtiles.
 contour-merge:
@@ -163,7 +171,7 @@ preview bbox="-74.30,40.40,-73.75,40.80" local="":
     fi
     # Build the mask locally (one-time OSM download) if we're pointed at a local path with no file.
     case "$LANDMASK" in /vsicurl/*) : ;; *) [ -f "$LANDMASK" ] || just landmask ;; esac
-    rm -rf store/aggregation store/pmtiles store/bundle store/meta store/contour store/soundings store/drying
+    rm -rf store/aggregation store/pmtiles store/bundle store/meta store/contour store/soundings store/drying store/depare
     just planet
     ../worker/seed.sh
 

--- a/docs/plans/depth-areas.md
+++ b/docs/plans/depth-areas.md
@@ -1,0 +1,102 @@
+# Vector depth-band polygons (ENC DEPARE) alongside contour lines
+
+## Goal
+
+Add ENC-style depth-area polygons (S-57 DEPARE: banded water polygons carrying their depth range) as a vector layer next to `contours`, so band tints get crisp edges that sit exactly on the isobaths, stay sharp under overzoom (the raster color-relief blurs above native zoom), and can be recolored client-side by safety depth with ordinary fill expressions — the ECDIS model, where the safety contour snaps to the next-deeper available band edge. The raster color-relief stays; bands are an alternative shading the style can select.
+
+## Approach
+
+`gdal_contour -p` (polygon mode, `-amin`/`-amax`) on the same merged, smoothed DEM each aggregation tile already contours. Its polygon edges are the same linearly-interpolated isolines `gdal_contour` emits as lines, so band edges and contour lines coincide by construction (see "smoothing" below for the one exception). New sibling module `pipelines/depare_run.py`, shaped like `drying_run.py`.
+
+### Band levels
+
+The full contour ladders: `CONTOUR_LEVELS` + 0 for the metre set (0 closes the shoalest band at the shoreline), `CONTOUR_LEVELS_FT` + 0 tagged `sys=ft`. Every charted isobath is a band edge, so safety recoloring snaps to any level the chart draws (ECDIS behavior; a value between levels rounds deeper — bias shallow) and band edges coincide with every contour line, not just the shoal ones.
+
+Partition polygons can't be per-zoom thinned with a filter (dropping a partition leaves a hole), so the low-zoom cost of the full ladder is controlled by a zoom floor instead: the layer bundles and renders from z6 (the contour lines' presentation floor), with the raster relief carrying z<6. If deep-ocean z6–8 tiles still bust tippecanoe's budget, trim DEPARE levels deeper than −200 m (config-only): those bands render as near-identical near-white tints and no safety value lives down there.
+
+### Attributes
+
+`drval1`/`drval2` (ENC names): positive-down metres, shallow/deep bound of the band, derived from `-amin`/`-amax` (negate, swap). Plus `sys` (`m`/`ft`). Drop partitions with `amin >= 0` (land — the encoder clamps water to ≤ −LSB, land ≥ 0). No `-j` per-zoom filter needed, so the Integer64-string `-j` trap doesn't apply; `-T drval1:float -T drval2:float` (fathom edges aren't integer metres).
+
+### Smoothing and cracks — the load-bearing decisions
+
+- **No Chaikin, no shapely simplify on the polygons.** Adjacent partitions share edges; any per-feature smoothing/simplification treats the shared chain differently in each polygon (different ring anchors) and opens see-through cracks between bands. Leave geometry raw in the FGBs.
+- **tippecanoe `--detect-shared-borders`** does crack-free simplification of shared polygon borders per zoom — this flag exists for exactly this layer shape. Because maxzoom tiles simplify crack-free, overzoom stays crack-free too.
+- Line/edge coincidence: nav-band contour lines (≤ `CONTOUR_NAV_SMOOTH_MAX`, 30 m) skip Chaikin, so every shoal band edge matches its line to within the lines' sub-pixel simplify. Deeper lines are Chaikin-smoothed and will sit slightly deep of the raw band edge — visible only as a sliver between near-white deep tints, where tint carries no safety meaning. Accepted; do not engineer ring-matched smoothing.
+
+### Per-tile flow (`depare_run.generate`)
+
+Same seam contract as contours/drying — deterministic on the buffered DEM, restricted to the unbuffered tile:
+
+1. `gdal_contour -q -p -amin amin -amax amax -fl <levels> -f FlatGeobuf` on the merged 3857 DEM, once per level set (m, ft).
+2. Load with geopandas; drop land partitions; add `drval1`/`drval2`/`sys`.
+3. Clip to the unbuffered tile bbox **in shapely** (`make_valid` + `box` intersection + the `_polys` polygon-only reducer — reuse/lift from `drying_run`; ogr2ogr `-clipsrc` is the GDAL 3.8 GeometryCollection trap).
+4. Reproject to 4326, write `store/depare/{z}-{x}-{y}-{child_z}.fgb` (tile-keyed so clean tiles persist across incremental runs).
+
+Skip knob: `SKIP_DEPARE`, wired in `aggregation_run.py` next to the `drying_run.generate` fork.
+
+### Bundle
+
+`depare_run.bundle()` + `fold()`, copied from drying's shape:
+
+- Orphan filter via `contour_run._live_fgbs` / `_current_stems`.
+- **Shared tileset maxzoom** via `contour_run.bundle_maxz` (drying's lesson: a layer bundled shallower than the joined tileset vanishes from deeper tiles).
+- tippecanoe: `-l depare -Z 6 -z <maxz> --detect-shared-borders --coalesce-smallest-as-needed` — coalesce, **not** `--drop-densest-as-needed`: dropping a partition punches a tint hole; coalescing mis-tints a sub-pixel blob instead.
+- `fold()` tile-joins `depare.pmtiles` into `vector.pmtiles` (`-pk`), after the contour bundle like drying.
+
+Scale check: vertex weight ≈ 2× the corresponding contour lines (each isoline is stored in both neighbouring partitions) with no zoom tiering, concentrated in deep-ocean mid zooms — the z6 floor plus `--simplification` headroom covers it, and the abyssal-level trim above is the escape hatch. If a shoal-fractal tile still busts the size limit, raise `--simplification`, not the drop policy.
+
+## Drying seam (considered folding into this pipeline — rejected)
+
+Drying stays in `drying_run`. It can't come from `gdal_contour -p`: its definition needs the OSM land mask (a bare [0, DRYING_CAP] DEM band repaints polders and low coastal plains as foreshore), and post-intersecting with mask polygons just rebuilds `drying_run` with extra steps. Nor is exact drying/band edge alignment achievable: they're separate MVT layers from separate tippecanoe runs (`--detect-shared-borders` only works within a layer), so coincident edges would diverge under independent simplification into cracks. The robust cross-layer seam is the existing overlap design — drying's seaward overhang paints over the band edge, making the drying edge the visible waterline.
+
+Bands mode does tighten the overhang requirement: in relief mode the raster is continuous under drying, but the shallowest band's 0-edge is an independently-wobbling vector edge, and the current `DRYING_SEAWARD_PX=1` is inside drying's own 1.5 px DP tolerance — a bare-basemap sliver can open between blue and green. Raise `DRYING_SEAWARD_PX` to 3 (overhang > combined simplification wobble of both layers; shoal-conservative — water only reads narrower) in the same rebuild depare already forces.
+
+## Style (`style/index.ts`)
+
+- New fill layer `depth-areas` (`source-layer: depare`, minzoom 6 — the same presentation floor as `contour-lines`), between `depth-shading` and `drying-areas`. Filter by `sys` per unit like `contour-lines`. In bands mode `depth-shading` keeps z<6 (maxzoom 6); same palette, so the handoff is a sharpness change, not a colour change.
+- `fill-color`: literal expression keyed on `drval1` — `step`-style match assigning `bandColors`, with every band whose `drval2 <= safety-snapped-edge` painted `flavor.hazard`. Same literal-expression pattern as `depthRelief`; a `depthAreasColor(flavor, {unit, safety})` helper next to it. Opacity 0.85 to match.
+- Selection: a `shading: "relief" | "bands"` option on `layers()`/`style()` (default `"relief"`) emits one or the other visible — don't stack both at 0.85, the hues compound. `applyState` gains the `depth-areas` filter + fill-color updates.
+- Drying still paints over the shoalest band; land wash unchanged (relief ramp or, in bands mode, no fill over land — OSM base + drying carry it; verify in preview).
+
+Viewer: a shading toggle in `index.js` mirroring the existing unit/safety controls, so preview can A/B it.
+
+## CI (`.github/workflows/build.yml`)
+
+Mirror every `store/drying` line for `store/depare`:
+
+- aggregate job: `mkdir store/depare`, `aws s3 sync store/depare …/bathymetry/depare`.
+- Prune job: orphan-FGB prune stanza (covering re-tile).
+- contour-bundle job: pull `bathymetry/depare`, run bundle + fold after drying's.
+- Justfile: `depare` recipe (`bundle` + `fold`) called from the `planet` recipe next to `drying`; add `store/depare` to the clean recipe.
+
+Worker: no change — the layer rides `vector.pmtiles` passthrough.
+
+## Rebuild caveat (do not skip)
+
+A new fork produces nothing for clean tiles: the incremental diff only re-aggregates dirty tiles, so the first CI build after merge would carry depare FGBs for dirty tiles only. Clear the R2 aggregation/covering state (or force-dirty everything) before the first full build — same trap as contour-level config changes.
+
+## Checks
+
+- `depare_run.py check` (repo convention): synthetic DEM → partitions exactly tile the water (union == water footprint, pairwise disjoint), `drval1 < drval2`, land dropped, byte-identical on re-run (seam contract reduces to determinism), shapely clip keeps the layer uniformly polygon (bowtie + GeometryCollection cases, lifted from drying's check).
+- `test_engine.py`: `check_depare` adjacent-tile seam test mirroring `check_drying`.
+- Style: extend `npm test` for `depthAreasColor` (band → color, safety snapping deeper, hazard painting).
+- Visual: `just preview` in both shadings, m + ft, safety on/off; drag `vector.pmtiles` into the PMTiles viewer to confirm the `depare` layer and attributes. In bands mode, inspect the waterline at overzoom for blue/green slivers (the drying-overhang margin) and macrotile boundaries for band cracks.
+
+## Sequence
+
+1. `config.py` levels + `depare_run.py` (generate/bundle/fold/check) + `aggregation_run.py` fork + Justfile recipes.
+2. `test_engine.py` seam check.
+3. Style layer + `shading` option + `applyState` + viewer toggle + style tests.
+4. `just preview` evaluation; tune tippecanoe flags if tiles bust limits.
+5. build.yml wiring, then a full (state-cleared) build dispatch.
+
+## Skipped (deliberately)
+
+- Deriving contour lines from polygon boundaries, or drawing the polygons *as* the lines (true ENC DEPCNT/DEPARE topology) — evaluated and rejected: each partition ring fuses two isobath levels (no per-level filtering or labelling), macrotile clip edges baked into the rings would be stroked and labelled as isobaths, and the two `gdal_contour` modes share one generator on one DEM, so line/edge coincidence is already guaranteed without chaining vector ops. Clip edges are harmless to *fills* (fills don't stroke their boundary — the drying layer already proves macrotile-clipped polygons tile invisibly).
+- Nested/cumulative bands ("deeper than L") — translucent fills composite once per covering feature, so deep water stacks to ~full opacity and off-palette hues; partitions cover each pixel exactly once, keeping the 0.85-over-basemap design exact.
+
+## Follow-ups (explicitly not this plan)
+
+- Crank the depth-gated deep-water DEM smoothing (`smooth.py`) to see whether the deep-line Chaikin can retire — would close the residual deep line/band-edge mismatch at the source. Each tuning pass is a planet re-aggregation, and the DEM feeds shading/soundings/drying too.
+- Uniform polygon smoothing (cyclic Chaikin with clip-boundary vertices pinned) if raw deep band edges look noisy in preview despite the above.

--- a/index.html
+++ b/index.html
@@ -142,6 +142,12 @@
         <label>
           <input type="checkbox" id="toggle-drying" checked /> Drying areas
         </label>
+        <label title="Smooth raster relief, or vector ENC depth bands (crisp isobath edges, safety snapped to a charted level)">Shading
+          <select id="shading-select">
+            <option value="relief">smooth</option>
+            <option value="bands">bands</option>
+          </select>
+        </label>
         <label>Units
           <select id="unit-select">
             <option value="m">metres</option>

--- a/index.js
+++ b/index.js
@@ -89,6 +89,26 @@ map.on("load", () => {
   document
     .getElementById("unit-select")
     ?.addEventListener("change", applyControls);
+  // Shading mode — relief (raster ramp, continuous) vs bands (vector ENC depth
+  // areas: crisp isobath edges, safety snapped to a charted level). Bands data
+  // floors at z6, so relief keeps z<6 in bands mode; never both at once (the
+  // 0.85 opacities would compound).
+  const applyShading = () => {
+    const bands =
+      document.getElementById("shading-select")?.value === "bands";
+    if (map.getLayer("depth-areas"))
+      map.setLayoutProperty(
+        "depth-areas",
+        "visibility",
+        bands ? "visible" : "none",
+      );
+    if (map.getLayer("depth-shading"))
+      map.setLayerZoomRange("depth-shading", 0, bands ? 6 : 24);
+  };
+  applyShading();
+  document
+    .getElementById("shading-select")
+    ?.addEventListener("change", applyShading);
   // Layer toggles: the checkboxes are the source of truth — sync once on load
   // (the style's own defaults may differ, e.g. hillshade ships hidden) and on
   // every change.

--- a/pipelines/aggregation_run.py
+++ b/pipelines/aggregation_run.py
@@ -25,6 +25,7 @@ import aggregation_merge
 import aggregation_reproject
 import aggregation_tile
 import contour_run
+import depare_run
 import drying_run
 import landmask
 import smooth
@@ -35,6 +36,7 @@ import utils
 SKIP_CONTOURS = os.environ.get("SKIP_CONTOURS", "")
 SKIP_SOUNDINGS = os.environ.get("SKIP_SOUNDINGS", "")
 SKIP_DRYING = os.environ.get("SKIP_DRYING", "")
+SKIP_DEPARE = os.environ.get("SKIP_DEPARE", "")
 SKIP_SMOOTH = os.environ.get("SKIP_SMOOTH", "")
 
 
@@ -60,6 +62,8 @@ def run(filepath):
         soundings_run.generate(filepath)     # vector soundings off the same merged DEM
     if not SKIP_DRYING:
         drying_run.generate(filepath)        # green-foreshore polygons off the DEM + land mask
+    if not SKIP_DEPARE:
+        depare_run.generate(filepath)        # depth-area partitions (ENC DEPARE) off the same DEM
     if not os.environ.get("KEEP_TMP"):       # KEEP_TMP=1 preserves the merged DEM for re-running a fork
         shutil.rmtree(tmp_folder)
     utils.run_command(f'touch {filepath.replace("-aggregation.csv", "-aggregation.done")}')

--- a/pipelines/config.py
+++ b/pipelines/config.py
@@ -35,6 +35,14 @@ FATHOM_CURVES = [1, 2, 3, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 300
 # Ascending (deepest first, like CONTOUR_LEVELS) — gdal_contour -fl needs strictly increasing.
 CONTOUR_LEVELS_FT = sorted(round(-fm * 1.8288, 4) for fm in FATHOM_CURVES)
 
+# Depth-area (ENC DEPARE) partition levels: every charted isobath is a band edge, plus 0 to
+# close the shoalest band at the shoreline (the encoder holds land at >= 0, water below).
+# gdal_contour -p buckets the DEM between successive levels; the style tints buckets off
+# drval1 and snaps the safety contour to the next-deeper level. Mirrored in style/index.ts
+# (DEPARE_LADDER_M / DEPARE_LADDER_FT) — keep them in sync.
+DEPARE_LEVELS = CONTOUR_LEVELS + [0]
+DEPARE_LEVELS_FT = CONTOUR_LEVELS_FT + [0]
+
 
 def sources():
     """All source ids (directory names under SOURCES_DIR)."""

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -241,7 +241,7 @@ def _stems_maxz(stems):
 
 def bundle_maxz(own_max):
     """The tileset maxzoom EVERY vector layer bundles to (contours, soundings,
-    drying). They tile-join into one vector.pmtiles, whose maxzoom is the max
+    drying, depare). They tile-join into one vector.pmtiles, whose maxzoom is the max
     across layers — a layer bundled only to its own regional max silently
     vanishes from deeper tiles (drying stopped at z11 while contours ran to
     z14, so the Æbelø flats rendered as bare land above z11). Use the shared
@@ -331,14 +331,15 @@ def _coverage_pmtiles(maxz):
 
 def _finalize_contours(archives, maxz):
     """tile-join the layer archives (a local build's contour pmtiles, or the CI shards —
-    which carry contours, soundings, AND drying slices) + the coverage layer + the
-    whole-set soundings/drying pmtiles (local path, when their bundles ran first) into
-    store/bundle/vector.pmtiles. ONE join: tile-join rewrites every tile of the whole
+    which carry contours, soundings, drying, AND depare slices) + the coverage layer + the
+    whole-set soundings/drying/depare pmtiles (local path, when their bundles ran first)
+    into store/bundle/vector.pmtiles. ONE join: tile-join rewrites every tile of the whole
     archive, so folding each sparse layer in afterwards re-paid the planet-wide join
     per layer (~90 min each in CI). -pk keeps every feature of every layer; a layer
     whose pmtiles isn't present locally is simply not joined."""
     cov = _coverage_pmtiles(maxz)
-    layers = [p for p in [cov, "store/bundle/soundings.pmtiles", "store/bundle/drying.pmtiles"]
+    layers = [p for p in [cov, "store/bundle/soundings.pmtiles", "store/bundle/drying.pmtiles",
+                          "store/bundle/depare.pmtiles"]
               if p and os.path.isfile(p)]
     subprocess.run(["tile-join", "-o", "store/bundle/vector.pmtiles", "-f", "-pk",
                     *archives, *layers], check=True)

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -59,7 +59,10 @@ def partitions(dem, levels, raw_fgb):
         f"gdal_contour -q -p -amin amin -amax amax -fl {fl} -f FlatGeobuf {dem} {raw_fgb}",
         "gdal_contour -p")
     g = gpd.read_file(raw_fgb)
-    g = g[g["amin"] < 0].copy()
+    # Water = amax <= 0, NOT amin < 0: GDAL 3.8's polygon mode writes a garbage amin
+    # (0) on the deepest bucket, which then read as land and vanished — amax is correct
+    # on every version. drval2 off a buggy amin still trips _check's drval1 < drval2.
+    g = g[g["amax"] <= 0].copy()
     g["drval1"] = 0.0 - g["amax"]  # 0.0 - keeps the shoalest bound 0.0, not -0.0
     g["drval2"] = 0.0 - g["amin"]
     return g

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -1,0 +1,220 @@
+"""Depth-area polygons (ENC DEPARE) as a fork off each aggregation tile's merged DEM.
+
+The vector twin of the raster depth shading: water partitioned into bands between the
+charted isobath levels, each polygon carrying its depth range as drval1/drval2 (ENC
+DEPARE semantics, positive-down metres). A plain fill layer tints them — crisp band
+edges at any zoom, and client-side safety recolouring that snaps to the next-deeper
+charted level (the ECDIS model) with ordinary expressions.
+
+gdal_contour -p buckets the same merged, smoothed DEM the contour lines trace, with the
+same contour generator — band edges and contour lines coincide by construction. Two
+bucket sets, like the two contour sets: the metre ladder and the fathom curves (sys=ft).
+Partitions, not nested "deeper than" bands: exactly one polygon covers each water pixel,
+so a translucent fill composites once and the tint stays exact.
+
+Geometry stays raw — no Chaikin, no shapely simplify: adjacent partitions share edges,
+and per-feature smoothing treats the shared chain differently in each polygon, opening
+see-through cracks between bands. tippecanoe --detect-shared-borders simplifies shared
+borders identically per zoom instead. (Shoal band edges still match the drawn contour
+lines, which skip Chaikin in the navigable band; deep lines smooth away from the raw
+edge by design — an invisible sliver between near-white deep tints.)
+
+Per tile: gdal_contour -p at DEPARE_LEVELS / DEPARE_LEVELS_FT -> drop land buckets
+(amin >= 0) -> drval1/drval2/sys -> clip to the unbuffered tile bbox in shapely
+(polygon-only by construction, see drying_run) -> 4326 -> store/depare/{stem}.fgb.
+Same seam contract as contours/drying: deterministic on the buffered grid, so
+neighbouring tiles' partitions abut exactly at the clip line — invisible to fills,
+which never stroke their boundary. bundle() tippecanoes them into a `depare` layer
+pmtiles (or a per-shard slice in CI); the contours tile-join folds it into
+vector.pmtiles like soundings/drying.
+"""
+
+import os
+import subprocess
+import sys
+from glob import glob
+
+import mercantile
+
+import config
+import contour_run
+import drying_run
+import utils
+
+# The bands' zoom floor (matches the style's depth-areas/contour-lines minzoom):
+# partitions can't be level-thinned per zoom like the lines' CONTOUR_TIERS (dropping
+# one leaves a hole), so the floor is the low-zoom cost control — the raster depth
+# shading carries z<6.
+MIN_ZOOM = 6
+
+
+def partitions(dem, levels, raw_fgb):
+    """Water partitions off `dem`: gdal_contour -p buckets between `levels` -> drop land
+    (amin >= 0; 0 is always a level, so land is exactly the buckets above it) -> add
+    drval1/drval2 (ENC: shallow/deep bound, positive-down metres). GeoDataFrame in the
+    DEM's CRS."""
+    import geopandas as gpd
+    fl = " ".join(str(l) for l in levels)
+    contour_run._run(
+        f"gdal_contour -q -p -amin amin -amax amax -fl {fl} -f FlatGeobuf {dem} {raw_fgb}",
+        "gdal_contour -p")
+    g = gpd.read_file(raw_fgb)
+    g = g[g["amin"] < 0].copy()
+    g["drval1"] = 0.0 - g["amax"]  # 0.0 - keeps the shoalest bound 0.0, not -0.0
+    g["drval2"] = 0.0 - g["amin"]
+    return g
+
+
+def generate(filepath):
+    import geopandas as gpd
+    import pandas as pd
+    from shapely import make_valid
+    from shapely.geometry import box
+
+    agg_id, filename = filepath.split("/")[-2:]
+    z, x, y, child_z = (int(a) for a in filename.replace("-aggregation.csv", "").split("-"))
+    tile = mercantile.Tile(x=x, y=y, z=z)
+    tmp = f"store/aggregation/{agg_id}/{z}-{x}-{y}-{child_z}-tmp"
+    stem = f"{z}-{x}-{y}-{child_z}"
+    dem = f"{tmp}/{len(glob(f'{tmp}/*.tiff')) - 1}-3857.tiff"
+    if not os.path.exists(dem):
+        print(f"depare: no merged DEM for {filename}")
+        return
+
+    parts = []
+    for sys_tag, levels in (("m", config.DEPARE_LEVELS), ("ft", config.DEPARE_LEVELS_FT)):
+        g = partitions(dem, levels, f"{tmp}/depare-raw-{sys_tag}.fgb")
+        if len(g):
+            g["sys"] = sys_tag
+            parts.append(g)
+    if not parts:
+        print(f"depare: no water for {filename}")
+        return
+    gdf = gpd.GeoDataFrame(pd.concat(parts, ignore_index=True), crs=parts[0].crs)
+
+    # Clip in shapely, not ogr2ogr -clipsrc (the GDAL-3.8 GeometryCollection trap — see
+    # drying_run): make_valid + intersect + keep polygonal parts only, so the layer is
+    # uniformly polygon by construction.
+    clip = box(*mercantile.xy_bounds(tile))  # unbuffered, tile-aligned (EPSG:3857)
+    rows = [{"geometry": p, "drval1": r.drval1, "drval2": r.drval2, "sys": r.sys}
+            for r in gdf.itertuples()
+            for p in drying_run._polys(make_valid(r.geometry).intersection(clip))]
+    if not rows:
+        print(f"depare: no water in tile bbox for {filename}")
+        return
+
+    utils.create_folder("store/depare")  # tile-keyed, so clean tiles persist across incremental runs
+    out = f"store/depare/{stem}.fgb"
+    gpd.GeoDataFrame(rows, crs="EPSG:3857").to_crs("EPSG:4326").to_file(out, driver="FlatGeobuf")
+    print(f"depare: {filename} -> {len(rows)} polygons")
+
+
+# ── bundle ───────────────────────────────────────────────────────────────────
+
+def bundle(shard=None):
+    """tippecanoe the per-tile depare FGBs into store/bundle/depare.pmtiles (layer `depare`,
+    folded into vector.pmtiles by the contours tile-join, same as soundings/drying), z
+    MIN_ZOOM..shared maxz (see contour_run.bundle_maxz). With a shard index →
+    depare-shard-{shard}.pmtiles from this shard's local slice, like the other vector
+    layers. --detect-shared-borders keeps shared partition edges identical through
+    per-zoom simplification (no cracks between bands); --coalesce-smallest-as-needed,
+    never --drop-densest: a dropped partition is a tint hole, a coalesced one mis-tints
+    a sub-pixel blob. Orphan filter as contours/drying."""
+    fgbs = contour_run._live_fgbs(sorted(glob("store/depare/*.fgb")), contour_run._current_stems())
+    if not fgbs:
+        print("depare bundle: no depare FGBs")
+        return
+    maxz = contour_run.bundle_maxz(
+        max(int(f.split("/")[-1].replace(".fgb", "").split("-")[3]) for f in fgbs))
+    utils.create_folder("store/bundle")
+    out = "store/bundle/depare.pmtiles" if shard is None \
+        else f"store/bundle/depare-shard-{shard}.pmtiles"
+    subprocess.run(
+        ["tippecanoe", "-o", out, "-f", "-l", "depare",
+         "-n", "Depth areas", "-A", utils.ATTRIBUTION,
+         "-Z", str(MIN_ZOOM), "-z", str(maxz), "-P", "-q",
+         "--detect-shared-borders", "--coalesce-smallest-as-needed",
+         "--simplification", os.environ.get("DEPARE_SIMPLIFICATION", "8"),
+         "-y", "drval1", "-y", "drval2", "-y", "sys", *fgbs],
+        check=True)
+    print(f"depare bundle: {out} (z{MIN_ZOOM}-{maxz}, {len(fgbs)} FGBs)")
+
+
+def _check():
+    """gdal_contour -p buckets on a synthetic DEM: land dropped, each depth lands in its
+    ladder bucket (drval1/drval2 = the enclosing levels), partitions are pairwise disjoint
+    and jointly cover the water (the fill contract: no holes, no overlaps), the level
+    ladders ascend and end at 0 (gdal_contour -fl requires ascending; 0 closes the shoalest
+    band), and the output is deterministic (the seam contract reduces to this)."""
+    import tempfile
+
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+    from shapely.geometry import Point
+    from shapely.ops import unary_union
+
+    for levels in (config.DEPARE_LEVELS, config.DEPARE_LEVELS_FT):
+        assert levels == sorted(levels) and levels[-1] == 0, "levels must ascend and end at 0"
+
+    d = tempfile.mkdtemp()
+    h = w = 50
+    res = 100.0
+    tr = from_origin(0, h * res, res, res)  # top-left origin, EPSG:3857
+    # Land on top, then four water bands stepping deeper — each 10 rows, values chosen to
+    # sit strictly inside a ladder bucket. Step transitions interpolate through the
+    # intervening levels, so extra sliver partitions between bands are expected and fine.
+    dem = np.full((h, w), 5.0, dtype="float32")
+    for i, v in enumerate([-1.0, -7.0, -25.0, -150.0]):
+        dem[(i + 1) * 10:(i + 2) * 10, :] = v
+    p = f"{d}/dem.tif"
+    with rasterio.open(p, "w", driver="GTiff", height=h, width=w, count=1, dtype="float32",
+                       nodata=-9999, crs="EPSG:3857", transform=tr) as dst:
+        dst.write(dem, 1)
+
+    g = partitions(p, config.DEPARE_LEVELS, f"{d}/raw.fgb")
+    assert len(g) and (g["drval1"] >= 0).all(), "land buckets must be dropped"
+    assert (g["drval1"] < g["drval2"]).all(), "drval1 must be the shallow bound"
+
+    def bucket_at(gdf, row):
+        pt = Point(tr * (w / 2 + 0.5, row + 0.5))
+        hit = gdf[gdf.covers(pt)]
+        assert len(hit) == 1, f"exactly one partition must cover row {row}, got {len(hit)}"
+        return (hit.iloc[0]["drval1"], hit.iloc[0]["drval2"])
+
+    assert bucket_at(g, 15) == (0.0, 2.0), "-1 m must land in the [0,2] bucket"
+    assert bucket_at(g, 25) == (5.0, 10.0), "-7 m must land in the [5,10] bucket"
+    assert bucket_at(g, 35) == (20.0, 30.0), "-25 m must land in the [20,30] bucket"
+    assert bucket_at(g, 45) == (100.0, 200.0), "-150 m must land in the [100,200] bucket"
+    assert not g.covers(Point(tr * (w / 2 + 0.5, 5.5))).any(), "no partition may cover land"
+
+    # The fill contract: pairwise disjoint (sum of areas == union area) and jointly
+    # covering the water (union area == the water rows, ± the interpolated land edge).
+    union = unary_union(list(g.geometry))
+    assert abs(g.geometry.area.sum() - union.area) < 1e-6 * union.area, "partitions overlap"
+    water = (h - 10) * w * res * res
+    assert abs(union.area - water) < 1.5 * w * res * res, \
+        f"partitions must tile the water ({union.area:.0f} vs {water:.0f})"
+
+    # Fathom-curve set: -7 m sits between the 3 fm and 5 fm curves.
+    gft = partitions(p, config.DEPARE_LEVELS_FT, f"{d}/raw-ft.fgb")
+    d1, d2 = bucket_at(gft, 25)
+    assert abs(d1 - 3 * 1.8288) < 1e-6 and abs(d2 - 5 * 1.8288) < 1e-6, (d1, d2)
+
+    # Deterministic: same DEM -> byte-identical buckets.
+    g2 = partitions(p, config.DEPARE_LEVELS, f"{d}/raw2.fgb")
+    assert sorted(x.wkb for x in g.geometry) == sorted(x.wkb for x in g2.geometry), \
+        "partitions not deterministic"
+    print(f"depare_run self-check ok ({len(g)} m-partitions, {len(gft)} ft-partitions)")
+
+
+if __name__ == "__main__":
+    a = sys.argv[1:]
+    if a[:1] == ["bundle"]:
+        bundle()
+    elif a[:1] == ["bundle-shard"]:
+        bundle(int(a[1]))
+    elif a[:1] == ["check"]:
+        _check()
+    else:
+        sys.exit("usage: depare_run.py bundle | bundle-shard <i> | check")

--- a/pipelines/drying_run.py
+++ b/pipelines/drying_run.py
@@ -39,8 +39,11 @@ DRYING_GROW_PX = int(os.environ.get("DRYING_GROW_PX", "2"))
 # the polygon's seaward edge sits INSIDE the blue. The drying fill renders above the depth
 # shading, so the visible water/foreshore boundary becomes the crisp vector edge — the
 # simplification retreat (DP tol 1.5 px + tippecanoe) and the overzoom halo can no longer
-# open a land-wash gap at the waterline. Shoal-conservative: water only ever reads narrower.
-DRYING_SEAWARD_PX = int(os.environ.get("DRYING_SEAWARD_PX", "1"))
+# open a land-wash gap at the waterline. Sized to exceed the COMBINED simplification wobble
+# of drying and the depare band edge beneath it: in bands mode the shallowest depth band's
+# 0-edge is an independently simplified vector edge (not a continuous raster), so both edges
+# wobble ~1.5 px each. Shoal-conservative: water only ever reads narrower.
+DRYING_SEAWARD_PX = int(os.environ.get("DRYING_SEAWARD_PX", "3"))
 _DILATE_BAND = 4096  # rows per _dilate band; module-level so the self-check can shrink it
 
 
@@ -272,10 +275,13 @@ def _check():
     assert arr[27, 0] == 0, "nodata in the band must not be drying"
     assert arr[7, 5] == 0, "in-band elevation under land must not be drying"
     assert arr[34, 5] == 0, "above-cap topo must not be drying"
-    assert arr[2, 5] == 0 and arr[38, 5] == 0, "deep water / bare land must not be drying"
-    # seaward overhang: the water row adjacent to the band greens; the next row out does not
-    assert arr[30, 5] == 1, "water adjacent to foreshore must join it (seaward overhang)"
-    assert arr[31, 5] == 0, "water beyond the overhang must stay water"
+    # (rows 0-4 are sub-datum pixels under the land mask — seed pixels — so the 3 px
+    # overhang legitimately claims them next to the grown rows-5/6 foreshore; probe
+    # farther from any foreshore instead.)
+    assert arr[13, 5] == 0 and arr[38, 5] == 0, "far land / deep water must not be drying"
+    # seaward overhang: the water rows adjacent to the band green; above-cap water never does
+    assert arr[30, 5] == 1 and arr[31, 5] == 1, "water within the overhang must join the foreshore"
+    assert arr[32, 5] == 0, "above-cap water is never claimed, even inside the overhang"
     # Pixelwise-pure: same inputs -> byte-identical mask (the seam contract reduces to this once
     # the DEM/mask are deterministic, which merge/smooth/landmask already assert). The real
     # adjacent-tile seam is exercised end-to-end in test_engine.check_drying.
@@ -299,8 +305,8 @@ def _check():
     assert arr2[7, 8] == 1 and arr2[6, 8] == 1, "registration sliver must green (within grow)"
     assert arr2[5, 8] == 0 and arr2[4, 8] == 0, "low land beyond the grow must stay land"
     assert arr2[1, 1] == 0, "isolated low blob (polder) must stay land"
-    assert arr2[8, 8] == 1, "grown foreshore must overhang one water row"
-    assert arr2[10, 8] == 0, "deep water beyond the overhang is never drying"
+    assert arr2[8, 8] == 1 and arr2[10, 8] == 1, "grown foreshore must overhang into the water"
+    assert arr2[11, 8] == 0, "deep water beyond the overhang is never drying"
 
     # _dilate: banded result == single-band result (band boundaries carry the halo), and the
     # zero pad means no wraparound (a seed at the top edge never reaches the bottom edge).

--- a/pipelines/drying_run.py
+++ b/pipelines/drying_run.py
@@ -31,6 +31,18 @@ import contour_run
 import landmask
 import utils
 
+# Shoreline grow (px, on the merged-DEM grid): how far the wet/foreshore seed may claim
+# adjacent foreshore-height land pixels — sized to the OSM-coastline/DEM registration
+# error, NOT a coastline redefinition (see drying_mask). Env-tunable on a re-run.
+DRYING_GROW_PX = int(os.environ.get("DRYING_GROW_PX", "2"))
+# Seaward overhang (px): drying also claims water pixels this close to the foreshore, so
+# the polygon's seaward edge sits INSIDE the blue. The drying fill renders above the depth
+# shading, so the visible water/foreshore boundary becomes the crisp vector edge — the
+# simplification retreat (DP tol 1.5 px + tippecanoe) and the overzoom halo can no longer
+# open a land-wash gap at the waterline. Shoal-conservative: water only ever reads narrower.
+DRYING_SEAWARD_PX = int(os.environ.get("DRYING_SEAWARD_PX", "1"))
+_DILATE_BAND = 4096  # rows per _dilate band; module-level so the self-check can shrink it
+
 
 def _polys(geom):
     """Every non-empty Polygon inside a geometry, recursing into Multi/GeometryCollection and
@@ -46,14 +58,24 @@ def _polys(geom):
 
 def drying_mask(dem_path, mask_path, cap):
     """Whole-tile Byte drying mask (1 = foreshore) built in windows, so the multi-GB Float32 DEM
-    is never held whole — only this uint8 result (a quarter the size). 1 where a valid DEM pixel
-    is above chart datum but no deeper than the tide range (0 <= elev <= cap) AND seaward of the
-    land polygons (mask == 0). read_masks so nodata/alpha pixels drop out; the >= 0 term also
+    is never held whole. 1 where a valid DEM pixel is above chart datum but no deeper than the
+    tide range (0 <= elev <= cap) AND seaward of the land polygons (mask == 0), PLUS a bounded
+    shoreline grow (below). read_masks so nodata/alpha pixels drop out; the >= 0 term also
     excludes the DEM's -9999 nodata by itself. Returns (uint8 array, transform).
 
-    Ceiling: the uint8 mask is materialised whole for polygonize (rasterio.features.shapes needs
-    one array). It is a quarter the DEM's bytes, but a deep coastal macrotile is still ~1 GB;
-    upgrade path is a windowed streaming polygonize (gdal_polygonize) if that ever OOMs a shard.
+    Shoreline grow: the OSM coastline and the DEM waterline never register exactly — the line is
+    drawn at a different tide state than chart datum, and any DEM pixel straddling it rasterizes
+    to land — so a 1-3 px strip of foreshore-height "land" (much of it the clamp's elev==0
+    signature: the source read it below datum) separates the water from the drying polygons and
+    renders as a bare land-wash sliver between blue and green. Grow the wet/foreshore seed
+    DRYING_GROW_PX into land pixels within [0, cap]: registration-error sized, so it heals the
+    sliver without repainting genuinely low coastal land (Fyn, polders) — beyond it, OSM's land
+    verdict stands. An unbounded connectivity fill is NOT safe: low country connects the beach
+    to sub-cap terrain tens of km inland.
+
+    Ceiling: three uint8 planes are materialised whole (out for polygonize needs one array
+    anyway; seed/fringe for the cross-window grow). A deep coastal macrotile is ~1 GB each;
+    upgrade path is a windowed streaming polygonize + banded grow if that ever OOMs a shard.
     """
     with rasterio.open(dem_path) as d, rasterio.open(mask_path) as m:
         if (d.height, d.width) != (m.height, m.width):
@@ -61,6 +83,8 @@ def drying_mask(dem_path, mask_path, cap):
                 f"land mask {(m.height, m.width)} != DEM {(d.height, d.width)} for {dem_path} "
                 "(rasterize -te/-tr must match the merged DEM grid)")
         out = np.zeros((d.height, d.width), dtype="uint8")
+        seed = np.zeros_like(out)    # wet or foreshore: what the grow spreads from
+        fringe = np.zeros_like(out)  # foreshore-height land: what the grow may claim
         block = 2048
         for row in range(0, d.height, block):
             for col in range(0, d.width, block):
@@ -69,9 +93,40 @@ def drying_mask(dem_path, mask_path, cap):
                 elev = d.read(1, window=win)
                 valid = d.read_masks(1, window=win) != 0
                 land = m.read(1, window=win)
-                hit = valid & (elev >= 0) & (elev <= cap) & (land == 0)
-                out[row:row + hit.shape[0], col:col + hit.shape[1]] = hit
+                in_range = valid & (elev >= 0) & (elev <= cap)
+                hit = in_range & (land == 0)
+                sl = np.s_[row:row + hit.shape[0], col:col + hit.shape[1]]
+                out[sl] = hit
+                seed[sl] = hit | (valid & (elev < 0))
+                fringe[sl] = in_range & (land == 1)
+        out |= fringe & _dilate(seed, DRYING_GROW_PX)
+        # Seaward overhang: claim adjacent WATER pixels (seed minus foreshore) so the polygon
+        # edge overlaps the blue — see DRYING_SEAWARD_PX. Runs after the landward grow so
+        # grown foreshore overhangs too.
+        out |= (seed != 0) & (out == 0) & _dilate(out, DRYING_SEAWARD_PX)
         return out, d.transform
+
+
+def _dilate(a, n):
+    """Chebyshev binary dilation of a uint8 mask by n pixels, done in horizontal bands with an
+    n-px halo so the temporaries stay band-sized (a whole-plane pad would double peak memory).
+    Zero-padded at the array edge — no wraparound (np.roll would bleed one coast onto the
+    opposite edge, and the halo the tile carries can be as thin as 1 px)."""
+    if n <= 0:
+        return a.astype(bool)
+    h, w = a.shape
+    out = np.zeros((h, w), dtype=bool)
+    band = _DILATE_BAND
+    for r0 in range(0, h, band):
+        r1 = min(r0 + band, h)
+        p = np.pad(a[max(r0 - n, 0):min(r1 + n, h)] != 0, n)  # halo rows + zero edge pad
+        top = n + (r0 - max(r0 - n, 0))                       # first row of the band inside p
+        acc = np.zeros((r1 - r0, w), dtype=bool)
+        for dy in range(-n, n + 1):
+            for dx in range(-n, n + 1):
+                acc |= p[top + dy:top + dy + (r1 - r0), n + dx:n + dx + w]
+        out[r0:r1] = acc
+    return out
 
 
 def polygons(mask_arr, transform):
@@ -218,10 +273,47 @@ def _check():
     assert arr[7, 5] == 0, "in-band elevation under land must not be drying"
     assert arr[34, 5] == 0, "above-cap topo must not be drying"
     assert arr[2, 5] == 0 and arr[38, 5] == 0, "deep water / bare land must not be drying"
+    # seaward overhang: the water row adjacent to the band greens; the next row out does not
+    assert arr[30, 5] == 1, "water adjacent to foreshore must join it (seaward overhang)"
+    assert arr[31, 5] == 0, "water beyond the overhang must stay water"
     # Pixelwise-pure: same inputs -> byte-identical mask (the seam contract reduces to this once
     # the DEM/mask are deterministic, which merge/smooth/landmask already assert). The real
     # adjacent-tile seam is exercised end-to-end in test_engine.check_drying.
     assert np.array_equal(arr, drying_mask(dem_p, mask_p, cap)[0]), "drying mask not deterministic"
+
+    # Shoreline grow: foreshore-height LAND within DRYING_GROW_PX of the wet seed greens (heals
+    # the OSM-line/DEM registration sliver); the same height farther inland — and an isolated
+    # low blob (a clamped polder) — stay land. Water rows >= 8; land: dry +30 above a 0.0 strip.
+    land2 = np.zeros((16, 16), dtype="uint8"); land2[:8, :] = 1
+    dem2 = np.full((16, 16), -50.0, dtype="float32")
+    dem2[:4, :] = 30.0     # dry land above the cap — neither seed nor fringe
+    dem2[4:8, :] = 0.0     # rows 6,7 within 2 px of water -> grow greens; rows 4,5 beyond -> land
+    dem2[0:2, 0:3] = 0.0   # isolated low blob far from water -> stays land
+    d2, m2 = f"{d}/dem2.tif", f"{d}/mask2.tif"
+    for path, a2, dt in ((d2, dem2, "float32"), (m2, land2, "uint8")):
+        with rasterio.open(path, "w", driver="GTiff", height=16, width=16, count=1, dtype=dt,
+                           nodata=NODATA if dt == "float32" else 0, crs="EPSG:3857",
+                           transform=from_origin(0, 1600, 100, 100)) as dst:
+            dst.write(a2, 1)
+    arr2, _ = drying_mask(d2, m2, cap)
+    assert arr2[7, 8] == 1 and arr2[6, 8] == 1, "registration sliver must green (within grow)"
+    assert arr2[5, 8] == 0 and arr2[4, 8] == 0, "low land beyond the grow must stay land"
+    assert arr2[1, 1] == 0, "isolated low blob (polder) must stay land"
+    assert arr2[8, 8] == 1, "grown foreshore must overhang one water row"
+    assert arr2[10, 8] == 0, "deep water beyond the overhang is never drying"
+
+    # _dilate: banded result == single-band result (band boundaries carry the halo), and the
+    # zero pad means no wraparound (a seed at the top edge never reaches the bottom edge).
+    global _DILATE_BAND
+    seed_a = (np.random.default_rng(7).random((37, 21)) < 0.1).astype("uint8")
+    whole = _dilate(seed_a, 2)
+    _DILATE_BAND = 8
+    try:
+        assert np.array_equal(whole, _dilate(seed_a, 2)), "banded dilation != whole-array dilation"
+    finally:
+        _DILATE_BAND = 4096
+    edge = np.zeros((12, 5), dtype="uint8"); edge[0, 0] = 1
+    assert not _dilate(edge, 2)[10:, :].any(), "dilation must not wrap around the array edge"
 
     from shapely.geometry import Point
     geoms = polygons(arr, transform)

--- a/pipelines/test_engine.py
+++ b/pipelines/test_engine.py
@@ -441,6 +441,82 @@ def check_drying():
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def check_depare():
+    """The depare fork through the REAL depare_run.generate(): off a merged DEM it buckets the
+    water into depth-band partitions (drval1/drval2, both level ladders, tagged sys). Two
+    adjacent tiles carry the same depth bands across their shared edge, so the assertions
+    cover: exactly one m-partition with the right bucket over each band, land dropped, the
+    fathom-curve set present, and — the seam contract — both tiles' partitions meet at the
+    boundary (each clipped exactly to its bbox)."""
+    import geopandas as gpd
+    import mercantile
+    from pyproj import Transformer
+    from shapely.geometry import Point
+
+    import depare_run
+    from aggregation_reproject import get_resolution
+
+    tmp = tempfile.mkdtemp()
+    cwd = os.getcwd()
+    aid = "01DEPAREDEPAREDEPAREDEPARE"
+    try:
+        os.chdir(tmp)
+        to4326 = Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True)
+
+        def build(tile):
+            """Write a merged DEM for `tile` on its native 3857 grid, run generate()."""
+            stem = f"{tile.z}-{tile.x}-{tile.y}-{tile.z}"  # child_z == z: a native 512 px tile
+            tdir = f"store/aggregation/{aid}/{stem}-tmp"
+            os.makedirs(tdir, exist_ok=True)
+            b = mercantile.xy_bounds(tile)
+            res = get_resolution(tile.z)
+            px = round((b.right - b.left) / res)
+            tr = from_origin(b.left, b.top, res, res)
+            q = px // 4
+            dem = np.full((px, px), -150.0, dtype="float32")  # [100,200] bucket baseline
+            dem[:q, :] = 8.0             # land -> no partition
+            dem[q:2 * q, :] = -1.0       # -> the [0,2] bucket
+            dem[2 * q:3 * q, :] = -25.0  # -> the [20,30] bucket
+            with rasterio.open(f"{tdir}/0-3857.tiff", "w", driver="GTiff", height=px, width=px,
+                               count=1, dtype="float32", nodata=-9999, crs="EPSG:3857",
+                               transform=tr) as d:
+                d.write(dem, 1)
+            depare_run.generate(f"store/aggregation/{aid}/{stem}-aggregation.csv")
+            row_lonlat = lambda r: to4326.transform(*(tr * (px // 2 + 0.5, r + 0.5)))
+            return (gpd.read_file(f"store/depare/{stem}.fgb"),
+                    {"land": Point(row_lonlat(q // 2)),
+                     "shoal": Point(row_lonlat(q + q // 2)),
+                     "mid": Point(row_lonlat(2 * q + q // 2)),
+                     "deep": Point(row_lonlat(3 * q + q // 2))})
+
+        left = mercantile.Tile(x=301, y=384, z=10)
+        right = mercantile.Tile(x=302, y=384, z=10)          # shares left's east edge
+        gL, pts = build(left)
+        gR, _ = build(right)
+        m = gL[gL["sys"] == "m"]
+
+        def bucket(pt):
+            hit = m[m.covers(pt)]
+            assert len(hit) == 1, f"exactly one m-partition must cover the point, got {len(hit)}"
+            return (hit.iloc[0]["drval1"], hit.iloc[0]["drval2"])
+
+        assert bucket(pts["shoal"]) == (0.0, 2.0), "-1 m must land in the [0,2] bucket"
+        assert bucket(pts["mid"]) == (20.0, 30.0), "-25 m must land in the [20,30] bucket"
+        assert bucket(pts["deep"]) == (100.0, 200.0), "-150 m must land in the [100,200] bucket"
+        assert not gL.covers(pts["land"]).any(), "no partition may cover land"
+        assert (gL["sys"] == "ft").any(), "the fathom-curve partition set must be present"
+
+        # Seam: left's partitions reach its east edge, right's reach its west edge, and they are
+        # the same longitude (each clipped exactly to its bbox) — the band fills meet across it.
+        seam = mercantile.bounds(left).east
+        assert abs(gL.total_bounds[2] - seam) < 1e-4, f"left depare stops short of the seam: {gL.total_bounds[2]}"
+        assert abs(gR.total_bounds[0] - seam) < 1e-4, f"right depare stops short of the seam: {gR.total_bounds[0]}"
+        print("depare ok — bands bucketed to their ladder levels, land dropped, tiles meet at the seam")
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
 def main():
     tmp = tempfile.mkdtemp()
     try:
@@ -567,10 +643,12 @@ def main():
 
 
 if __name__ == "__main__":
+    import depare_run
     import drying_run
     import landmask
     landmask._check()
     drying_run._check()
+    depare_run._check()
     check_priority()
     check_shard_partition()
     check_weighted_shards()
@@ -578,4 +656,5 @@ if __name__ == "__main__":
     check_grid_split()
     check_land_clamp()
     check_drying()
+    check_depare()
     main()

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -3,6 +3,7 @@ import { validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
 import {
   applyState,
   day,
+  depthAreasColor,
   depthRelief,
   sources,
   layers,
@@ -22,6 +23,7 @@ test("generated style validates against the MapLibre style spec", () => {
       unit: "ft",
       safety: 3,
     }),
+    style({ tilesBase: "https://t.example", shading: "bands", safety: 5 }),
   ];
   for (const s of variants) expect(validateStyleMin(s)).toEqual([]);
 });
@@ -101,6 +103,7 @@ test("contour lines floor at z6 — depth shading carries lower zooms", () => {
 test("layer ids are stable — consumers key toggles/queries off them", () => {
   expect(layers().map((l) => l.id)).toEqual([
     "depth-shading",
+    "depth-areas",
     "hillshade",
     "drying-areas",
     "contour-lines",
@@ -111,6 +114,43 @@ test("layer ids are stable — consumers key toggles/queries off them", () => {
     "source-outline",
     "source-labels",
   ]);
+});
+
+test("shading picks relief or bands, never both at once", () => {
+  const get = (ls: ReturnType<typeof layers>, id: string) =>
+    ls.find((l) => l.id === id) as {
+      maxzoom?: number;
+      minzoom?: number;
+      layout?: { visibility?: string };
+    };
+  const relief = layers(); // default
+  expect(get(relief, "depth-areas").layout?.visibility).toBe("none");
+  expect(get(relief, "depth-shading").maxzoom).toBeUndefined();
+  const bands = layers(day, { shading: "bands" });
+  expect(get(bands, "depth-areas").layout?.visibility).toBe("visible");
+  // Handoff at the bands' z6 data floor: relief below, bands above.
+  expect(get(bands, "depth-shading").maxzoom).toBe(6);
+  expect(get(bands, "depth-areas").minzoom).toBe(6);
+});
+
+test("depthAreasColor tints bands off drval1 and snaps safety deeper", () => {
+  // No safety: a step from shoalest to deepest band colour, stops just under
+  // the band edges (float32 drval fuzz guard).
+  const off = raw(depthAreasColor(day, { unit: "m", safety: 0 }));
+  expect(off[0]).toBe("step");
+  expect(off[2]).toBe(day.bandColors[5]); // < 2 m → shoalest
+  expect(off[3]).toBe(2 - 0.01);
+  expect(off[off.length - 2]).toBe(50 - 0.01);
+  expect(off[off.length - 1]).toBe(day.bandColors[0]); // ≥ 50 m → deepest
+  expect(off).not.toContain(day.hazard);
+  // safety 15 m snaps to the 20 m rung: bands with drval1 < 20 go hazard.
+  const on = depthAreasColor(day, { unit: "m", safety: 15 }) as unknown[];
+  expect(on[0]).toBe("case");
+  expect(JSON.stringify(on[1])).toContain(String(20 - 0.01));
+  expect(on[2]).toBe(day.hazard);
+  // Fathom mode snaps up the fathom-curve ladder (safety 3 m → the 2 fm rung).
+  const fm = depthAreasColor(day, { unit: "fm", safety: 3 }) as unknown[];
+  expect(JSON.stringify(fm[1])).toContain(String(2 * 1.8288 - 0.01));
 });
 
 test("applyState re-derives every unit/safety-dependent property", () => {
@@ -132,10 +172,20 @@ test("applyState re-derives every unit/safety-dependent property", () => {
   );
   expect(ramp).toContain(-30 * 1.8288);
   expect(ramp).toContain(day.hazard);
-  // Isobath filters flip to the fathom-curve set — lines and labels together.
-  for (const id of ["contour-lines", "contour-labels"])
+  // Isobath filters flip to the fathom-curve set — lines, labels, and the
+  // depth bands together.
+  for (const id of ["contour-lines", "contour-labels", "depth-areas"])
     expect(calls.find((c) => c.fn === "filter" && c.layer === id)!.value)
       .toEqual(["==", ["get", "sys"], "ft"]);
+  // Band fill recolours with the snapped safety contour (5 m is a rung).
+  expect(
+    JSON.stringify(
+      calls.find(
+        (c) =>
+          c.fn === "paint" && c.layer === "depth-areas" && c.prop === "fill-color",
+      )!.value,
+    ),
+  ).toContain(day.hazard);
   // Label text follows the unit.
   expect(
     JSON.stringify(

--- a/style/index.ts
+++ b/style/index.ts
@@ -19,7 +19,9 @@
  * run on any GL JS with color-relief (MapLibre >= 5.6). To change them on a
  * live map, applyState() re-derives the handful of unit/safety-dependent
  * properties and sets them in place; or fetch a regenerated style
- * (`/style.json?unit=ft&safety=3`).
+ * (`/style.json?unit=ft&safety=3`). `shading` ("relief" | "bands") picks the
+ * water shading: the raster ramp, or the vector ENC depth-area bands above z6
+ * (the relief keeps z<6 either way).
  */
 import type {
   ExpressionSpecification,
@@ -29,6 +31,11 @@ import type {
 } from "@maplibre/maplibre-gl-style-spec";
 
 export type Unit = "m" | "ft" | "fm";
+// Water shading: the raster color-relief ramp (continuous, fuzzy edges) or the
+// vector ENC depth-area bands (crisp edges on the charted isobaths, safety
+// snapped to the next-deeper charted level). Never both at once — the 0.85
+// opacities would compound.
+export type Shading = "relief" | "bands";
 
 export interface Flavor {
   bandColors: string[]; // deepest → shoalest (6 entries)
@@ -85,6 +92,11 @@ export const day: Flavor = {
 // Mariner-setting defaults for layers()/style() when the caller omits them.
 const DEFAULT_UNIT: Unit = "m";
 const DEFAULT_SAFETY = 2;
+const DEFAULT_SHADING: Shading = "relief";
+
+// The depare layer's data floor (tippecanoe -Z in the pipeline) and the contour
+// lines' presentation floor — depth shading carries lower zooms.
+const BANDS_MIN_ZOOM = 6;
 
 const DEFAULT_GLYPHS =
   "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf";
@@ -172,6 +184,50 @@ export function depthRelief(
   ] as unknown as ExpressionSpecification;
 }
 
+// ─── Depth-area (ENC DEPARE) band colour ─────────────────────────────────────
+// Charted isobath ladders, positive-down metres — must mirror pipelines/config.py
+// DEPARE_LEVELS / DEPARE_LEVELS_FT (the bucket edges baked into the depare
+// layer). The safety contour snaps UP this ladder to the next-deeper rung
+// (ECDIS behaviour, bias shallow) — vector bands can only flip at charted
+// levels, unlike the raster ramp's continuous crisp edge.
+const DEPARE_LADDER_M = [
+  2, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 4000, 5000, 6000,
+  8000, 10000,
+];
+const DEPARE_LADDER_FT = [
+  1, 2, 3, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000,
+].map((fm) => fm * 1.8288);
+
+// Comparisons against drval1 subtract this: tiles may carry the fathom-curve
+// drvals (1.8288, 5.4864, …) as 32-bit floats, which can land a hair below the
+// exact edge value. Ladder rungs are ≥ ~1.8 m apart, so 0.01 m is safely
+// inside every gap.
+const DRVAL_EPS = 0.01;
+
+// Fill colour for the depare partitions: the band tint keyed off drval1 (the
+// band's shallow bound), with every band shallower than the snapped safety
+// contour painted the hazard tint. Literals only, like depthRelief — runtime
+// changes go through applyState().
+export function depthAreasColor(
+  flavor: Flavor = day,
+  { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
+): ExpressionSpecification {
+  const metric = unit === "m";
+  const edges = [...flavor.bandEdges[metric ? "m" : "ft"]].reverse(); // shoalest → deepest
+  const step: unknown[] = ["step", ["get", "drval1"], flavor.bandColors[5]];
+  edges.forEach((d, i) => step.push(d - DRVAL_EPS, flavor.bandColors[4 - i]));
+  if (!(safety > 0)) return step as unknown as ExpressionSpecification;
+  const ladder = metric ? DEPARE_LADDER_M : DEPARE_LADDER_FT;
+  const snap =
+    ladder.find((l) => l >= safety - DRVAL_EPS) ?? ladder[ladder.length - 1];
+  return [
+    "case",
+    ["<", ["get", "drval1"], snap - DRVAL_EPS],
+    flavor.hazard,
+    step,
+  ] as unknown as ExpressionSpecification;
+}
+
 // ─── Sources ─────────────────────────────────────────────────────────────────
 // tilesBase is the Worker endpoint; the sources reference its TileJSON docs
 // (raster.json / vector.json), which carry the tile URLs, zoom range, bounds,
@@ -209,11 +265,13 @@ export function layers(
     vector = "seascape-vector",
     unit = DEFAULT_UNIT,
     safety = DEFAULT_SAFETY,
+    shading = DEFAULT_SHADING,
   }: {
     dem?: string;
     vector?: string;
     unit?: Unit;
     safety?: number;
+    shading?: Shading;
   } = {},
 ): LayerSpecification[] {
   // `unit` picks every sounding/contour label and which isobath set shows;
@@ -266,9 +324,30 @@ export function layers(
       id: "depth-shading",
       type: "color-relief",
       source: dem,
+      // Bands mode: the vector depth areas take over at their z6 data floor;
+      // the relief carries lower zooms (same palette, so the handoff is a
+      // sharpness change, not a colour change).
+      ...(shading === "bands" ? { maxzoom: BANDS_MIN_ZOOM } : {}),
       paint: {
         "color-relief-color": depthRelief(flavor, { unit, safety }),
         "color-relief-opacity": 0.85,
+      },
+    },
+    {
+      // ENC DEPARE depth bands: the vector twin of depth-shading — crisp band
+      // edges on the charted isobaths, safety recolour snapped to the next-
+      // deeper charted level. Hidden in relief mode (never rendered under the
+      // relief — the opacities would compound).
+      id: "depth-areas",
+      type: "fill",
+      source: vector,
+      "source-layer": "depare",
+      filter: contourLineFilter,
+      minzoom: BANDS_MIN_ZOOM,
+      layout: { visibility: shading === "bands" ? "visible" : "none" },
+      paint: {
+        "fill-color": depthAreasColor(flavor, { unit, safety }),
+        "fill-opacity": 0.85,
       },
     },
     {
@@ -292,7 +371,7 @@ export function layers(
       type: "fill",
       source: vector,
       "source-layer": "drying",
-      paint: { "fill-color": flavor.drying, "fill-opacity": 0.55 },
+      paint: { "fill-color": flavor.drying, "fill-opacity": 0.85 },
     },
     {
       id: "contour-lines",
@@ -416,6 +495,7 @@ export function style({
   osm = true,
   unit = DEFAULT_UNIT,
   safety = DEFAULT_SAFETY,
+  shading = DEFAULT_SHADING,
 }: {
   tilesBase: string;
   flavor?: Flavor;
@@ -423,6 +503,7 @@ export function style({
   osm?: boolean;
   unit?: Unit;
   safety?: number;
+  shading?: Shading;
 }): StyleSpecification {
   const osmSource: Record<string, SourceSpecification> = osm
     ? {
@@ -443,7 +524,7 @@ export function style({
     name: "Open Waters Seascape",
     glyphs,
     sources: { ...osmSource, ...sources({ tilesBase }) },
-    layers: [...osmBase, ...layers(flavor, { unit, safety })],
+    layers: [...osmBase, ...layers(flavor, { unit, safety, shading })],
   };
 }
 
@@ -481,6 +562,14 @@ export function applyState(
       "color-relief-color",
       spec["depth-shading"].paint["color-relief-color"],
     );
+  if (map.getLayer("depth-areas")) {
+    map.setFilter("depth-areas", spec["depth-areas"].filter);
+    map.setPaintProperty(
+      "depth-areas",
+      "fill-color",
+      spec["depth-areas"].paint["fill-color"],
+    );
+  }
   if (map.getLayer("contour-lines"))
     map.setFilter("contour-lines", spec["contour-lines"].filter);
   if (map.getLayer("contour-labels")) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -364,8 +364,9 @@ export default {
     // Drop-in MapLibre style for these tiles — the same style the viewer
     // renders (assembled by @openwaters/seascape); the endpoint base is derived
     // from the request. Point MapLibre's `style:` (or Maputnik) at this URL
-    // directly. ?unit=m|ft|fm and ?safety=<metres> set mariner defaults in the
-    // served style; on a live map the package's applyState changes them.
+    // directly. ?unit=m|ft|fm, ?safety=<metres>, and ?shading=relief|bands set
+    // mariner defaults in the served style; on a live map the package's
+    // applyState changes unit/safety in place.
     if (rel === "/style.json") {
       // Uncacheable plain-text 400s: an intermediary must never cache an error
       // for a URL that would succeed once the param is fixed.
@@ -389,11 +390,19 @@ export default {
       const safety = safetyParam === null ? undefined : Number(safetyParam);
       if (safety !== undefined && !(Number.isFinite(safety) && safety >= 0))
         return bad("safety must be a non-negative number (metres)");
+      const shadingParam = url.searchParams.get("shading");
+      const shading =
+        shadingParam === null
+          ? undefined
+          : (["relief", "bands"] as const).find((s) => s === shadingParam);
+      if (shadingParam !== null && shading === undefined)
+        return bad("shading must be relief or bands");
       return json(
         seascapeStyle({
           tilesBase,
           ...(unit !== undefined ? { unit } : {}),
           ...(safety !== undefined ? { safety } : {}),
+          ...(shading !== undefined ? { shading } : {}),
         }),
       );
     }
@@ -453,6 +462,16 @@ export default {
             // Green-foreshore polygons (drying areas) — geometry only, no attributes.
             id: "drying",
             fields: {},
+          },
+          {
+            // Depth-band partitions (ENC DEPARE): water between charted
+            // isobaths, drval1/drval2 = shallow/deep bound (positive-down m).
+            id: "depare",
+            fields: {
+              drval1: "Number",
+              drval2: "Number",
+              sys: "String",
+            },
           },
           {
             // Per-source data-extent polygons (provenance / click-to-identify).


### PR DESCRIPTION
Adds ENC-style depth-area polygons (S-57 DEPARE: banded water polygons carrying their depth range) as a `depare` layer in `vector.pmtiles`, next to the contour lines — plus the drying-seam fix that rides the same rebuild. Design rationale lives in `docs/plans/depth-areas.md`.

## Why

Band tints get crisp edges that sit exactly on the isobaths (the raster color-relief blurs above native zoom), and the safety depth can recolour bands client-side with ordinary fill expressions — the ECDIS model, where the safety contour snaps to the next-deeper charted level.

## How

- **`pipelines/depare_run.py`** — a sibling fork of contours/soundings/drying off each aggregation tile's merged DEM. `gdal_contour -p` buckets the same smoothed DEM the lines trace (same contour generator, so band edges and lines coincide by construction) at the full charted ladders: `CONTOUR_LEVELS` + 0, and the fathom curves tagged `sys=ft`. Each polygon carries `drval1`/`drval2` (shallow/deep bound, positive-down metres).
- **Partitions, not nested bands**: exactly one polygon covers each water pixel, so the translucent fill composites once. Geometry stays raw — per-feature smoothing/simplify treats a shared edge differently in each neighbour and opens cracks; tippecanoe `--detect-shared-borders` simplifies shared borders identically per zoom, and `--coalesce-smallest-as-needed` (never drop — a dropped partition is a tint hole) absorbs the rest.
- **z6 floor**: partitions can't be level-thinned per zoom like `CONTOUR_TIERS` (a dropped level is a hole), so the layer bundles from z6 — the contour lines' presentation floor — and the raster relief carries lower zooms.
- **Style**: `depth-areas` fill layer + `depthAreasColor()` (band tint off `drval1`, hazard below the snapped safety contour, literal expressions like everything else) behind a `shading: "relief" | "bands"` option (default `relief`; bands mode caps `depth-shading` at z6 — same palette, so the handoff is a sharpness change, not a colour change). `applyState()` re-derives filter + fill colour; the Worker serves `?shading=` and advertises the layer in `vector.json`; the viewer grows a Shading select.
- **Drying seam**: `DRYING_SEAWARD_PX` defaults 1 → 3. In bands mode the shallowest band's 0-edge is an independently simplified vector edge (not a continuous raster under the drying fill), so the overhang must exceed the combined simplification wobble of both layers or a bare-basemap sliver opens between blue and green. Shoal-conservative: water only ever reads narrower.
- **CI**: depare rides the sharded vector model end to end — store sync + orphan prune in the aggregate/plan jobs, `bundle-shard` in `just vector-shard`, and the single `contour-merge` tile-join folds it into `vector.pmtiles`.

## Verification

- `depare_run.py check`: buckets land in their ladder levels, partitions pairwise disjoint + jointly tile the water, deterministic (the seam contract).
- `test_engine.check_depare`: adjacent tiles' partitions meet at the clip line; full `just test-engine` green.
- Style tests cover `depthAreasColor` (band mapping, deeper-snapping, hazard fold), the shading handoff, and spec validation of the bands variant.
- NY-harbor preview (`just preview` + viewer): band edges sit on the labelled isobaths at z15 overzoom, no cracks or waterline slivers; `queryRenderedFeatures` confirms one partition per point with correct drvals; safety=10 hazard-tints exactly the sub-10 m buckets; fm mode flips to the fathom set; z5 hands off to relief.

## Rollout note

A new fork produces nothing for clean tiles under the incremental diff — dispatch the first build after merge with **force** (or clear the R2 aggregation state), or `vector.pmtiles` ships depare only where tiles happened to be dirty. That forced build also re-tiles the ft/fm isobath fix (#56) into prod.
