### PR TITLE
Build coverage in its own parallel job; BBOX-scope it for previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,7 +392,10 @@ jobs:
           markers: "false"
       - name: Build + push coverage.pmtiles
         run: |
-          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just coverage
+          # -e BBOX like the plan job's `just cover`: a regional dispatch (bbox input) builds a
+          # regional covering, so coverage must scope to the same window; empty (a planet build)
+          # → the whole world.
+          docker run --rm -v "$PWD:/app" -e BBOX -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just coverage
           aws s3 cp store/bundle/coverage.pmtiles "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/coverage.pmtiles" \
             --content-type application/octet-stream
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,20 +265,6 @@ jobs:
           # so the sharded downsample job downstream sees the same plan from R2.
           docker run --rm -v "$PWD:/app" -e BBOX -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just cover
           docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just downsample-cover
-      - name: Build coverage.pmtiles
-        run: |
-          # Source-provenance footprints → their own small tileset (z0-8; the renderer
-          # overzooms it past that, independent of vector.pmtiles). Built here, not in
-          # contour-bundle: plan just wrote the covering, whose aggregation CSVs are the
-          # authoritative per-source maxzoom (metadata.json max_zoom is only an optional
-          # cap most sources omit). `just coverage` fails loudly when bathymetry/polygon/
-          # is empty — a planet build without footprints is a broken build, not a
-          # fallback; the silent drop is how the layer went missing from every release.
-          mkdir -p store/polygon
-          aws s3 sync "s3://$DATA_BUCKET/bathymetry/polygon" store/polygon
-          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just coverage
-          aws s3 cp store/bundle/coverage.pmtiles "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/coverage.pmtiles" \
-            --content-type application/octet-stream
       - name: Freeze the dirty work lists
         run: |
           # Compute the aggregate + downsample dirty sets ONCE, from this single R2 listing
@@ -375,6 +361,40 @@ jobs:
           SHARDS=$(docker run --rm -v "$PWD:/app" -e FORCE_REBUILD -v "$PWD/store:/app/pipelines/store" \
             "$IMAGE:$IMAGE_TAG" just downsample-matrix "$AGG_SHARDS" | tail -n1)
           echo "shards=$SHARDS" >> "$GITHUB_OUTPUT"
+
+  # Source-provenance footprints → coverage.pmtiles (z0-8; its own small tileset the renderer
+  # overzooms deeper, independent of vector.pmtiles). Its own job, NOT inline in plan: the
+  # tippecanoe of the footprints kept whole (uk_surfzone/infomar are large intertidal-survey
+  # unions) runs ~40 min, and inline it serialized that ahead of the whole aggregate fan-out
+  # (aggregate needs plan). It depends only on the covering plan just wrote (for the per-source
+  # maxzoom — metadata.json max_zoom is only an optional cap most sources omit) + the footprints,
+  # nothing from aggregate, so it runs in parallel with the multi-hour aggregate/downsample/
+  # contour chains and finishes long before release. `just coverage` fails loudly on missing
+  # footprints — a planet build without them ships a dead layer; the silent drop is how the
+  # layer went missing from every release.
+  coverage:
+    needs: [image, plan]
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: read }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/ghcr-login
+      - name: Pull footprints from R2
+        run: |
+          mkdir -p store/polygon
+          aws s3 sync "s3://$DATA_BUCKET/bathymetry/polygon" store/polygon
+      # The covering plan just wrote — its aggregation CSVs are the authoritative per-source
+      # maxzoom. markers: false — coverage reads CSVs only, never the resume markers.
+      - name: Pull covering from R2
+        uses: ./.github/actions/pull-covering
+        with:
+          markers: "false"
+      - name: Build + push coverage.pmtiles
+        run: |
+          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just coverage
+          aws s3 cp store/bundle/coverage.pmtiles "s3://$DATA_BUCKET/bathymetry/build/${{ github.sha }}/coverage.pmtiles" \
+            --content-type application/octet-stream
 
   # Reproject → merge → tile → contour for one strided slice of the dirty tiles.
   # Shards re-derive the same sorted dirty list and never overlap, so each pushes
@@ -721,8 +741,8 @@ jobs:
   # dispatch release.yml for this exact sha. Only main builds deploy to production —
   # a build dispatched from a feature branch still writes build/<sha>/, but won't ship.
   release:
-    needs: [bundle-merge, contour-bundle]
-    if: ${{ github.ref == 'refs/heads/main' && needs.bundle-merge.result == 'success' && needs.contour-bundle.result == 'success' }}
+    needs: [bundle-merge, contour-bundle, coverage]
+    if: ${{ github.ref == 'refs/heads/main' && needs.bundle-merge.result == 'success' && needs.contour-bundle.result == 'success' && needs.coverage.result == 'success' }}
     runs-on: ubuntu-latest
     permissions: { actions: write }
     steps:

--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,8 @@ sources:
 # pmtiles into vector.pmtiles in the same single pass. Drying rides inside depare (a DEPARE band
 # with negative drval1) — aggregation_run generates its per-tile FGB, which depare consumes.
 # Coverage right after cover (it needs only footprints + the covering) so missing footprints
