### PR TITLE
Ship source coverage as its own tileset (coverage.pmtiles)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,8 +127,15 @@ jobs:
         run: |
           volatile=$(jq -r '.volatile // false' "sources/${{ matrix.source }}/metadata.json")
           have=$(aws s3 cp "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/.recipe-hash" - 2>/dev/null || true)
+          # A source whose recipe polygonizes must have its footprint in R2 (the plan
+          # job's coverage tileset builds from bathymetry/polygon/). Missing means the
+          # source last built before the polygon push existed — rebuild once to backfill.
+          poly_ok=true
+          if grep -q source_polygonize "sources/${{ matrix.source }}/Justfile"; then
+            aws s3 ls "s3://$DATA_BUCKET/bathymetry/polygon/${{ matrix.source }}.gpkg" >/dev/null || poly_ok=false
+          fi
           if [ "$volatile" = "true" ]; then current=false
-          elif [ -n "$RECIPE_HASH" ] && [ "$have" = "$RECIPE_HASH" ]; then current=true
+          elif [ -n "$RECIPE_HASH" ] && [ "$have" = "$RECIPE_HASH" ] && [ "$poly_ok" = "true" ]; then current=true
           else current=false; fi
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "hash=$RECIPE_HASH" >> "$GITHUB_OUTPUT"
@@ -154,6 +161,11 @@ jobs:
         if: steps.check.outputs.current != 'true'
         run: |
           aws s3 sync "store/source/${{ matrix.source }}" "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}" --delete --exclude '.recipe-hash'
+          # Provenance footprint → bathymetry/polygon/ (the plan job's coverage tileset
+          # reads them all). Guarded: streaming sources register remote COGs and build none.
+          if [ -f "store/polygon/${{ matrix.source }}.gpkg" ]; then
+            aws s3 cp "store/polygon/${{ matrix.source }}.gpkg" "s3://$DATA_BUCKET/bathymetry/polygon/${{ matrix.source }}.gpkg"
+          fi
           # The container writes store/ as root, so write the marker to R2 from stdin
           # (not into the root-owned dir); --exclude above keeps --delete off it.
           printf '%s' "${{ steps.check.outputs.hash }}" | aws s3 cp - "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/.recipe-hash"
@@ -228,6 +240,20 @@ jobs:
           # so the sharded downsample job downstream sees the same plan from R2.
           docker run --rm -v "$PWD:/app" -e BBOX -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just cover
           docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just downsample-cover
+      - name: Build coverage.pmtiles
+        run: |
+          # Source-provenance footprints → their own small tileset (z0-8; the renderer
+          # overzooms it past that, independent of vector.pmtiles). Built here, not in
+          # contour-bundle: plan just wrote the covering, whose aggregation CSVs are the
+          # authoritative per-source maxzoom (metadata.json max_zoom is only an optional
+          # cap most sources omit). `just coverage` fails loudly when bathymetry/polygon/
+          # is empty — a planet build without footprints is a broken build, not a
+          # fallback; the silent drop is how the layer went missing from every release.
+          mkdir -p store/polygon
+          aws s3 sync "s3://$DATA_BUCKET/bathymetry/polygon" store/polygon
+          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just coverage
+          aws s3 cp store/bundle/coverage.pmtiles "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/coverage.pmtiles" \
+            --content-type application/octet-stream
       - name: Freeze the dirty work lists
         run: |
           # Compute the aggregate + downsample dirty sets ONCE, from this single R2 listing
@@ -637,15 +663,12 @@ jobs:
         run: |
           aws s3 cp store/bundle "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-shards/" \
             --recursive --exclude '*' --include '*-shard-*.pmtiles' --content-type application/octet-stream
-          # Global contour maxz (identical from every shard) — contour-bundle's merge needs
-          # it to tile the coverage layer to the same depth as the contours.
-          aws s3 cp store/contour-maxz.txt "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-maxz.txt"
 
-  # tile-join the per-shard pmtiles (contours + soundings + drying slices) + coverage
-  # into one vector.pmtiles, in ONE join: tile-join rewrites every tile of the whole
+  # tile-join the per-shard pmtiles (contours + soundings + drying + depare slices) into
+  # one vector.pmtiles, in ONE join: tile-join rewrites every tile of the whole
   # archive, so the old merge-then-fold-per-layer shape re-paid the planet-wide join
   # per layer (~90 min each, serial, as the only job left running — the last 2 h 40
-  # of the build).
+  # of the build). Coverage is its own tileset, built by the plan job.
   contour-bundle:
     needs: contours
     if: ${{ !cancelled() && needs.contours.result == 'success' }}
@@ -658,8 +681,7 @@ jobs:
         run: |
           mkdir -p store/bundle
           aws s3 sync "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-shards" store/bundle
-          aws s3 cp "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/contour-maxz.txt" store/contour-maxz.txt
-      - name: Merge shards + fold coverage
+      - name: Merge shards
         run: docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just contour-merge
       - name: Push vector.pmtiles to R2 build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           node worker/src/terrarium.test.mjs
           node worker/src/overlay.test.mjs
           node worker/src/cache.test.mjs
+          node worker/src/coverage.test.mjs
       - name: Worker type-check (imports @openwaters/seascape across packages)
         working-directory: worker
         run: npx tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,11 @@ jobs:
             echo "::error::No build at $src/ — release/dispatch a commit that was built on main."
             exit 1
           fi
-          # contour-maxz.txt is a build-only handoff; contour-shards/bundle-frags are build scratch.
+          # contour-shards/bundle-frags are build scratch.
           # manifest.json copied separately, last, so a crash mid-copy never leaves a false marker.
           rclone copy "$src" "$dst" --transfers 16 --checkers 16 \
             --exclude 'contour-shards/**' --exclude 'bundle-frags/**' \
-            --exclude 'manifest.json' --exclude 'contour-maxz.txt'
+            --exclude 'manifest.json'
           rclone copyto "$src/manifest.json" "$dst/manifest.json"
       - name: Prune old releases (keep newest 3)
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,13 +91,14 @@ Four stages — `source → aggregation → downsampling → bundle` — all wri
 - **source** (`source_*.py`, per `sources/<id>/`): fetch → datum offset → normalize to a 4326 COG → `bounds.csv` → coverage polygon → tarball. Each source owns its recipe (`sources/<id>/Justfile`) composing the shared steps. Priority derives from `(maxzoom, id)` — GEBCO loses (smallest maxzoom), so regional sources win in overlap.
 - **aggregation** (`aggregation_*.py`): `cover` slices the planet into source-aware aggregation tiles (one CSV each); `run` reprojects each source by priority into a merged Float32 DEM (Gaussian seam feather), slope-smooths it (`smooth.py`), encodes Terrarium raster tiles, and forks contours (`contour_run.py`) and soundings (`soundings_run.py`) off the same merged DEM. Sources flagged `land_clamp` (GEBCO/EMODnet — coarse, no land/water concept) get their negative land pixels clamped to 0 against the OSM land mask (`landmask.py`, prep once with `just landmask`) right after warp, so shoreline cells don't paint false water/contours/soundings over land. The same mask feeds a `drying_run.py` fork: it polygonizes the green foreshore (elevation in `[0, DRYING_CAP]` seaward of the land line — chart drying areas) into the `drying` layer. A `depare_run.py` fork buckets the same merged DEM into depth-area partitions (ENC DEPARE: water between charted isobaths, `drval1`/`drval2` depth bounds) — the vector twin of the raster depth shading.
 - **downsampling**: 2×2-average overview pyramid below each source's native maxzoom.
