### PR TITLE
Bound overzoom decode concurrency to stop isolate OOM

### DIFF
--- a/docs/health-check.md
+++ b/docs/health-check.md
@@ -1,0 +1,84 @@
+# Health Check
+
+A weekly runbook for spotting production regressions. Each section is self-contained: read it, run the queries, judge the numbers against the "healthy" note. Nothing here mutates anything — all reads.
+
+Credentials: the read-only Cloudflare API token and account ID live in the repo's gitignored `.envrc` (the "Read-only" comment block). Never commit them; never paste them into a doc or a PR.
+
+```sh
+CF_TOKEN=…   # cfat_… from .envrc
+ACCT=7822da9c68cfce969e63d07534969359
+```
+
+## Worker
+
+The `seascape-tiles` Worker serves the raster/vector tiles. Its overzoom path decodes a parent WebP, resamples, and re-encodes — the memory-heavy step that has failed under load before ([#67](https://github.com/openwatersio/seascape/pull/67)). Observability logging is on (`observability.logs.enabled`), so `console.log` lines and uncaught exceptions are queryable for ~the last few days.
+
+### 1. Which version is live
+
+An error's `scriptVersion.id` only means something once you know what's deployed. Confirm the live version (and the release prefix it serves) before trusting any log:
+
+```sh
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCT/workers/scripts/seascape-tiles/deployments" \
+  -H "Authorization: Bearer $CF_TOKEN" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); dep=d['result']['deployments'][0]; print(dep['created_on'], [v['version_id'] for v in dep['versions']])"
+
+# Release prefix (which R2 snapshot it reads):
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCT/workers/services/seascape-tiles/environments/production/settings" \
+  -H "Authorization: Bearer $CF_TOKEN" \
+  | python3 -c "import sys,json; b=json.load(sys.stdin)['bindings']; print({x['name']:x.get('text') for x in b if x['type']=='plain_text'})"
+```
+
+### 2. Query the logs
+
+Workers observability (the same store the dashboard's "Logs" tab reads) is queried via the telemetry endpoint. The body needs a `parameters` wrapper; `filters[].key` uses the dotted event field (`$metadata.message`, `$workers.outcome`, …). This pulls the last 24h of decode errors:
+
+```sh
+NOW=$(python3 -c "import time; print(int(time.time()*1000))")
+FROM=$(python3 -c "import time; print(int((time.time()-24*3600)*1000))")
+
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCT/workers/observability/telemetry/query" \
+  -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"queryId\":\"q1\",\"view\":\"events\",\"limit\":500,\"dry\":false,
+       \"timeframe\":{\"from\":$FROM,\"to\":$NOW},
+       \"parameters\":{\"datasets\":[\"cloudflare-workers\"],
+         \"filters\":[{\"id\":\"f1\",\"key\":\"\$metadata.message\",\"type\":\"string\",
+                       \"operation\":\"includes\",\"value\":\"Decoding error\"}]}}" \
+  > /tmp/events.json
+```
+
+For a broad sweep (not just decode errors), swap the filter to catch every failed request — `{"key":"$workers.outcome","operation":"eq","value":"exception"}` — or drop `filters` entirely to see all events. `operation` is one of `includes` / `eq` / `neq` / `exists`. `limit` caps at a few hundred per call; widen `timeframe` or narrow the filter rather than paging.
+
+### 3. Aggregate
+
+Raw events lie about scale — one bad tile requested a thousand times looks like a thousand problems. Collapse to distinct causes. For the decode errors, the useful key is the *parent* tile actually being decoded (the message reports the overzoom target, not the parent):
+
+```python
+import json, re, collections
+evs = json.load(open('/tmp/events.json'))['result']['events']['events']
+out, parents = collections.Counter(), collections.Counter()
+for e in evs:
+    out[e['$workers']['outcome']] += 1                     # ok / exception / canceled
+    m = re.search(r'overlay (\S+) overzoom z(\d+) failed at (\d+)/(\d+)/(\d+)', e['source']['message'])
+    if m:
+        f, sz, z, x, y = m[1], int(m[2]), int(m[3]), int(m[4]), int(m[5])
+        lv = z - sz
+        parents[(f, sz, x >> lv, y >> lv)] += 1             # the tile that failed to decode
+print('outcomes:', dict(out))
+print('distinct failing parent tiles:', len(parents))
+for k, v in parents.most_common(15): print(f'  {k[0]} z{k[1]}/{k[2]}/{k[3]}  ×{v}')
+```
+
+Also bucket `e['timestamp']` by minute — a tight burst points at load/memory pressure; an even spread points at a persistently broken tile or a code bug.
+
+### 4. Is a suspect tile actually corrupt?
+
+A "Decoding error" is almost never bad bytes in R2 — confirm before chasing the pipeline. Fetch the failing parent straight from the Worker and decode it locally; if `dwebp` (libwebp CLI) is happy, the data is fine and the fault is runtime memory pressure, not the tile:
+
+```sh
+curl -s "https://tiles.openwaters.io/seascape/9/282/149.webp" -o /tmp/t.webp
+dwebp /tmp/t.webp -o /dev/null   # "Decoded … 512 x 512" = valid; the R2 tile is not the problem
+```
+
+### Healthy
+
+Near-zero `outcome: exception` over a week. The overzoom path is the usual offender; a burst of `Decoding error` with `exception` outcomes clustered in minutes is the [#67](https://github.com/openwatersio/seascape/pull/67) failure mode (isolate OOM under concurrent overzoom) — if it recurs, the `limiter(4)` cap in `worker/src/index.ts` is the knob to raise. A steady trickle on one fixed tile instead means that tile genuinely won't decode; fetch it (step 4) and, if `dwebp` also fails, rebuild it in the pipeline.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -32,6 +32,7 @@ import { CachedSource, contentEtag, OVERZOOM_TAG_VERSION } from "./cache";
 import { coverageTileJSON } from "./coverage";
 import { unpackTerrarium, packTerrariumInto, cubicBSpline } from "./terrarium";
 import { OverlayIndex, overlayFor } from "./overlay";
+import { limiter } from "./semaphore";
 // jSquash on Workers: WASM must be imported as a module and passed to init()
 // (no fetch-based instantiation in the Workers runtime).
 import decodeWebp, { init as initWebpDecode } from "@jsquash/webp/decode";
@@ -147,6 +148,14 @@ async function tile(
 // handler can derive the tile's validator from the ancestor bytes (the output
 // is a pure function of them) and skip this work entirely on a matching
 // revalidation.
+// Decode + B-spline + re-encode each hold several MB of libwebp working memory.
+// A request burst over a detailed region ran enough concurrently to exhaust the
+// isolate — malloc returned null and jsquash threw "Decoding error" on tiles that
+// are perfectly valid (they decode fine one at a time). Cap the concurrency so the
+// slow overzoom path queues instead of OOMing.
+// ponytail: fixed cap; raise it if bursts still starve throughput.
+const overzoomGate = limiter(4);
+
 async function synthesize(
   parent: ArrayBuffer,
   srcMax: number,
@@ -565,7 +574,10 @@ export default {
       if (!parent) return null; // ancestor missing; caller tries the next source
       const tag = await contentEtag(parent, OVERZOOM_TAG_VERSION + "-");
       if (inm === tag) return notModified(tag);
-      return sendTile(await synthesize(parent, srcMax, z, x, y), WEBP, tag);
+      const body = await overzoomGate(() =>
+        synthesize(parent, srcMax, z, x, y),
+      );
+      return sendTile(body, WEBP, tag);
     };
 
     const isVector = ext === "pbf" || ext === "mvt";

--- a/worker/src/semaphore.test.mjs
+++ b/worker/src/semaphore.test.mjs
@@ -1,0 +1,52 @@
+// Run: node src/semaphore.test.mjs   (Node ≥22.18 strips the imported .ts)
+import assert from "node:assert/strict";
+import { limiter } from "./semaphore.ts";
+
+// Never more than `max` fns run at once, and every fn still completes.
+const run = limiter(2);
+let active = 0,
+  peak = 0,
+  done = 0;
+const defer = () => {
+  let resolve;
+  const p = new Promise((r) => (resolve = r));
+  return { p, resolve };
+};
+const gates = Array.from({ length: 6 }, defer);
+
+const tasks = gates.map((g, i) =>
+  run(async () => {
+    active++;
+    peak = Math.max(peak, active);
+    await g.p; // hold the slot until released, so overlap is observable
+    active--;
+    done++;
+    return i;
+  }),
+);
+
+// Release in waves; the limiter must keep ≤2 in flight throughout.
+await Promise.resolve();
+gates[0].resolve();
+gates[1].resolve();
+await new Promise((r) => setTimeout(r, 0));
+gates[2].resolve();
+gates[3].resolve();
+gates[4].resolve();
+gates[5].resolve();
+const out = await Promise.all(tasks);
+
+assert.equal(peak, 2, `peak concurrency ${peak}, want 2`);
+assert.equal(done, 6, "all tasks completed");
+assert.deepEqual(out, [0, 1, 2, 3, 4, 5]);
+
+// A throwing fn releases its slot (finally), so later work isn't starved.
+const run1 = limiter(1);
+await assert.rejects(
+  run1(async () => {
+    throw new Error("boom");
+  }),
+);
+assert.equal(await run1(async () => "ok"), "ok");
+
+console.log("semaphore.test.mjs ok");

--- a/worker/src/semaphore.ts
+++ b/worker/src/semaphore.ts
@@ -1,0 +1,26 @@
+/**
+ * A counting semaphore: at most `max` calls run concurrently, the rest queue.
+ * The tile Worker uses it to cap overzoom synthesis — each decode+encode holds
+ * several MB of libwebp working memory, and a request burst over a detailed
+ * region ran enough of them at once to exhaust the isolate (malloc → null →
+ * "Decoding error"). Bounding the concurrency keeps peak memory flat.
+ *
+ * Plain, dependency-free, Node-importable (semaphore.test.mjs).
+ */
+export function limiter(max: number) {
+  let active = 0;
+  const waiters: Array<() => void> = [];
+  return async function run<T>(fn: () => Promise<T>): Promise<T> {
+    // Free slot: take it. Otherwise wait — a releaser hands its slot directly to
+    // the next waiter (active unchanged), so active never exceeds max.
+    if (active >= max) await new Promise<void>((r) => waiters.push(r));
+    else active++;
+    try {
+      return await fn();
+    } finally {
+      const next = waiters.shift();
+      if (next) next();
+      else active--;
+    }
+  };
+}


### PR DESCRIPTION
## Symptom

The `seascape-tiles` Worker throws `overlay … overzoom z9 failed …: Error: Decoding error`. Pulling Workers observability for the live version: **~500 events in the last 24h, 485 of them HTTP 500s**, all inside a single **10-minute burst**.

## Root cause — memory pressure, not bad data

- Failures cluster in **4 overlay cells** on **31 distinct parent tiles**, and every one is the **largest ~100 KB lossless tile** in its area.
- Those exact tiles fetched from prod **decode fine with libwebp**, and hammering the biggest one's overzoom succeeded **20/20 at low load**.

Under a concurrent burst, many overzoom synthesises run in one isolate at once. Each `decode → cubic-B-spline → re-encode` holds several MB of libwebp working memory, so a burst blows the 128 MB isolate limit → `malloc` returns null → jsquash throws `Decoding error`. The largest lossless tiles need the most decode memory, so they tip first.

## Fix

**`limiter(4)`** around `synthesize` caps concurrent synthesis so the slow overzoom path queues instead of OOMing.

New `semaphore.ts` is a tiny dependency-free counting semaphore with a `semaphore.test.mjs` self-check (peak concurrency ≤ cap; slot released on throw).

**Deliberately no fallback:** a decode failure still 500s. This keeps the signal honest — if the limiter works, the 500s stop; a graceful fallback would just hide whether it actually fixed anything. Cap is a knob (`limiter(4)`) — raise it if bursts still starve throughput.

## Verification

`semaphore.test.mjs` + all existing worker tests pass; `tsc` clean; `wrangler deploy --dry-run` bundles (in a tree with deps installed).