-# fail in the first minute, not after hours of aggregation.
+# fail in the first minute, not after hours of aggregation. Coverage honors BBOX, so a preview
+# builds only the region's footprints (CI builds the whole planet, in its own parallel job).
 planet:
     just cover
     just coverage
@@ -128,6 +129,7 @@ depare:
 # Source-provenance footprints -> their own store/bundle/coverage.pmtiles (z0-8;
 # the renderer overzooms it deeper). Needs store/polygon/*.gpkg + a covering;
 # fails loudly without footprints — a build without them ships a dead layer.
+# Honors BBOX: a preview builds only the region's footprints (whole planet if unset).
 coverage:
     uv run python contour_run.py coverage
 

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -307,7 +307,7 @@ def _coverage_geojson():
     valid = set(config.sources())
     zmax = _source_maxzooms()
     bbox = os.environ.get("BBOX", "").strip()
-    spat = ["-spat", *bbox.split(",")] if bbox else []
+    spat = ["-spat", *(c.strip() for c in bbox.split(","))] if bbox else []
     feats = []
     for gpkg in sorted(glob("store/polygon/*.gpkg")):
         sid = gpkg.split("/")[-1].replace(".gpkg", "")

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -297,9 +297,17 @@ def _source_maxzooms():
 def _coverage_geojson():
     """Combine every regional source's simplified footprint into one GeoJSON FC with
     {source_id, source_name, source_maxzoom}; write it and return the path. None if no
-    polygons are present locally (coverage_bundle turns that into a hard failure)."""
+    polygons are present locally (coverage_bundle turns that into a hard failure).
+
+    BBOX (W,S,E,N lon/lat, the same regional-build env the covering uses) pushes a -spat
+    filter onto each footprint read, so a preview builds only the region's coverage instead of
+    tippecanoeing every footprint whole (the large intertidal-survey unions — uk_surfzone,
+    infomar — dominate that cost). Footprints are EPSG:4326, so BBOX maps straight to -spat.
+    Unset (a planet/CI build) → the whole world."""
     valid = set(config.sources())
     zmax = _source_maxzooms()
+    bbox = os.environ.get("BBOX", "").strip()
+    spat = ["-spat", *bbox.split(",")] if bbox else []
     feats = []
     for gpkg in sorted(glob("store/polygon/*.gpkg")):
         sid = gpkg.split("/")[-1].replace(".gpkg", "")
@@ -307,7 +315,7 @@ def _coverage_geojson():
             continue
         meta = config.load_metadata(sid)
         out = subprocess.run(
-            ["ogr2ogr", "-f", "GeoJSON", "/vsistdout/", gpkg,
+            ["ogr2ogr", "-f", "GeoJSON", "/vsistdout/", gpkg, *spat,
              "-simplify", "0.001", "-lco", "COORDINATE_PRECISION=5"],
             capture_output=True, text=True, check=True).stdout
         for f in json.loads(out).get("features", []):


### PR DESCRIPTION
## Problem

The plan job's `Build coverage.pmtiles` step (added in #60) takes **~40 minutes** and sits inline in `plan`. Since `aggregate` needs `plan`, that 40 minutes serializes ahead of the entire aggregate → downsample → bundle / contour fan-out — every build waits ~40 min that does nothing but block. Measured across recent runs: plan's "Cover" step is ~45s, then "Build coverage.pmtiles" is 43–44 min.

The cost is real: coverage tippecanoes the source footprints kept whole (`--no-tile-size-limit`), and a few are huge — `uk_surfzone` 76 MB, `infomar_10m` 40 MB, `noaa_estuarine` 19 MB (detailed intertidal-survey unions).

## Changes

**Move coverage to its own job.** It depends only on the covering `plan` wrote (for per-source maxzoom) and the footprints — nothing from `aggregate`. So a new `coverage` job (`needs: [image, plan]`) runs in parallel with the multi-hour aggregate/downsample/contour chains and finishes long before `release` (which now requires it). Plan drops to ~1 min → **aggregate starts ~40 min sooner**, at zero added wall-clock since coverage is never the long pole. Same pattern the terrain/vector bundles already use.

**BBOX-scope the coverage build.** `_coverage_geojson` now honors `BBOX` (the same regional-build env the covering and `prep_water` already use) as a `-spat` filter on each footprint read. A `just preview` builds only the region's footprints instead of tippecanoeing every one whole — so the coverage layer stays visible in previews without the 40-minute cost. Footprints are EPSG:4326, so BBOX maps straight to `-spat`; unset (planet/CI) builds the whole world.

## Verification

- build.yml parses; `coverage` job present with `needs: [image, plan]`; `release.needs` includes `coverage`; plan no longer has the coverage step; `DATA_BUCKET` is workflow-level so the new job inherits it.
- `-spat` filter verified end-to-end on a footprint-shaped 4326 gpkg: included bbox keeps the feature, excluded bbox filters it out, no bbox keeps it.
- `contour_run` imports; Justfile parses.

## Notes

- The deeper cost (a 40-min whole-planet tippecanoe of `uk_surfzone`/`infomar` footprints kept whole) is unchanged — this moves it off the critical path rather than reducing it. A follow-up could dissolve/simplify those footprints harder or drop `--no-tile-size-limit`.
- Independent of the drying-geometry PR (#65).