-- **bundle** (`bundle.py`): concat single-zoom pmtiles into `planet.pmtiles` + one overlay archive per populated grid cell + `manifest.json`; contours, soundings, and drying/depare/coverage layers bundle into `vector.pmtiles` via tippecanoe.
+- **bundle** (`bundle.py`): concat single-zoom pmtiles into `planet.pmtiles` + one overlay archive per populated grid cell + `manifest.json`; contours, soundings, and drying/depare layers bundle into `vector.pmtiles` via tippecanoe; the per-source coverage footprints bundle standalone into `coverage.pmtiles` (`just coverage`).
 
 A full build (`planet`) lands in `pipelines/store/bundle/`:
 
 - `planet.pmtiles` — the all-sources-merged base (Terrarium-encoded raster, per-zoom quantized), z0–`macrotile_z` (z8 = GEBCO native, no upsampling).
 - `overlay-{z}-{x}-{y}.pmtiles` — one per populated `OVERLAY_SPLIT_Z` grid cell (default z5), z`macrotile_z+1`→cell-max, carrying the GEBCO-filled merged mosaic under that cell.
-- `vector.pmtiles` — MVT vector source: `contours` (GEBCO baked to the deepest zoom by tippecanoe) plus the folded-in `soundings`, `drying` (green-foreshore polygons), `depare` (depth-band partitions, z6+), and `coverage` layers.
+- `vector.pmtiles` — MVT vector source: `contours` (GEBCO baked to the deepest zoom by tippecanoe) plus the folded-in `soundings`, `drying` (green-foreshore polygons), and `depare` (depth-band partitions, z6+) layers.
+- `coverage.pmtiles` — source-provenance footprints, its own tileset ending at z8 (MapLibre overzooms it independently; inside `vector.pmtiles` the sea-sized fills either minted millions of deep-ocean tiles or vanished above their zoom).
 - `manifest.json` — planet metadata + `overlay.cells` ({cell: max_zoom}) for the Worker.
 
 ### Why a planet cap + grid overlays
@@ -118,9 +119,11 @@ The Worker presents one endpoint per layer and resolves per tile:
 
 ```
 GET /seascape/{z}/{x}/{y}.webp   raster: z≤8 → planet · z>8 in a populated grid cell → that cell's overlay · else → overzoom the planet · miss → transparent
-GET /seascape/{z}/{x}/{y}.pbf    vector: vector.pmtiles passthrough (contours, soundings, drying, depare, coverage layers)
+GET /seascape/{z}/{x}/{y}.pbf    vector: vector.pmtiles passthrough (contours, soundings, drying, depare layers)
+GET /seascape/coverage/{z}/{x}/{y}.pbf  coverage.pmtiles passthrough (source-provenance footprints)
 GET /seascape/raster.json        TileJSON (terrarium raster)
 GET /seascape/vector.json        TileJSON (vector layers)
+GET /seascape/coverage.json      TileJSON (coverage footprints)
 ```
 
 This keeps the base at native z8 (no global upsampling) while presenting one

--- a/Justfile
+++ b/Justfile
@@ -26,9 +26,12 @@ sources:
 
 # Planet build: cover -> aggregate -> downsample -> bundle -> vector layers (BBOX="W,S,E,N"
 # for a region). Soundings + drying + depare bundle BEFORE contours: the contours tile-join
-# folds their pmtiles into vector.pmtiles in the same single pass.
+# folds their pmtiles into vector.pmtiles in the same single pass. Coverage right after cover
+# (it needs only footprints + the covering) so missing footprints fail in the first minute,
+# not after hours of aggregation.
 planet:
     just cover
+    just coverage
     uv run python aggregation_run.py
     just combine
     just soundings
@@ -118,6 +121,12 @@ drying:
 depare:
     uv run python depare_run.py bundle
 
+# Source-provenance footprints -> their own store/bundle/coverage.pmtiles (z0-8;
+# the renderer overzooms it deeper). Needs store/polygon/*.gpkg + a covering;
+# fails loudly without footprints — a build without them ships a dead layer.
+coverage:
+    uv run python contour_run.py coverage
+
 # tippecanoe this shard's local slice of every vector layer -> {contours,soundings,
 # drying,depare}-shard-{i}.pmtiles (CI pulls only the shard's slices + writes
 # store/contour-maxz.txt so all layers tile to one depth; merged by contour-merge).
@@ -130,7 +139,7 @@ vector-shard i:
     uv run python drying_run.py bundle-shard {{i}}
     uv run python depare_run.py bundle-shard {{i}}
 
-# tile-join the per-shard pmtiles (all layers) + coverage into vector.pmtiles.
+# tile-join the per-shard pmtiles (all layers) into vector.pmtiles.
 contour-merge:
     uv run python contour_run.py bundle-merge
 
@@ -150,10 +159,17 @@ preview bbox="-74.30,40.40,-73.75,40.80" local="":
     if [ -z "{{local}}" ]; then
         export SOURCE_VSI_BASE="${SOURCE_VSI_BASE:-/vsicurl/https://data.openwaters.io/bathymetry/source}"
         BOUNDS_BASE="${BOUNDS_BASE:-https://data.openwaters.io/bathymetry/source}"
+        POLY_BASE="${POLY_BASE:-${BOUNDS_BASE%/source}/polygon}"
+        mkdir -p store/polygon
         for id in $(uv run python -c "import config; print('\n'.join(config.sources()))"); do
             mkdir -p "store/source/$id"
             curl -fsS "$BOUNDS_BASE/$id/bounds.csv" -o "store/source/$id/bounds.csv" \
                 || { echo "skip $id (no bounds.csv in R2)"; rm -rf "store/source/$id"; }
+            # Provenance footprint for the coverage tileset (streaming sources have none).
+            # Replace only on success — a 404 must not clobber a locally-prepared polygon.
+            curl -fsS "$POLY_BASE/$id.gpkg" -o "store/polygon/$id.gpkg.tmp" \
+                && mv "store/polygon/$id.gpkg.tmp" "store/polygon/$id.gpkg" \
+                || rm -f "store/polygon/$id.gpkg.tmp"
         done
         # S-102 re-registers from a live catalog (and may not be in R2 yet), so re-sync it
         just source noaa_s102

--- a/docs/plans/coverage-pmtiles.md
+++ b/docs/plans/coverage-pmtiles.md
@@ -1,0 +1,140 @@
+# Coverage as its own tileset (coverage.pmtiles)
+
+## Goal
+
+Ship the source-provenance layer for real. Today it doesn't exist in any published
+build: the planet bundle silently drops `coverage` because the footprint polygons
+never reach the CI bundle job, and the viewer's "Source coverage" checkbox renders
+nothing — click-to-identify names every point "GEBCO (global)". Fixing the supply
+alone isn't enough, because coverage can't live in `vector.pmtiles` at any zoom
+range without breaking something (below). Serve it as its own small tileset with
+its own low maxzoom and let MapLibre's per-source overzoom carry it to every zoom.
+
+## Why it can't stay in vector.pmtiles — the zoom-range trap
+
+A tile-joined archive makes every layer share one zoom range, and coverage is the
+one layer that fits at neither end:
+
+- **Tiled to the shared max (z14, today's `_coverage_pmtiles(maxz)`):** footprints
+  are sea-sized *fill* polygons (EMODnet = all European waters). tippecanoe emits a
+  tile for every zoom across a feature's whole extent and `tile-join` unions tile
+  sets, so the archive gains millions of deep-ocean tiles containing nothing but a
+  polygon slice — tiles contours/soundings/drying never create. Only survivable
+  today because the layer is being dropped.
+- **Tiled low (z8):** above z8 the joined tiles still exist (contours), just without
+  a coverage layer — and MapLibre only overzooms a missing *tile*, never a missing
+  layer. Click-to-identify silently dies above z8. This is the drying/soundings
+  vanishing-layer bug again, but the fix used there ("tile to the shared max") is
+  the first bullet.
+
+A separate tileset dissolves the trap: `coverage.pmtiles` ends at z8, MapLibre
+overzooms it independently of the vector source, and the fat, rarely-toggled
+provenance bytes leave the hot vector path entirely.
+
+## Part 1 — get the footprints (and maxzooms) into CI
+
+The source stage builds `store/polygon/<id>.gpkg` (the per-source union footprint
+`contour_run._coverage_geojson()` reads), but the sources job syncs only
+`store/source/<id>` to R2 and no later job pulls polygons — `build.yml` mentions
+"polygon" only in comments. `_coverage_geojson()` then globs an empty dir, returns
+`None`, and `_finalize_contours` takes the shard-job fallback ("coverage is dropped
+from the join when no footprints are present locally") on every planet build.
+
+- **sources job:** after the store sync, `aws s3 cp store/polygon/<id>.gpkg
+  s3://$DATA_BUCKET/bathymetry/polygon/<id>.gpkg` (guarded: streaming-only sources
+  like CUDEM may have no polygon). Same `.recipe-hash` skip as the rest of the
+  recipe — the polygon only changes when the source rebuilds.
+- **Build coverage in the `plan` job**, not contour-bundle: plan has the covering
+  locally, so `_source_maxzooms()` works unchanged (it reads the newest covering's
+  aggregation CSVs). contour-bundle has no covering, and `metadata.json` `max_zoom`
+  is only an optional cap — absent for DDM/EMODnet/vaklodingen/AusBathyTopo/both
+  GSCs — so building there would need a new maxzoom sidecar for no benefit.
+  The plan job pulls `bathymetry/polygon/*.gpkg` into `store/polygon/`, runs
+  `just coverage` (below) in the container, and pushes
+  `build/<sha>/coverage.pmtiles`. Coverage depends on footprints + covering only —
+  nothing from aggregate — so plan is also the earliest it can build.
+- **Make the empty case loud where it's wrong:** `_coverage_geojson()` returning
+  `None` stays valid for contour shard jobs, but the new `coverage` recipe must
+  fail (non-zero) when it finds no polygons — a planet build without footprints is
+  a broken build, not a fallback. The silent drop is how this bug shipped.
+
+## Part 2 — bundle standalone
+
+In `contour_run.py` (the footprint code already lives there):
+
+- `_coverage_pmtiles(maxz)` becomes `coverage_bundle()` → `store/bundle/coverage.pmtiles`,
+  CLI `contour_run.py coverage`, Justfile recipe `coverage`, wired into the local
+  `just planet` flow. `_finalize_contours` loses its coverage input and the
+  "dropped from the join" branch — the single tile-join no longer sees coverage.
+- tippecanoe: `-l coverage -Z 0 -z 8 --no-tile-size-limit` (keep footprints whole;
+  `COVERAGE_MAX_ZOOM` env knob). z8 loses nothing: footprints are already
+  simplified to 0.001° (~100 m) and a z8 tile's 4096 MVT grid resolves ~37 m —
+  geometry fidelity is simplify-bound, not zoom-bound. Global tile count at z8 is
+  bounded at 65k and footprints cover a fraction of it.
+- `bundle_maxz` deliberately NOT used — that helper exists to keep layers *inside*
+  the joined tileset alive to its max; coverage's whole point is to leave the join.
+- Ships automatically: `worker/seed.sh` seeds `store/bundle/*.pmtiles` and
+  release.yml's rclone promotes everything except manifest/contour-maxz, manifest
+  last. No manifest change: the Worker reads zooms/bounds from the pmtiles header,
+  like `/vector.json` does; `source_ids` (viewer palette) is already there.
+
+## Part 3 — Worker
+
+Two additions in `worker/src/index.ts`, both reusing the existing `pm()`/`tile()`/
+`sendTile` machinery and the content-ETag + colo-cache path (release-scoped cache
+keys make it self-invalidating; nothing new to purge):
+
+- **`GET /coverage.json`** — TileJSON like `/vector.json`: header-derived
+  minzoom/maxzoom/bounds from `coverage.pmtiles`, tiles
+  `${tilesBase}/coverage/{z}/{x}/{y}.pbf`, the `coverage` vector_layer entry
+  (`source_id`, `source_name`, `source_maxzoom`), manifest attribution.
+- **`GET /coverage/{z}/{x}/{y}.pbf`** — match a `/coverage/...` prefix before the
+  existing tile regex; serve from `coverage.pmtiles`, 204 on a miss (same `noTile`
+  contract as vector). Out-of-range x/y → 204, uncached.
+- Remove the `coverage` entry from `/vector.json`'s hardcoded `vector_layers`.
+- A missing `coverage.pmtiles` (old release being served by a new Worker) must
+  degrade to 204s/an empty TileJSON, not 500s — same tolerance the manifest code
+  extends to pre-grid releases.
+- Tests: `coverage.json` shape, a tile round-trip, miss → 204, absent archive →
+  degraded not thrown (alongside the existing `*.test.mjs`).
+
+## Part 4 — style package + viewer
+
+- `style/index.ts` `sources()` gains
+  `"seascape-coverage": { type: "vector", url: `${tilesBase}/coverage.json` }`;
+  the four `source-*` layers move `source:` to it (a `coverage` source-name param
+  next to `dem`/`vector`). `style()` output — which the Worker serves at
+  `/style.json` — picks the change up from the same function.
+- Versioning: by the letter of the package's policy (semver against the tile
+  schema) removing `coverage` from the vector tileset is a major. In practice no
+  published build has ever contained the layer, so nothing can depend on it;
+  recommend shipping as a minor with a CHANGELOG note saying exactly that, and
+  reserving the major for schema changes that can actually strand a consumer.
+- Viewer (`index.js`): no logic change — `sourceAt()` queries by layer id
+  (`source-fill`) and the checkbox toggles visibility; both follow the layer to
+  its new source. Rebuild `style/dist` (wrangler dev and `vite build` read dist).
+
+## Rejected alternatives
+
+- **Coverage in vector.pmtiles at full depth, boundaries-only:** outlines tile
+  cheaply but click-to-identify needs fills; `queryRenderedFeatures` on lines
+  can't answer "which footprint contains this point".
+- **Worker-side merge (inject coverage into vector tiles at request time by
+  overzooming coverage.pmtiles and splicing layers):** re-encoding MVT per request
+  on the hot path to avoid one extra source declaration — all cost, no benefit.
+- **Sidecar maxzoom file for contour-bundle** instead of building in plan: works,
+  but adds a build artifact and a second home for "which zoom is this source" when
+  the covering — the authoritative answer — is already sitting in the plan job.
+
+## Verification
+
+1. `just preview` (Æbelø/Odense bbox): `store/bundle/coverage.pmtiles` exists;
+   `pmtiles show` says z0–8; the z8 tile at Æbelø has DDM + EMODnet footprints
+   with real `source_maxzoom` (10, not 0).
+2. `vector.pmtiles` no longer contains a coverage layer at any zoom.
+3. Dev worker: `/coverage.json` sane; `/coverage/8/135/80.pbf` → 200,
+   `/coverage/8/0/0.pbf` (open ocean) → 204; `/vector.json` no longer lists it.
+4. Viewer at z13 over Æbelø: checkbox shows footprints (overzoomed z8 fills),
+   click names DDM — not "GEBCO (global)" — and deepest-wins ordering is exercised
+   where DDM overlaps EMODnet.
+5. CI dry-run: plan job fails loudly if `bathymetry/polygon/` is empty.

--- a/docs/plans/coverage-pmtiles.md
+++ b/docs/plans/coverage-pmtiles.md
@@ -74,9 +74,10 @@ In `contour_run.py` (the footprint code already lives there):
 - `bundle_maxz` deliberately NOT used — that helper exists to keep layers *inside*
   the joined tileset alive to its max; coverage's whole point is to leave the join.
 - Ships automatically: `worker/seed.sh` seeds `store/bundle/*.pmtiles` and
-  release.yml's rclone promotes everything except manifest/contour-maxz, manifest
-  last. No manifest change: the Worker reads zooms/bounds from the pmtiles header,
-  like `/vector.json` does; `source_ids` (viewer palette) is already there.
+  release.yml's rclone promotes everything except build scratch
+  (contour-shards/bundle-frags), manifest last. No manifest change: the Worker
+  reads zooms/bounds from the pmtiles header, like `/vector.json` does;
+  `source_ids` (viewer palette) is already there.
 
 ## Part 3 — Worker
 

--- a/index.js
+++ b/index.js
@@ -127,21 +127,21 @@ map.on("load", () => {
 });
 
 // ─── Click to inspect ─────────────────────────────────────────────────────
-// Which source covers a clicked point: the deepest footprint wins (lex-first id on a
-// tie), matching the build's merge rule, so this names the source the depth came from.
-// undefined → coverage layer hidden (skip the line); null → no footprint here = GEBCO.
-function sourceAt(point) {
+// Which sources cover a clicked point, deepest footprint first (lex-first id on
+// a tie) — the build's merge rule, so [0] names the source the depth came from
+// and the rest are the overlapped alternates. Deduped by id: a footprint split
+// across tile boundaries hits once per fragment.
+// undefined → coverage layer hidden (skip the line); [] → no footprint = GEBCO.
+function sourcesAt(point) {
   if (map.getLayoutProperty("source-fill", "visibility") === "none")
     return undefined;
   const hits = map.queryRenderedFeatures(point, { layers: ["source-fill"] });
-  if (!hits.length) return null;
-  return hits
-    .map((f) => f.properties)
-    .sort(
-      (a, b) =>
-        b.source_maxzoom - a.source_maxzoom ||
-        (a.source_id < b.source_id ? -1 : 1),
-    )[0];
+  const byId = new Map(hits.map((f) => [f.properties.source_id, f.properties]));
+  return [...byId.values()].sort(
+    (a, b) =>
+      b.source_maxzoom - a.source_maxzoom ||
+      (a.source_id < b.source_id ? -1 : 1),
+  );
 }
 
 map.on("click", async (e) => {
@@ -150,12 +150,12 @@ map.on("click", async (e) => {
     e.lngLat,
     Math.min(map.getZoom(), MAX_ZOOM),
   );
-  const src = sourceAt(e.point);
+  const srcs = sourcesAt(e.point);
   if (map.getLayer("source-highlight"))
     map.setFilter("source-highlight", [
       "==",
       ["get", "source_id"],
-      src?.source_id ?? "__none__",
+      srcs?.[0]?.source_id ?? "__none__",
     ]);
 
   const lines = [];
@@ -169,10 +169,13 @@ map.on("click", async (e) => {
       }</strong>`,
     );
   }
-  if (src !== undefined)
+  if (srcs !== undefined) {
     lines.push(
-      `<small>source: ${src ? src.source_name : "GEBCO (global)"}</small>`,
+      `<small>source: ${srcs[0]?.source_name ?? "GEBCO (global)"}</small>`,
     );
+    for (const s of srcs.slice(1))
+      lines.push(`<small>also covered by: ${s.source_name}</small>`);
+  }
   if (!lines.length) return;
 
   new maplibregl.Popup()

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -260,11 +260,21 @@ def bundle_maxz(own_max):
 
 # ── source coverage (provenance) layer ───────────────────────────────────────
 # Tile each source's union footprint (store/polygon/<id>.gpkg, from the source stage)
-# into a `coverage` layer alongside `contours` in the same pmtiles, so the viewer can
-# show which source covers a clicked point. GEBCO (the global base) declares no
-# max_zoom, so it's skipped; only regional footprints get a polygon.
+# into its own store/bundle/coverage.pmtiles, so the viewer can show which source
+# covers a clicked point. Its own tileset, NOT a layer in vector.pmtiles: a joined
+# archive shares one zoom range, and sea-sized fill polygons tiled to the contours'
+# maxzoom mint millions of deep-ocean tiles, while tiled lower the layer vanishes
+# above its maxzoom (MapLibre overzooms a missing *tile*, never a missing *layer*).
+# Standalone, the renderer overzooms it past COVERAGE_MAX_ZOOM on its own. GEBCO
+# (the global base) declares no max_zoom, so it's skipped; only regional footprints
+# get a polygon.
 
 BASE_SOURCE = "gebco"  # the global fallback; its footprint is the whole planet, never an overlay
+
+# z8's 4096-cell MVT grid resolves ~37 m and the footprints are already simplified
+# to 0.001° (~100 m) — fidelity is simplify-bound, not zoom-bound — while the z8
+# tile address space caps the archive at 65k tiles.
+COVERAGE_MAX_ZOOM = int(os.environ.get("COVERAGE_MAX_ZOOM", "8"))
 
 
 def _source_maxzooms():
@@ -287,7 +297,7 @@ def _source_maxzooms():
 def _coverage_geojson():
     """Combine every regional source's simplified footprint into one GeoJSON FC with
     {source_id, source_name, source_maxzoom}; write it and return the path. None if no
-    polygons are present locally (e.g. a CI contour job that only pulled FGB slices)."""
+    polygons are present locally (coverage_bundle turns that into a hard failure)."""
     valid = set(config.sources())
     zmax = _source_maxzooms()
     feats = []
@@ -315,35 +325,40 @@ def _coverage_geojson():
     return path
 
 
-def _coverage_pmtiles(maxz):
+def coverage_bundle():
     """tippecanoe the source footprints into store/bundle/coverage.pmtiles (layer
-    `coverage`, z0..maxz, footprints kept whole). None when no footprints are local."""
+    `coverage`, z0..COVERAGE_MAX_ZOOM, footprints kept whole). Fails when no
+    footprints are local: a planet build without them ships a dead provenance
+    layer — the silent drop is exactly how the layer went missing from every
+    published build. (Contour shard jobs never take this path; only the plan job
+    and a local `just planet` build coverage.)"""
     src = _coverage_geojson()
     if not src:
-        return None
-    out = "store/contour/coverage.pmtiles"  # intermediate (not store/bundle, which seed.sh ships)
+        raise SystemExit("coverage: no footprints in store/polygon/ — pull "
+                         "bathymetry/polygon/*.gpkg or prepare a source first")
+    utils.create_folder("store/bundle")
+    out = "store/bundle/coverage.pmtiles"
     subprocess.run(
         ["tippecanoe", "-o", out, "-f", "-l", "coverage", "-n", "Source coverage",
-         "-A", utils.ATTRIBUTION, "-Z", "0", "-z", str(maxz), "-P", "-q",
+         "-A", utils.ATTRIBUTION, "-Z", "0", "-z", str(COVERAGE_MAX_ZOOM), "-P", "-q",
          "--no-tile-size-limit", src], check=True)
-    return out
+    print(f"coverage bundle: {out} (z0-{COVERAGE_MAX_ZOOM})")
 
 
-def _finalize_contours(archives, maxz):
+def _finalize_contours(archives):
     """tile-join the layer archives (a local build's contour pmtiles, or the CI shards —
-    which carry contours, soundings, drying, AND depare slices) + the coverage layer + the
-    whole-set soundings/drying/depare pmtiles (local path, when their bundles ran first)
-    into store/bundle/vector.pmtiles. ONE join: tile-join rewrites every tile of the whole
+    which carry contours, soundings, drying, AND depare slices) + the whole-set
+    soundings/drying/depare pmtiles (local path, when their bundles ran first) into
+    store/bundle/vector.pmtiles. ONE join: tile-join rewrites every tile of the whole
     archive, so folding each sparse layer in afterwards re-paid the planet-wide join
     per layer (~90 min each in CI). -pk keeps every feature of every layer; a layer
-    whose pmtiles isn't present locally is simply not joined."""
-    cov = _coverage_pmtiles(maxz)
-    layers = [p for p in [cov, "store/bundle/soundings.pmtiles", "store/bundle/drying.pmtiles",
+    whose pmtiles isn't present locally is simply not joined. Coverage is its own
+    tileset (coverage_bundle), not a layer here."""
+    layers = [p for p in ["store/bundle/soundings.pmtiles", "store/bundle/drying.pmtiles",
                           "store/bundle/depare.pmtiles"]
-              if p and os.path.isfile(p)]
+              if os.path.isfile(p)]
     subprocess.run(["tile-join", "-o", "store/bundle/vector.pmtiles", "-f", "-pk",
                     *archives, *layers], check=True)
-    return cov is not None
 
 
 def _current_stems():
@@ -381,34 +396,29 @@ def bundle(shard=None):
         return
     maxz = bundle_maxz(_global_maxz(fgbs))
     utils.create_folder("store/bundle")
-    if shard is not None:  # CI: lines only; coverage joins once at the merge step
+    if shard is not None:  # CI: lines only; soundings/drying join once at the merge step
         out = f"store/bundle/contours-shard-{shard}.pmtiles"
         _tippecanoe(fgbs, 0, maxz, out)
         print(f"contour shard {shard}: {out} (z0-{maxz}, {len(fgbs)} FGBs)")
         return
-    # Local whole-set: tippecanoe the lines, then fold in the coverage layer.
+    # Local whole-set: tippecanoe the lines, then fold in soundings/drying.
     lines = "store/contour/contours-lines.pmtiles"
     _tippecanoe(fgbs, 0, maxz, lines)
-    cov = _finalize_contours([lines], maxz)
+    _finalize_contours([lines])
     os.remove(lines)
-    print(f"contour bundle: store/bundle/vector.pmtiles (z0-{maxz}, {len(fgbs)} FGBs"
-          f"{', + coverage layer' if cov else ''})")
+    print(f"contour bundle: store/bundle/vector.pmtiles (z0-{maxz}, {len(fgbs)} FGBs)")
 
 
 def bundle_merge():
     """tile-join the per-shard pmtiles — contours, soundings, drying (each shard job
-    bundles its slice of all three) — + the coverage layer into one vector.pmtiles
-    (-pk keeps every feature; the shards are disjoint file slices unioned per tile)."""
+    bundles its slice of all three) — into one vector.pmtiles (-pk keeps every
+    feature; the shards are disjoint file slices unioned per tile)."""
     shards = sorted(glob("store/bundle/*-shard-*.pmtiles"))
     if not shards:
         print("contour merge: no shard pmtiles")
         return
-    maxzfile = "store/contour-maxz.txt"  # the CI shard path always writes this (shared global maxz)
-    if not os.path.isfile(maxzfile):
-        raise SystemExit("contour merge: store/contour-maxz.txt missing (the shard jobs write it)")
-    cov = _finalize_contours(shards, int(open(maxzfile).read().strip()))
-    print(f"contour merge: store/bundle/vector.pmtiles ({len(shards)} shard archives"
-          f"{', + coverage layer' if cov else ''})")
+    _finalize_contours(shards)
+    print(f"contour merge: store/bundle/vector.pmtiles ({len(shards)} shard archives)")
 
 
 def _check():
@@ -448,7 +458,9 @@ if __name__ == "__main__":
         bundle(int(a[1]))
     elif a[:1] == ["bundle-merge"]:
         bundle_merge()
+    elif a[:1] == ["coverage"]:
+        coverage_bundle()
     elif a[:1] == ["check"]:
         _check()
     else:
-        sys.exit("usage: contour_run.py bundle | bundle-shard <i> | bundle-merge | check")
+        sys.exit("usage: contour_run.py bundle | bundle-shard <i> | bundle-merge | coverage | check")

--- a/style/README.md
+++ b/style/README.md
@@ -13,7 +13,8 @@ style.
 ## Usage
 
 Whole style (OSM raster base + bathymetry). Zooms, bounds, and attribution
-come from the endpoint's TileJSON (`raster.json` / `vector.json`) — no other
+come from the endpoint's TileJSON (`raster.json` / `vector.json` /
+`coverage.json`) — no other
 fetch needed:
 
 ```js
@@ -88,6 +89,11 @@ layers({ ...day, hazard: "#c00", font: ["Noto Sans Regular"] });
 Semver against the *tile schema* (protomaps' policy): renaming or removing a
 vector layer or feature property the style reads is a major; additive tile or
 style changes are minor; visual-only tweaks are patch.
+
+0.2.0 moved the `coverage` layer out of the vector tileset into its own
+`coverage.json` source (the `source-*` layers follow it). By the letter that's
+a major, but no published build ever contained the layer — nothing could have
+consumed it — so it ships as a minor.
 
 ## Development
 

--- a/style/README.md
+++ b/style/README.md
@@ -90,11 +90,6 @@ Semver against the *tile schema* (protomaps' policy): renaming or removing a
 vector layer or feature property the style reads is a major; additive tile or
 style changes are minor; visual-only tweaks are patch.
 
-0.2.0 moved the `coverage` layer out of the vector tileset into its own
-`coverage.json` source (the `source-*` layers follow it). By the letter that's
-a major, but no published build ever contained the layer — nothing could have
-consumed it — so it ships as a minor.
-
 ## Development
 
 TypeScript; `tsc` emits `dist/` on install (`prepare`) and via `npm run

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -43,6 +43,7 @@ test("sources reference the endpoint's TileJSON, encoding inline", () => {
   // MapLibre doesn't read `encoding` from TileJSON — it must be inline.
   expect(src["seascape-dem"].encoding).toBe("terrarium");
   expect(src["seascape-vector"].url).toBe("https://t.example/vector.json");
+  expect(src["seascape-coverage"].url).toBe("https://t.example/coverage.json");
 });
 
 test("unit/safety reach the layers as literals", () => {
@@ -89,10 +90,17 @@ test("depthRelief stops stay strictly ascending for any safety depth", () => {
 });
 
 test("layers reference only the caller's source names", () => {
-  const named = layers(day, { dem: "bathy-dem", vector: "bathy" });
+  const named = layers(day, {
+    dem: "bathy-dem",
+    vector: "bathy",
+    coverage: "bathy-coverage",
+  });
   expect(
     [...new Set(named.map((l) => (l as { source: string }).source))].sort(),
-  ).toEqual(["bathy", "bathy-dem"]);
+  ).toEqual(["bathy", "bathy-coverage", "bathy-dem"]);
+  // The source-* provenance layers read the coverage source, not vector.
+  for (const l of named.filter((l) => l.id.startsWith("source-")))
+    expect((l as { source: string }).source).toBe("bathy-coverage");
 });
 
 test("contour lines floor at z6 — depth shading carries lower zooms", () => {

--- a/style/index.ts
+++ b/style/index.ts
@@ -230,16 +230,21 @@ export function depthAreasColor(
 
 // ─── Sources ─────────────────────────────────────────────────────────────────
 // tilesBase is the Worker endpoint; the sources reference its TileJSON docs
-// (raster.json / vector.json), which carry the tile URLs, zoom range, bounds,
-// and the combined per-source attribution.
+// (raster.json / vector.json / coverage.json), which carry the tile URLs, zoom
+// range, bounds, and the combined per-source attribution. Coverage is its own
+// source: its tileset ends at a low maxzoom and MapLibre overzooms it
+// independently of the vector source (a layer inside vector.pmtiles would
+// vanish above the zoom it was tiled to).
 export function sources({
   tilesBase,
   dem = "seascape-dem",
   vector = "seascape-vector",
+  coverage = "seascape-coverage",
 }: {
   tilesBase: string;
   dem?: string;
   vector?: string;
+  coverage?: string;
 }): Record<string, SourceSpecification> {
   tilesBase = tilesBase.replace(/\/+$/, ""); // tolerate a trailing slash
   return {
@@ -254,6 +259,10 @@ export function sources({
       type: "vector",
       url: `${tilesBase}/vector.json`,
     },
+    [coverage]: {
+      type: "vector",
+      url: `${tilesBase}/coverage.json`,
+    },
   };
 }
 
@@ -263,12 +272,14 @@ export function layers(
   {
     dem = "seascape-dem",
     vector = "seascape-vector",
+    coverage = "seascape-coverage",
     unit = DEFAULT_UNIT,
     safety = DEFAULT_SAFETY,
     shading = DEFAULT_SHADING,
   }: {
     dem?: string;
     vector?: string;
+    coverage?: string;
     unit?: Unit;
     safety?: number;
     shading?: Shading;
@@ -435,12 +446,12 @@ export function layers(
       },
     },
     // Source coverage (provenance): footprint polygons with props source_id /
-    // source_name / source_maxzoom. Hidden by default; a viewer can toggle
-    // them on for click-to-identify.
+    // source_name / source_maxzoom, from the standalone coverage tileset.
+    // Hidden by default; a viewer can toggle them on for click-to-identify.
     {
       id: "source-fill",
       type: "fill",
-      source: vector,
+      source: coverage,
       "source-layer": "coverage",
       layout: { visibility: "none" },
       paint: { "fill-color": coverageColor, "fill-opacity": 0.12 },
@@ -449,7 +460,7 @@ export function layers(
       // Brightened fill of one source (filter set by the consumer on click).
       id: "source-highlight",
       type: "fill",
-      source: vector,
+      source: coverage,
       "source-layer": "coverage",
       filter: ["==", ["get", "source_id"], "__none__"],
       layout: { visibility: "none" },
@@ -458,7 +469,7 @@ export function layers(
     {
       id: "source-outline",
       type: "line",
-      source: vector,
+      source: coverage,
       "source-layer": "coverage",
       layout: { visibility: "none" },
       paint: { "line-color": coverageColor, "line-width": 1.5 },
@@ -466,7 +477,7 @@ export function layers(
     {
       id: "source-labels",
       type: "symbol",
-      source: vector,
+      source: coverage,
       "source-layer": "coverage",
       layout: {
         visibility: "none",

--- a/style/package.json
+++ b/style/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwaters/seascape",
-  "version": "0.1.0",
-  "description": "MapLibre GL style for Open Waters bathymetry tiles — depth shading, contours, soundings, drying areas",
+  "version": "0.2.0",
+  "description": "MapLibre GL style for Open Waters bathymetry tiles \u2014 depth shading, contours, soundings, drying areas",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "dist/index.js",

--- a/worker/src/coverage.test.mjs
+++ b/worker/src/coverage.test.mjs
@@ -1,0 +1,39 @@
+// Run: node src/coverage.test.mjs   (Node ≥22.18 strips the imported .ts)
+import assert from "node:assert/strict";
+import { coverageTileJSON } from "./coverage.ts";
+
+// Shape with a real header (what /coverage.json serves for a coverage-bearing release).
+const h = {
+  minZoom: 0,
+  maxZoom: 8,
+  minLon: -180,
+  minLat: -66,
+  maxLon: 180,
+  maxLat: 84,
+};
+const tj = coverageTileJSON(h, "https://tiles.example/seascape", "credit");
+assert.equal(tj.tilejson, "3.0.0");
+assert.deepEqual(tj.tiles, [
+  "https://tiles.example/seascape/coverage/{z}/{x}/{y}.pbf",
+]);
+assert.equal(tj.minzoom, 0);
+assert.equal(tj.maxzoom, 8);
+assert.deepEqual(tj.bounds, [-180, -66, 180, 84]);
+assert.equal(tj.vector_layers.length, 1);
+assert.equal(tj.vector_layers[0].id, "coverage");
+assert.deepEqual(Object.keys(tj.vector_layers[0].fields).sort(), [
+  "source_id",
+  "source_maxzoom",
+  "source_name",
+]);
+assert.equal(tj.attribution, "credit");
+
+// Absent coverage.pmtiles (a pre-coverage release under a new Worker) degrades
+// to a valid empty document — same tiles URL (its requests 204), never a throw.
+const empty = coverageTileJSON(null, "http://localhost:8787", "");
+assert.equal(empty.minzoom, 0);
+assert.equal(empty.maxzoom, 0);
+assert.equal(empty.tiles[0], "http://localhost:8787/coverage/{z}/{x}/{y}.pbf");
+assert.equal(empty.bounds.length, 4);
+
+console.log("coverage.ts ok — TileJSON shape, absent-archive degradation");

--- a/worker/src/coverage.ts
+++ b/worker/src/coverage.ts
@@ -1,0 +1,45 @@
+// TileJSON for the standalone coverage tileset (source-provenance footprints,
+// its own coverage.pmtiles — see /coverage.json in index.ts). Separated from the
+// handler so the shape is testable under plain node (index.ts's WASM imports
+// aren't loadable there).
+
+export interface CoverageHeader {
+  minZoom: number;
+  maxZoom: number;
+  minLon: number;
+  minLat: number;
+  maxLon: number;
+  maxLat: number;
+}
+
+// header = null means coverage.pmtiles is absent (a pre-coverage release served
+// by a new Worker): degrade to a valid empty document — zero zooms, same tiles
+// URL (whose requests then 204) — never a throw/500.
+export function coverageTileJSON(
+  h: CoverageHeader | null,
+  tilesBase: string,
+  attribution: string,
+) {
+  return {
+    tilejson: "3.0.0",
+    name: "Open Waters Bathymetry (source coverage)",
+    tiles: [`${tilesBase}/coverage/{z}/{x}/{y}.pbf`],
+    minzoom: h?.minZoom ?? 0,
+    maxzoom: h?.maxZoom ?? 0,
+    bounds: h
+      ? [h.minLon, h.minLat, h.maxLon, h.maxLat]
+      : [-180, -85.051129, 180, 85.051129],
+    vector_layers: [
+      {
+        // Per-source data-extent polygons (provenance / click-to-identify).
+        id: "coverage",
+        fields: {
+          source_id: "String",
+          source_name: "String",
+          source_maxzoom: "Number",
+        },
+      },
+    ],
+    attribution,
+  };
+}

--- a/worker/src/coverage.ts
+++ b/worker/src/coverage.ts
@@ -22,7 +22,7 @@ export function coverageTileJSON(
 ) {
   return {
     tilejson: "3.0.0",
-    name: "Open Waters Bathymetry (source coverage)",
+    name: "Open Waters Seascape (source coverage)",
     tiles: [`${tilesBase}/coverage/{z}/{x}/{y}.pbf`],
     minzoom: h?.minZoom ?? 0,
     maxzoom: h?.maxZoom ?? 0,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,12 +2,14 @@
  * Unified bathymetry tile endpoint.
  *
  *   GET /seascape/{z}/{x}/{y}.webp  (or .png)  → Terrarium WebP (raster terrain)
- *   GET /seascape/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, soundings, drying, coverage)
+ *   GET /seascape/{z}/{x}/{y}.pbf   (or .mvt)  → MVT (vector — contours, soundings, drying)
+ *   GET /seascape/coverage/{z}/{x}/{y}.pbf     → MVT (source-provenance footprints)
  *
  * Extension picks the representation: webp/png → raster, pbf/mvt → vector.
  *
  * Reads the bundles published to R2 (planet.pmtiles + one overlay-{cell}.pmtiles
- * per populated grid cell + vector.pmtiles + manifest.json) and resolves per tile:
+ * per populated grid cell + vector.pmtiles + coverage.pmtiles + manifest.json)
+ * and resolves per tile:
  *   - z ≤ planet.max_zoom        → planet tile
  *   - z > planet.max_zoom, the tile's grid cell is populated → that cell's tile
  *     (or the overzoomed deepest ancestor present in the cell)
@@ -27,6 +29,7 @@
 import { PMTiles, Source, RangeResponse } from "pmtiles";
 import { style as seascapeStyle } from "@openwaters/seascape";
 import { CachedSource, contentEtag, OVERZOOM_TAG_VERSION } from "./cache";
+import { coverageTileJSON } from "./coverage";
 import { unpackTerrarium, packTerrariumInto, cubicBSpline } from "./terrarium";
 import { OverlayIndex, overlayFor } from "./overlay";
 // jSquash on Workers: WASM must be imported as a module and passed to init()
@@ -473,31 +476,23 @@ export default {
               sys: "String",
             },
           },
-          {
-            // Per-source data-extent polygons (provenance / click-to-identify).
-            id: "coverage",
-            fields: {
-              source_id: "String",
-              source_name: "String",
-              source_maxzoom: "Number",
-            },
-          },
         ],
         attribution: mf.attribution ?? "",
       });
     }
-    // Tiles: extension selects representation — webp/png → raster, pbf/mvt → vector.
-    const m = rel.match(/^\/(\d+)\/(\d+)\/(\d+)\.(png|webp|pbf|mvt)$/);
-    if (!m)
-      return new Response(`usage: ${base}/{z}/{x}/{y}.{webp,pbf}`, {
-        status: 404,
-        headers: CORS,
-      });
-    const z = +m[1],
-      x = +m[2],
-      y = +m[3];
-    const ext = m[4];
-
+    // Source-provenance footprints — their own tileset with a low maxzoom that
+    // MapLibre overzooms independently of the vector source (in vector.pmtiles
+    // the layer either minted millions of deep-ocean fill tiles or vanished
+    // above its zoom — a joined archive shares one zoom range).
+    if (rel === "/coverage.json") {
+      const mf = await manifest(env);
+      // Absent coverage.pmtiles (a pre-coverage release) → empty TileJSON, not
+      // a 500 — same tolerance manifest() extends to pre-grid releases.
+      const h = await pm(env, "coverage.pmtiles")
+        .getHeader()
+        .catch(() => null);
+      return json(coverageTileJSON(h, tilesBase, mf.attribution ?? ""));
+    }
     // Tiles validate by CONTENT, not release: ETag = hash of the tile bytes
     // (or of the native ancestor a synthesized tile is a pure function of).
     // An unchanged tile keeps its validator across releases, so clients
@@ -526,6 +521,33 @@ export default {
         ctx.waitUntil(caches.default.put(cacheKey, res.clone()));
       return inm === tag ? notModified(tag) : res;
     };
+
+    // Coverage tiles, from their own archive. A within-range miss (open ocean),
+    // out-of-range x/y, and an absent archive (pre-coverage release) all 204 —
+    // the same noTile contract as vector, never a 500.
+    const cov = rel.match(/^\/coverage\/(\d+)\/(\d+)\/(\d+)\.(pbf|mvt)$/);
+    if (cov) {
+      const cz = +cov[1],
+        cx = +cov[2],
+        cy = +cov[3];
+      if (cx >= 2 ** cz || cy >= 2 ** cz) return noTile();
+      const t = await tile(env, "coverage.pmtiles", cz, cx, cy).catch(
+        () => undefined,
+      );
+      return t ? sendTile(t, MVT, await contentEtag(t)) : noTile();
+    }
+
+    // Tiles: extension selects representation — webp/png → raster, pbf/mvt → vector.
+    const m = rel.match(/^\/(\d+)\/(\d+)\/(\d+)\.(png|webp|pbf|mvt)$/);
+    if (!m)
+      return new Response(`usage: ${base}/{z}/{x}/{y}.{webp,pbf}`, {
+        status: 404,
+        headers: CORS,
+      });
+    const z = +m[1],
+      x = +m[2],
+      y = +m[3];
+    const ext = m[4];
     // Overzoom: resolve the ancestor first — the validator derives from it, so
     // a matching revalidation skips the decode → B-spline → encode entirely.
     // (The 304 path doesn't populate the colo cache; the next full GET does.)


### PR DESCRIPTION
## Summary

The source-provenance layer never reached a published build: the footprint polygons never left the sources job, so every planet `vector.pmtiles` silently dropped its `coverage` layer — the viewer's "Source coverage" checkbox rendered nothing and click-to-identify named every point "GEBCO (global)". Coverage also can't live inside the joined tileset at any zoom range (fills tiled to z14 mint millions of deep-ocean tiles; tiled low, the layer vanishes above its maxzoom because MapLibre only overzooms missing *tiles*, never missing *layers*).

This ships it as its own small tileset, per the plan in `docs/plans/coverage-pmtiles.md`:

- **Pipeline**: `coverage_bundle()` tiles `store/polygon/*.gpkg` into a standalone `store/bundle/coverage.pmtiles` (z0–8, `COVERAGE_MAX_ZOOM` knob) and **fails loudly** when no footprints are present — the silent drop is how this bug shipped. `vector.pmtiles` no longer joins a coverage layer; the `contour-maxz.txt` handoff that existed only for it is removed. `just coverage` is wired into `just planet` right after `cover` so a missing-footprint failure is fast.
- **CI**: the sources job pushes each footprint to `bathymetry/polygon/`, and its currency check treats "recipe polygonizes but no footprint in R2" as stale so existing sources **backfill themselves once** (only volatile sources rebuild by default, and those build no polygons — without this the loud-fail would trip on every build forever; note this includes a one-time GEBCO re-prep). The plan job — which has the covering, the authoritative per-source maxzoom — builds `coverage.pmtiles` into `build/<sha>/`; release.yml promotes it unchanged. `just preview` pulls footprints from R2 (download-to-temp so a 404 never clobbers a locally-prepared polygon).
- **Worker**: `GET /coverage.json` (header-derived zooms/bounds) and `GET /coverage/{z}/{x}/{y}.pbf`, reusing the content-ETag + colo-cache machinery. A release without `coverage.pmtiles` degrades to an empty TileJSON and 204s, never 500s. `/vector.json` drops the coverage entry.
- **Style (0.2.0)**: new `seascape-coverage` source; the four `source-*` layers move to it. By the letter removing a vector layer is a major, but no published build ever contained it — nothing could have consumed it — so it ships as a minor (noted in the README). The viewer popup now lists **every** overlapping source, deepest (winning) first.

## Verification

- Style tests (9), worker self-checks incl. new `coverage.test.mjs`, `tsc --noEmit`, `vite build`, `contour_run.py check` all pass.
- `just preview` over Æbelø: `coverage.pmtiles` z0–8; the z8 tile at 135/80 carries DDM + EMODnet with real `source_maxzoom` (10, not 0); `vector.pmtiles` layers are exactly `contours, drying, soundings`.
- Dev worker: `/coverage.json` sane; footprint tile → 200; open-ocean and out-of-range → 204; archive deleted from local R2 → empty TileJSON + 204s; restored → 200.
- Viewer at z13 over Æbelø: overzoomed z8 footprint fills render, click popup reads "source: Danmarks Dybdemodel (DDM) 50 m / also covered by: EMODnet Bathymetry 2024 DTM" (deepest-wins tie broken lex-first, matching the build's merge rule).
- Local verification used synthesized bbox-union footprints (R2 has none yet); the first CI build off this branch backfills the real ones.