### PR TITLE
Split source prep into download-once + normalize-many

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ data/
 work/
 output/
 dist/
-# pipeline stages + bundle output all write under pipelines/store/
+# pipeline stages + bundle output all write under pipelines/store/ — this includes the raw
+# source download cache (store/download/) and the normalized source work dir (store/source/)
 pipelines/store/
 .venv/
 node_modules

--- a/Justfile
+++ b/Justfile
@@ -5,13 +5,29 @@
 
 set working-directory := 'pipelines'
 
-# Prepare one source: fetch -> datum -> normalize -> bounds -> polygon -> tarball, then
-# assemble catalog.json. The catalog step is the shared tail, so every source (prepared or
-# mirrored) gets a generated catalog item without editing each recipe. RECIPE_HASH (the
-# source's recipe content hash, supplied by the caller; empty locally) rides into the item.
-source id:
-    just ../sources/{{id}}/
+# Prepare one source end to end: download (fetch raw into the cache) then normalize (stage
+# raw -> datum -> normalize -> bounds -> polygon -> tarball) then the shared catalog.json tail.
+# The catalog step is the shared tail, so every source (prepared or mirrored) gets a generated
+# catalog item without editing each recipe. RECIPE_HASH (the source's recipe content hash,
+# supplied by the caller; empty locally) rides into the item.
+source id: (source-download id) (source-normalize id)
+
+# Download phase: fetch a source's raw bytes into store/download/<id>/ (idempotent — a cached
+# file is skipped; source_download.py --force re-fetches). Mirrored sources (cudem/noaa_s102)
+# register + push to R2 here instead. Run once; normalize reruns off the cache.
+source-download id:
+    just ../sources/{{id}}/download
+
+# Normalize phase: stage raw from the cache into store/source/<id> and run the transform chain,
+# then the catalog tail. Network-free and re-runnable — this is the fast datum/masking loop.
+source-normalize id:
+    just ../sources/{{id}}/normalize
     uv run python source_catalog.py {{id}}
+
+# Drop the raw download cache (store/download/). Frees disk after prep; the next source-download
+# re-fetches. store/source/ (the normalized output) is untouched.
+clean-download:
+    rm -rf store/download
 
 # Prepare the OSM land mask once (download -> unzip -> EPSG:3857 FlatGeobuf at
 # store/landmask/land.fgb). Flagged coarse sources (GEBCO/EMODnet) clamp negative
@@ -232,6 +248,8 @@ test: test-sources test-engine test-workflows
 # Offline self-checks (synthetic data, no network).
 test-sources:
     uv run python test_source_stage.py
+    uv run python source_download.py --check
+    uv run python source_stage.py --check
     uv run python source_mirror.py --check
     uv run python source_catalog.py --check
     uv run python source_remote.py

--- a/docs/plans/2026-07-13-source-download-normalize-split.md
+++ b/docs/plans/2026-07-13-source-download-normalize-split.md
@@ -1,0 +1,145 @@
+# Split source preparation into download-once + normalize-many — planning doc
+
+*Written 2026-07-13. Point-in-time; the code is the source of truth.*
+
+Status: proposed. Motivated by iterating on the WSV DGM-W datum/masking (`sources/dgm_w`,
+on `add-source-wsv-dgmw`): every tweak to `build_reference.py` / `source_datum.py` forced a
+full re-download, because raw and normalized data share one directory and the raw is
+destroyed mid-run.
+
+## Problem: everything mutates one directory
+
+A source's whole lifecycle lives in and rewrites one directory, `store/source/<id>/`:
+
+1. [source_download.py](../../pipelines/source_download.py) writes `<id>_<i>.<ext>` there —
+   **always fetches**, no skip-if-present.
+2. [source_unzip.py](../../pipelines/source_unzip.py) extracts `*.tif`, then
+   **`os.remove(zpath)`** — the raw archive is gone.
+3. [source_datum.py](../../pipelines/source_datum.py) and
+   [source_normalize.py](../../pipelines/source_normalize.py) each **mutate the tifs in place**
+   (`os.replace(tmp, filepath)` at `source_datum.py:54` / `source_normalize.py:41`): raw →
+   datum-referenced → COG.
+
+The raw bytes exist only transiently, so any re-run must re-download and re-extract to get raw
+back. The masking work (`--clamp-positive`, the datum-surface subtraction) is entangled with the
+download only because they share the directory and the raw is deleted underneath the transform.
+
+## Goals / Non-goals
+
+**Goals.** Iterating on datum/masking reruns only the transform chain — seconds, zero network.
+Raw source bytes are fetched once into a cache that later phases never mutate, so `source_datum`
+/ `source_normalize` can be re-run to convergence against a pristine input. `just source <id>`
+stays the single entry point and its CI invocation is unchanged.
+
+**Non-goals.** Caching raw bytes across CI runs (runners are ephemeral; the payoff is local
+iteration — see Gotchas). Reworking the mirrored sources (`cudem`, `cudem_third`, `noaa_s102`)
+— they already fetch straight to R2 via [source_mirror.py](../../pipelines/source_mirror.py) and
+map onto the download phase trivially. Changing the R2 store layout or `bounds.csv` shape.
+
+## Approach: two directories, two phases
+
+| Dir | Written by | Lifecycle |
+| --- | --- | --- |
+| `store/download/<id>/` | `download` phase | cache — fetched once, never deleted, skip-if-present |
+| `store/source/<id>/` | `normalize` phase | regenerated each run from the cache → final COGs (pushed to R2) |
+
+- **`just source-download <id>`** — writes raw archives/tifs to `store/download/<id>/` under a
+  stable name. Idempotent: skip a URL whose cache file already exists (static sources);
+  size/etag check for volatile ones. Does not unzip, does not delete. A `--force` flag re-fetches.
+- **`just source-normalize <id>`** — clears `store/source/<id>/`, stages raw from the cache into
+  it (extract zips / copy plain tifs), then runs the transform chain: `source_datum` →
+  `source_normalize` → `source_bounds` → `source_polygonize` → `source_create_tarball`. Re-runnable
+  with zero network. (For DGM-W the chain also carries `build_reference` ahead of `source_datum`.)
+- **`just source <id>`** = `source-download` then `source-normalize` — unchanged, and still the
+  shared `source_catalog` tail from the top-level [Justfile](../../Justfile) rides after it.
+
+Win: the datum/masking loop reruns only `normalize`. CI still downloads once per run (the runner
+is thrown away), so the concrete payoff is local iteration.
+
+## Concrete changes
+
+- **[source_download.py](../../pipelines/source_download.py)**: target `store/download/<id>/`;
+  add skip-if-exists and a `--force` flag. Keep `fix_archive_ext` here so the cache holds a
+  correctly-named `.zip` for the extract step to find. (~10 lines.)
+- **[source_unzip.py](../../pipelines/source_unzip.py)**: read zips from `store/download/<id>/`,
+  extract into `store/source/<id>/`, and **stop deleting the zip**. Moves into the normalize
+  phase (extraction is cheap and keeps `download/` archive-pure). (~5 lines.)
+- **Non-zip sources** (plain `.tif` / `.nc`, e.g. GEBCO members aside, DDM): stage by **copying**
+  from `download/` → `source/` before the in-place mutation, so the cache stays pristine. A new
+  tiny `source_stage` step, or fold the copy into the start of `source-normalize`. Copy, never
+  move — `source_datum` / `source_normalize` overwrite in place.
+- **Bespoke downloaders** (`source_download_greatlakes.py`, `_estuarine`, `_swissbathy`,
+  `_tahoe`, `_african_lakes`, `_filelist`): each writes into `store/source/<id>/` today and some
+  do more than fetch. Repoint their raw output to `store/download/<id>/` and move any
+  transform-ish work into the normalize phase. Auditing these one by one is real work.
+- **Every `sources/*/Justfile`**: split the ordered `default:` command list into a `download:`
+  group and a `normalize:` group, with `default: download normalize` composing them. This is the
+  bulk of the work — each recipe is bespoke. Mirrored sources (`cudem` et al.) are the easy case:
+  `download: source_mirror`, `normalize:` empty (the shared catalog tail is all they need).
+- **Top-level [Justfile](../../Justfile)**: add `source-download` and `source-normalize` (each
+  delegating to the matching per-source group), keep `source` composing both + `source_catalog`,
+  and update the `sources` loop.
+
+## Alternatives considered
+
+- **Copy-on-write / snapshot the tifs in place** (e.g. a `.raw.tif` sibling before each mutate,
+  restore to re-run). Cheaper diff, but it litters `store/source/` with shadow copies, keeps the
+  download coupled to the transform, and doesn't give a clean "fetched once" cache. Two dirs is
+  the honest boundary.
+- **Make `source_datum` / `source_normalize` non-destructive** (write to new names, chain by
+  filename). Touches every downstream glob (`*.tif` everywhere) and the tarball/bounds contract;
+  much larger blast radius for the same iteration win.
+
+## Validation
+
+- `source_download.py --check` / `source_normalize.py` self-checks keep passing; extend
+  `source_download`'s to cover skip-if-exists and `--force`.
+- [test_source_stage.py](../../pipelines/test_source_stage.py) already runs the transform chain
+  offline from a pre-placed raster — the natural home for asserting `normalize` regenerates
+  `store/source/<id>/` from a `store/download/<id>/` cache without touching the cache bytes
+  (hash the cache before/after).
+- Manual: `just source-download gebco` (a zip source) then `just source-normalize gebco` twice —
+  second normalize is network-free and byte-identical, and `store/download/gebco/` is untouched.
+- `just source <id>` in the `sources.yml` container path still produces the same
+  `store/source/<id>/` artifacts (`bounds.csv`, `catalog.json`, COGs, tarball) it pushes to R2.
+
+## Gotchas
+
+- **CI gets no caching benefit.** [sources.yml](../../.github/workflows/sources.yml) runs
+  `just source <id>` in one container and pushes only `store/source/<id>` to R2 (`aws s3 sync`,
+  line ~306); `store/download/` is never persisted and the runner is destroyed after. So the
+  split is purely a local-iteration win. Persisting the cache (R2 or `actions/cache`) is a
+  separate follow-up, out of scope here. Keep `just source` = download + normalize precisely so
+  the CI invocation line doesn't change.
+- **Peak disk roughly doubles for zip sources during normalize.** Today `source_unzip` deletes
+  each zip as it extracts; keeping the archive in `store/download/` *and* the extracted tifs in
+  `store/source/` holds both at once. EMODnet already flags disk pressure (~7 GB zipped / tens
+  unzipped) — on a standard runner this could tip it over. Mitigation where the cache doesn't
+  help anyway (CI): let normalize consume-and-delete from `download/`, or keep the persistent
+  cache local-only.
+- **Copy, don't move, when staging.** `source_datum:54` and `source_normalize:41` both
+  `os.replace(tmp, filepath)` over the staged file. If `source-normalize` *moves* raw out of the
+  cache instead of copying, the first datum run destroys the cache and defeats the whole point.
+- **Splitting each Justfile changes its bytes → one-time re-registration.** `sources.yml`
+  short-circuits on `RECIPE_HASH = hashFiles('sources/<id>/**')`, which includes the Justfile.
+  Editing every recipe moves every hash, so the next `sources.yml` run re-prepares all sources
+  once. Expected and one-time; note it in the dispatch (same pattern the sources-mirror plan
+  called out).
+- **`store/download/` must be gitignored and stay out of the R2 push.** The existing
+  `aws s3 sync store/source ...` naturally excludes it, but the `.gitignore` and any tarball/
+  manifest globs should be checked so raw archives don't leak into an artifact.
+- **Mirrored sources have no local `store/download/`.** Their "cache" is R2. Don't force
+  `source_mirror` through the extract/stage dance — its download-phase mapping is the whole
+  recipe, and its normalize phase is empty.
+- **`source_datum` writes `datum.json` into `store/source/<id>/`**, not the cache — correct, it's
+  a normalize-phase provenance artifact and gets regenerated each run. Staging must not clobber
+  it with a stale copy from a previous run (clearing `store/source/<id>/` first handles this).
+
+## Open questions
+
+- One `source_stage` module vs. folding the copy/extract into `source-normalize` — implementer's
+  call; `source_stage` is more testable, the fold is fewer files.
+- Skip-if-present for volatile non-mirrored sources: is size/etag enough, or do any need a
+  content hash? (Mirrored sources sidestep this — they diff against the previous `bounds.csv`.)
+- Whether to land the CI cache-persistence follow-up now (R2-backed `store/download/`) or defer
+  until local iteration proves the split's shape.

--- a/docs/plans/2026-07-13-source-download-normalize-split.md
+++ b/docs/plans/2026-07-13-source-download-normalize-split.md
@@ -105,35 +105,48 @@ is thrown away), so the concrete payoff is local iteration.
 
 ## Gotchas
 
-- **CI gets no caching benefit.** [sources.yml](../../.github/workflows/sources.yml) runs
-  `just source <id>` in one container and pushes only `store/source/<id>` to R2 (`aws s3 sync`,
-  line ~306); `store/download/` is never persisted and the runner is destroyed after. So the
-  split is purely a local-iteration win. Persisting the cache (R2 or `actions/cache`) is a
-  separate follow-up, out of scope here. Keep `just source` = download + normalize precisely so
+- **Disk**: the raw cache now persists (DGM-W raw ≈ the zip sizes; the free-flowing Rhein
+  overview tiles are the large ones). Add `just clean-download` and a `.gitignore` / `store/` note.
+  `store/` runs cwd-relative to `pipelines/`, and `.gitignore` already ignores `pipelines/store/`,
+  so `store/download/` is untracked and the `aws s3 sync store/source ...` push naturally excludes
+  it — the note is to keep it that way, not to fix a leak.
+- **Recipe-hash gate**: CI's "Already current in R2?" hashes `sources/<id>/`. Splitting a recipe
+  changes the hash → one rebuild per source (expected). The hash still covers the normalize logic,
+  so a masking tweak correctly invalidates the source.
+- **In-place mutation stays** inside `normalize`, operating on freshly staged raw each run — so
+  `source_datum` / `source_normalize` need no change beyond reading the staged copy. The corollary:
+  staging must **copy**, not move (`source_datum:54` / `source_normalize:41` both `os.replace` over
+  the staged file), or the first datum run eats the cache.
+- **Member naming**: `source_unzip` flattens archives by basename; the download-cache key
+  (`<id>_<i>`) vs the archive's internal tif names must stay consistent, because `bounds.csv` and
+  `catalog.json` reference the final tif names.
+
+Two more sharp edges found reading the current pipeline + workflows:
+
+- **CI gets no caching benefit either way.** [sources.yml](../../.github/workflows/sources.yml)
+  runs `just source <id>` in one container, pushes only `store/source/<id>` to R2, then throws the
+  runner away — `store/download/` never persists across runs. The win is purely local iteration;
+  an R2-backed cross-run cache is a separate follow-up. Keeping `just source` = both phases means
   the CI invocation line doesn't change.
-- **Peak disk roughly doubles for zip sources during normalize.** Today `source_unzip` deletes
-  each zip as it extracts; keeping the archive in `store/download/` *and* the extracted tifs in
-  `store/source/` holds both at once. EMODnet already flags disk pressure (~7 GB zipped / tens
-  unzipped) — on a standard runner this could tip it over. Mitigation where the cache doesn't
-  help anyway (CI): let normalize consume-and-delete from `download/`, or keep the persistent
-  cache local-only.
-- **Copy, don't move, when staging.** `source_datum:54` and `source_normalize:41` both
-  `os.replace(tmp, filepath)` over the staged file. If `source-normalize` *moves* raw out of the
-  cache instead of copying, the first datum run destroys the cache and defeats the whole point.
-- **Splitting each Justfile changes its bytes → one-time re-registration.** `sources.yml`
-  short-circuits on `RECIPE_HASH = hashFiles('sources/<id>/**')`, which includes the Justfile.
-  Editing every recipe moves every hash, so the next `sources.yml` run re-prepares all sources
-  once. Expected and one-time; note it in the dispatch (same pattern the sources-mirror plan
-  called out).
-- **`store/download/` must be gitignored and stay out of the R2 push.** The existing
-  `aws s3 sync store/source ...` naturally excludes it, but the `.gitignore` and any tarball/
-  manifest globs should be checked so raw archives don't leak into an artifact.
-- **Mirrored sources have no local `store/download/`.** Their "cache" is R2. Don't force
-  `source_mirror` through the extract/stage dance — its download-phase mapping is the whole
-  recipe, and its normalize phase is empty.
-- **`source_datum` writes `datum.json` into `store/source/<id>/`**, not the cache — correct, it's
-  a normalize-phase provenance artifact and gets regenerated each run. Staging must not clobber
-  it with a stale copy from a previous run (clearing `store/source/<id>/` first handles this).
+- **Peak disk transiently doubles for zip sources during normalize.** Today `source_unzip` deletes
+  each zip as it extracts; holding the archive in `store/download/` *and* the extracted tifs in
+  `store/source/` keeps both at once. EMODnet already flags disk pressure (~7 GB zipped / tens
+  unzipped). Where the cache doesn't help anyway (CI), let normalize consume-and-delete from
+  `download/`, or keep the persistent cache local-only.
+
+Mirrored sources (`cudem`, `cudem_third`, `noaa_s102`) sidestep all of the above — `source_mirror`
+fetches straight to R2, so their `download:` group is the whole recipe and `normalize:` is empty.
+
+## Scope
+
+Small per-script (~30 lines across download/unzip/stage), but it touches **every source recipe** —
+the real cost and risk. Suggested order:
+
+1. Add the two new scripts + top-level `source-download` / `source-normalize` recipes.
+2. Migrate `sources/*/Justfile` one at a time — `dgm_w` first, as the motivating case.
+3. Add `clean-download` + the gitignore note.
+
+Backward-compatible throughout, since `source` keeps composing both phases.
 
 ## Open questions
 

--- a/pipelines/source_download.py
+++ b/pipelines/source_download.py
@@ -1,9 +1,13 @@
-"""Plain HTTP download of a source's file_list.txt URLs into store/source/<id>/.
+"""Plain HTTP download of a source's file_list.txt URLs into store/download/<id>/.
+
+The download phase: raw bytes land in the cache dir (store/download/<id>/) that later
+phases never mutate, so re-running normalize is network-free. Idempotent — a URL whose
+cache file already exists is skipped unless --force is passed. Does not unzip or delete.
 
 Uses requests (no shell) so query-string URLs with ``&`` work. Other access
 patterns are their own steps a recipe picks instead: source_mirror (volatile
 public tile collections, registered against the store's object mirror),
-source_unzip (extract archives this step fetched).
+source_unzip (extract archives this step fetched into the source work dir).
 """
 
 import os
@@ -39,17 +43,30 @@ def fix_archive_ext(dest):
     return zdest
 
 
-def main():
-    if len(sys.argv) != 2:
-        sys.exit("usage: source_download.py <source-id>")
+def cached(dest):
+    """The existing cache file for this dest, or None. Accounts for fix_archive_ext's
+    .tif->.zip rename: a prior run may have saved zip bytes under the .zip name, so a
+    dest ending .tif is also satisfied by its .zip sibling."""
+    if os.path.exists(dest):
+        return dest
+    zdest = dest.rsplit(".", 1)[0] + ".zip"
+    return zdest if os.path.exists(zdest) else None
+
+
+def main(force=False):
     source = sys.argv[1]
     urls = config.file_list(source)
     if not urls:
         sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    os.makedirs(f"store/source/{source}", exist_ok=True)
-    print(f"downloading {source}: {len(urls)} url(s)")
+    out = f"store/download/{source}"
+    os.makedirs(out, exist_ok=True)
+    print(f"downloading {source}: {len(urls)} url(s) -> {out}/")
     for i, url in enumerate(urls):
-        dest = f"store/source/{source}/{source}_{i}.{ext_for(url)}"
+        dest = f"{out}/{source}_{i}.{ext_for(url)}"
+        hit = cached(dest)
+        if hit and not force:
+            print(f"  [{i}] cached {hit}")
+            continue
         print(f"  [{i}] {url} -> {dest}")
         utils.http_download(url, dest)
         fix_archive_ext(dest)
@@ -68,11 +85,17 @@ def _check():
     with open(tpath, "wb") as f:
         f.write(b"II*\x00")
     assert fix_archive_ext(tpath) == tpath
+    # cached(): a .tif dest is satisfied by the .zip sibling fix_archive_ext left behind
+    assert cached(zpath) == os.path.join(d, "s_0.zip")  # zpath was renamed to .zip above
+    assert cached(tpath) == tpath                        # plain tif, present
+    assert cached(os.path.join(d, "missing.tif")) is None
     print("source_download.py self-check ok")
 
 
 if __name__ == "__main__":
     if sys.argv[1:2] == ["--check"]:
         _check()
+    elif len(sys.argv) < 2 or sys.argv[1].startswith("-"):
+        sys.exit("usage: source_download.py <source-id> [--force]")
     else:
-        main()
+        main(force="--force" in sys.argv[2:])

--- a/pipelines/source_download.py
+++ b/pipelines/source_download.py
@@ -45,12 +45,16 @@ def fix_archive_ext(dest):
 
 def cached(dest):
     """The existing cache file for this dest, or None. Accounts for fix_archive_ext's
-    .tif->.zip rename: a prior run may have saved zip bytes under the .zip name, so a
-    dest ending .tif is also satisfied by its .zip sibling."""
+    rename of the ext_for "tif" fallback to .zip (an extensionless URL that served zip
+    bytes): only a .tif/.tiff dest is legitimately satisfied by a .zip sibling, so a
+    stray .zip never shadows a .nc/.asc/... at the same index if the URL list changes."""
     if os.path.exists(dest):
         return dest
-    zdest = dest.rsplit(".", 1)[0] + ".zip"
-    return zdest if os.path.exists(zdest) else None
+    if dest.rsplit(".", 1)[-1].lower() in ("tif", "tiff"):
+        zdest = dest.rsplit(".", 1)[0] + ".zip"
+        if os.path.exists(zdest):
+            return zdest
+    return None
 
 
 def main(force=False):
@@ -89,6 +93,8 @@ def _check():
     assert cached(zpath) == os.path.join(d, "s_0.zip")  # zpath was renamed to .zip above
     assert cached(tpath) == tpath                        # plain tif, present
     assert cached(os.path.join(d, "missing.tif")) is None
+    # a stray .zip sibling must NOT shadow a non-tif dest at the same index (s_0.zip exists)
+    assert cached(os.path.join(d, "s_0.nc")) is None
     print("source_download.py self-check ok")
 
 

--- a/pipelines/source_download_african_lakes.py
+++ b/pipelines/source_download_african_lakes.py
@@ -38,7 +38,7 @@ def main():
     urls = config.file_list(source)
     if not urls:
         sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    out_dir = f"store/source/{source}"
+    out_dir = f"store/download/{source}"
     os.makedirs(out_dir, exist_ok=True)
 
     archive = f"{out_dir}/Bathymetric_Rasters.7z"

--- a/pipelines/source_download_estuarine.py
+++ b/pipelines/source_download_estuarine.py
@@ -35,7 +35,7 @@ def main():
     urls = config.file_list(source)
     if not urls:
         sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    out_dir = f"store/source/{source}"
+    out_dir = f"store/download/{source}"
     os.makedirs(out_dir, exist_ok=True)
     print(f"downloading {source}: {len(urls)} estuary netCDF(s)")
     for i, url in enumerate(urls):

--- a/pipelines/source_download_filelist.py
+++ b/pipelines/source_download_filelist.py
@@ -3,7 +3,7 @@
 For sources published as a tile collection with a maintained URL manifest (e.g.
 NOAA CUDEM's ``urllist8483.txt``: 942 tile URLs across all US coastal regions).
 ``file_list.txt`` holds the URL(s) of the *filelist(s)*; this step downloads each
-manifest, then downloads every file it names into ``store/source/<id>/``. Pointing
+manifest, then downloads every file it names into ``store/download/<id>/``. Pointing
 at NOAA's manifest (vs vendoring ~942 lines) means coverage tracks their periodic
 re-tiling automatically. The download is idempotent — a finished file is skipped,
 so a re-run after a flaky tile resumes instead of re-pulling everything.
@@ -32,7 +32,7 @@ def main():
     manifests = config.file_list(source)
     if not manifests:
         sys.exit(f"no filelist URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    os.makedirs(f"store/source/{source}", exist_ok=True)
+    os.makedirs(f"store/download/{source}", exist_ok=True)
 
     urls = []
     for m in manifests:
@@ -43,7 +43,7 @@ def main():
     print(f"downloading {source}: {len(urls)} file(s) from {len(manifests)} filelist(s)")
 
     for i, url in enumerate(urls):
-        dest = f"store/source/{source}/{source}_{i}.{ext_for(url)}"
+        dest = f"store/download/{source}/{source}_{i}.{ext_for(url)}"
         if os.path.exists(dest):
             continue
         print(f"  [{i}/{len(urls)}] {url} -> {dest}")

--- a/pipelines/source_download_greatlakes.py
+++ b/pipelines/source_download_greatlakes.py
@@ -29,7 +29,7 @@ def main():
     urls = config.file_list(source)
     if not urls:
         sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    out_dir = f"store/source/{source}"
+    out_dir = f"store/download/{source}"
     os.makedirs(out_dir, exist_ok=True)
 
     for i, url in enumerate(urls):

--- a/pipelines/source_download_swissbathy.py
+++ b/pipelines/source_download_swissbathy.py
@@ -26,7 +26,7 @@ def main():
     urls = config.file_list(source)
     if not urls:
         sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    out_dir = f"store/source/{source}"
+    out_dir = f"store/download/{source}"
     tiles_dir = f"{out_dir}/asc"
     os.makedirs(tiles_dir, exist_ok=True)
 

--- a/pipelines/source_download_tahoe.py
+++ b/pipelines/source_download_tahoe.py
@@ -71,7 +71,7 @@ def main():
     urls = config.file_list(source)
     if not urls:
         sys.exit(f"no URLs in {config.SOURCES_DIR}/{source}/file_list.txt")
-    out_dir = f"store/source/{source}"
+    out_dir = f"store/download/{source}"
     os.makedirs(out_dir, exist_ok=True)
 
     gz = f"{out_dir}/lt_bathy.e00.gz"

--- a/pipelines/source_stage.py
+++ b/pipelines/source_stage.py
@@ -1,0 +1,59 @@
+"""Stage raw rasters from the download cache into the source work dir.
+
+The normalize-phase entry for non-zip sources (plain .tif/.nc — GEBCO's siblings aside:
+DDM, the lakes, the estuarine netCDFs, …). source_datum / source_normalize mutate tifs
+in place, so they must run on a *copy*: store/download/<id>/ stays pristine and
+source-normalize is re-runnable with no network. Clears the source work dir first, then
+copies *.tif/*.nc — the files the transform chain globs. Download-only junk (archives,
+.vrt, intermediate dirs a bespoke downloader left behind) stays in the cache.
+
+Zip sources use source_unzip instead — extraction *is* their stage.
+"""
+
+import os
+import shutil
+import sys
+from glob import glob
+
+RASTER_GLOBS = ("*.tif", "*.tiff", "*.nc")
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: source_stage.py <source-id>")
+    source = sys.argv[1]
+    src = f"store/download/{source}"
+    dst = f"store/source/{source}"
+    files = sorted(f for pat in RASTER_GLOBS for f in glob(f"{src}/{pat}"))
+    if not files:
+        sys.exit(f"no rasters to stage in {src}/ (run source-download first?)")
+    shutil.rmtree(dst, ignore_errors=True)
+    os.makedirs(dst, exist_ok=True)
+    print(f"stage {source}: {len(files)} file(s) {src}/ -> {dst}/")
+    for f in files:
+        shutil.copy2(f, f"{dst}/{os.path.basename(f)}")
+
+
+def _check():
+    import tempfile
+    d = tempfile.mkdtemp()
+    os.chdir(d)
+    os.makedirs(f"store/download/x")
+    for n in ("x_0.tif", "x_1.nc", "x.vrt", "x.zip"):  # only tif/nc stage; vrt/zip stay
+        open(f"store/download/x/{n}", "wb").close()
+    os.makedirs("store/source/x")
+    open("store/source/x/stale.tif", "wb").close()  # cleared before staging
+    sys.argv = ["source_stage.py", "x"]
+    main()
+    staged = sorted(os.path.basename(p) for p in glob("store/source/x/*"))
+    assert staged == ["x_0.tif", "x_1.nc"], staged
+    assert sorted(os.path.basename(p) for p in glob("store/download/x/*")) == \
+        ["x.vrt", "x.zip", "x_0.tif", "x_1.nc"]  # cache untouched
+    print("source_stage.py self-check ok")
+
+
+if __name__ == "__main__":
+    if sys.argv[1:2] == ["--check"]:
+        _check()
+    else:
+        main()

--- a/pipelines/source_unzip.py
+++ b/pipelines/source_unzip.py
@@ -1,11 +1,14 @@
-"""Extract GeoTIFF tiles from any .zip archives in store/source/<id>/.
+"""Extract GeoTIFF tiles from any .zip archives in store/download/<id>/.
 
-For sources fetched as a zip (e.g. the GEBCO global grid). Flattens the archive's
-*.tif/*.tiff members into store/source/<id>/ and removes the zip. No ±85° clamp
-needed — the aggregation warp to EPSG:3857 clips the poles.
+The normalize-phase stage for zip sources (e.g. the GEBCO global grid): flattens the
+archive's *.tif/*.tiff members by basename into store/source/<id>/, leaving the archive
+untouched in the download cache so re-running normalize needs no re-fetch. Clears the
+source work dir first so a rerun starts from clean raw. No ±85° clamp needed — the
+aggregation warp to EPSG:3857 clips the poles.
 """
 
 import os
+import shutil
 import sys
 import zipfile
 from glob import glob
@@ -15,16 +18,21 @@ def main():
     if len(sys.argv) != 2:
         sys.exit("usage: source_unzip.py <source-id>")
     source = sys.argv[1]
-    zips = sorted(glob(f"store/source/{source}/*.zip"))
-    print(f"unzip {source}: {len(zips)} archive(s)")
+    src = f"store/download/{source}"
+    dst = f"store/source/{source}"
+    zips = sorted(glob(f"{src}/*.zip"))
+    if not zips:
+        sys.exit(f"no archives in {src}/ (run source-download first?)")
+    shutil.rmtree(dst, ignore_errors=True)
+    os.makedirs(dst, exist_ok=True)
+    print(f"unzip {source}: {len(zips)} archive(s) {src}/ -> {dst}/")
     for zpath in zips:
         with zipfile.ZipFile(zpath) as z:
             members = [n for n in z.namelist() if n.lower().endswith((".tif", ".tiff"))]
             print(f"  {zpath}: {len(members)} tif(s)")
             for name in members:
-                with open(f"store/source/{source}/{os.path.basename(name)}", "wb") as f:
+                with open(f"{dst}/{os.path.basename(name)}", "wb") as f:
                     f.write(z.read(name))
-        os.remove(zpath)
 
 
 if __name__ == "__main__":

--- a/sources/african_great_lakes/Justfile
+++ b/sources/african_great_lakes/Justfile
@@ -6,8 +6,15 @@
 # aggregation reprojects each lake from its own frame. Lakes are hydraulically isolated,
 # so no ocean seam.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_african_lakes.py african_great_lakes
+
+[no-cd]
+normalize:
+    uv run python source_stage.py african_great_lakes
     uv run python source_datum.py african_great_lakes --negate
     uv run python source_normalize.py african_great_lakes
     uv run python source_bounds.py african_great_lakes

--- a/sources/ausbathytopo/Justfile
+++ b/sources/ausbathytopo/Justfile
@@ -2,8 +2,14 @@
 # One zip → one Float32 COG; MSL elevation (seafloor negative, like GEBCO) → no datum transform.
 # Already EPSG:4326; normalize re-asserts it, warp happens in aggregation. Native ~250 m → z9.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py ausbathytopo
+
+[no-cd]
+normalize:
     uv run python source_unzip.py ausbathytopo
     uv run python source_normalize.py ausbathytopo --crs EPSG:4326
     uv run python source_bounds.py ausbathytopo

--- a/sources/batnas/Justfile
+++ b/sources/batnas/Justfile
@@ -6,8 +6,15 @@
 # Tiles have NO embedded CRS → normalize assigns EPSG:4326. MSL elevation (seafloor negative,
 # land positive, like GEBCO) → no datum transform.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py batnas
+
+[no-cd]
+normalize:
+    uv run python source_stage.py batnas
     uv run python source_normalize.py batnas --crs EPSG:4326
     uv run python source_bounds.py batnas
     uv run python source_polygonize.py batnas 8

--- a/sources/bodensee/Justfile
+++ b/sources/bodensee/Justfile
@@ -5,8 +5,15 @@
 # surrounding-terrain fringe. EPSG:25832 (DHHN92-UTM32N) assigned in normalize. Isolated lake,
 # no ocean seam. (PANGAEA also ships an ETRS89 variant — ellipsoidal height — avoid: messier offset.)
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_swissbathy.py bodensee
+
+[no-cd]
+normalize:
+    uv run python source_stage.py bodensee
     uv run python source_datum.py bodensee --offset -395.2 --clamp-positive
     uv run python source_normalize.py bodensee --crs EPSG:25832
     uv run python source_bounds.py bodensee

--- a/sources/cudem/Justfile
+++ b/sources/cudem/Justfile
@@ -4,5 +4,11 @@
 # store's object mirror separately, and aggregation range-reads them from there). Tiles
 # are already COGs (NAVD88 / NAD83), so no normalize/datum/tarball.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_mirror.py cudem
+
+[no-cd]
+normalize:

--- a/sources/cudem_third/Justfile
+++ b/sources/cudem_third/Justfile
@@ -4,5 +4,11 @@
 # ~10 m, NAVD88 / NAD83; already COGs → no normalize/datum/tarball.
 # Priority derives from (maxzoom, id): cudem (z13) wins over cudem_third (z12) over gebco.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_mirror.py cudem_third
+
+[no-cd]
+normalize:

--- a/sources/ddm/Justfile
+++ b/sources/ddm/Justfile
@@ -1,8 +1,15 @@
 # Danmarks Dybdemodel — Danish waters. Run from pipelines/:  just ../sources/ddm/
 # Plain HTTP download; stored as positive-down depth → negate (source_datum).
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py ddm
+
+[no-cd]
+normalize:
+    uv run python source_stage.py ddm
     uv run python source_datum.py ddm --negate
     uv run python source_normalize.py ddm --crs EPSG:3034
     uv run python source_bounds.py ddm

--- a/sources/emodnet/Justfile
+++ b/sources/emodnet/Justfile
@@ -4,8 +4,14 @@
 # NOTE: ~7 GB zipped / tens of GB unzipped — heavier than a standard CI runner's
 # disk; stage it or use a larger runner.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py emodnet
+
+[no-cd]
+normalize:
     uv run python source_unzip.py emodnet
     uv run python source_normalize.py emodnet --crs EPSG:4326
     uv run python source_bounds.py emodnet

--- a/sources/gbr30/Justfile
+++ b/sources/gbr30/Justfile
@@ -2,8 +2,14 @@
 # One zip of 4 COG tiles; values are MSL elevation (seafloor negative, like GEBCO) →
 # no datum transform. Already EPSG:4326; normalize re-asserts it, warp happens in aggregation.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py gbr30
+
+[no-cd]
+normalize:
     uv run python source_unzip.py gbr30
     uv run python source_normalize.py gbr30 --crs EPSG:4326
     uv run python source_bounds.py gbr30

--- a/sources/gebco/Justfile
+++ b/sources/gebco/Justfile
@@ -2,8 +2,14 @@
 #   just ../sources/gebco/
 # Fetched as a zip, then extracted. No datum transform.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py gebco
+
+[no-cd]
+normalize:
     uv run python source_unzip.py gebco
     uv run python source_normalize.py gebco --crs EPSG:4326
     uv run python source_bounds.py gebco

--- a/sources/great_lakes/Justfile
+++ b/sources/great_lakes/Justfile
@@ -6,8 +6,15 @@
 # (LWD is already the low-water/chart datum). CRS is a .prj sidecar we drop → normalize
 # assigns EPSG:4269 (NAD83 ≈ WGS84). Lakes are isolated → no ocean seam.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_greatlakes.py great_lakes
+
+[no-cd]
+normalize:
+    uv run python source_stage.py great_lakes
     uv run python source_datum.py great_lakes --clamp-positive
     uv run python source_normalize.py great_lakes --crs EPSG:4269
     uv run python source_bounds.py great_lakes

--- a/sources/gsc_atlantic/Justfile
+++ b/sources/gsc_atlantic/Justfile
@@ -4,8 +4,15 @@
 # so the coverage polygon is one solid footprint. Topo-bathy → elevation (seafloor negative,
 # like GEBCO) → no datum transform. (Verify sign on first build; vertical datum unconfirmed.)
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py gsc_atlantic
+
+[no-cd]
+normalize:
+    uv run python source_stage.py gsc_atlantic
     uv run python source_normalize.py gsc_atlantic
     uv run python source_bounds.py gsc_atlantic
     uv run python source_polygonize.py gsc_atlantic 8

--- a/sources/gsc_pacific/Justfile
+++ b/sources/gsc_pacific/Justfile
@@ -6,8 +6,15 @@
 # elevation (seafloor negative, like GEBCO) → no datum transform. Per-tile processing keeps normalize/
 # polygonize memory-safe; the aggregate range-reads per window. z13.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py gsc_pacific
+
+[no-cd]
+normalize:
+    uv run python source_stage.py gsc_pacific
     uv run python source_normalize.py gsc_pacific
     uv run python source_bounds.py gsc_pacific
     uv run python source_polygonize.py gsc_pacific 8

--- a/sources/infomar_10m/Justfile
+++ b/sources/infomar_10m/Justfile
@@ -3,8 +3,14 @@
 # Values are LAT-referenced elevation (seafloor negative, like GEBCO) → no datum transform.
 # The 25 m shelf grid is the sibling source sources/infomar_25m (cudem/cudem_third pattern).
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py infomar_10m
+
+[no-cd]
+normalize:
     uv run python source_unzip.py infomar_10m
     uv run python source_normalize.py infomar_10m --crs EPSG:4326
     uv run python source_bounds.py infomar_10m

--- a/sources/infomar_25m/Justfile
+++ b/sources/infomar_25m/Justfile
@@ -3,8 +3,14 @@
 # LAT-referenced elevation (seafloor negative, like GEBCO) → no datum transform. Sibling of the
 # 10 m sources/infomar_10m (cudem/cudem_third pattern): priority gives 10 m inshore, 25 m on shelf.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py infomar_25m
+
+[no-cd]
+normalize:
     uv run python source_unzip.py infomar_25m
     uv run python source_normalize.py infomar_25m --crs EPSG:4326
     uv run python source_bounds.py infomar_25m

--- a/sources/lac_leman/Justfile
+++ b/sources/lac_leman/Justfile
@@ -4,8 +4,15 @@
 # the surface ~0, the bed negative. EPSG:2056 (CH1903+ LV95) assigned in normalize.
 # Lake is hydraulically isolated, so no ocean seam.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_swissbathy.py lac_leman
+
+[no-cd]
+normalize:
+    uv run python source_stage.py lac_leman
     uv run python source_datum.py lac_leman --offset -372
     uv run python source_normalize.py lac_leman --crs EPSG:2056
     uv run python source_bounds.py lac_leman

--- a/sources/lac_neuchatel/Justfile
+++ b/sources/lac_neuchatel/Justfile
@@ -5,8 +5,15 @@
 # Lake is hydraulically isolated, so no ocean seam. The zip carries a surrounding-terrain
 # fringe (cells above lake level), so --clamp-positive drops post-offset >0 cells to nodata.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_swissbathy.py lac_neuchatel
+
+[no-cd]
+normalize:
+    uv run python source_stage.py lac_neuchatel
     uv run python source_datum.py lac_neuchatel --offset -429.3 --clamp-positive
     uv run python source_normalize.py lac_neuchatel --crs EPSG:2056
     uv run python source_bounds.py lac_neuchatel

--- a/sources/lake_tahoe/Justfile
+++ b/sources/lake_tahoe/Justfile
@@ -5,8 +5,15 @@
 # reference lake elevation) makes the surface ~0 and the bed negative. No negate.
 # Lake is hydraulically isolated, so no ocean seam.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_tahoe.py lake_tahoe
+
+[no-cd]
+normalize:
+    uv run python source_stage.py lake_tahoe
     uv run python source_datum.py lake_tahoe --offset -1899
     uv run python source_normalize.py lake_tahoe --crs EPSG:32610
     uv run python source_bounds.py lake_tahoe

--- a/sources/noaa_estuarine/Justfile
+++ b/sources/noaa_estuarine/Justfile
@@ -5,8 +5,15 @@
 # each from its own zone). Values are bed elevation on the local tidal datum (~MLLW),
 # already GEBCO convention (bed negative, intertidal positive) → no negate, no offset.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download_estuarine.py noaa_estuarine
+
+[no-cd]
+normalize:
+    uv run python source_stage.py noaa_estuarine
     uv run python source_normalize.py noaa_estuarine
     uv run python source_bounds.py noaa_estuarine
     uv run python source_polygonize.py noaa_estuarine 8

--- a/sources/noaa_s102/Justfile
+++ b/sources/noaa_s102/Justfile
@@ -6,5 +6,11 @@
 # mixed_crs + band 1 + negate (depth->elevation at reproject, since mirrored sources skip
 # source_datum). Already MLLW — no datum offset. Sibling of BlueTopo but datum-clean.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_mirror.py noaa_s102
+
+[no-cd]
+normalize:

--- a/sources/swiobc/Justfile
+++ b/sources/swiobc/Justfile
@@ -3,8 +3,15 @@
 # transform. Fully populated (no nodata holes). normalize re-asserts the CRS; the warp to
 # web mercator happens in aggregation. Native ~250 m → z9 (omit max_zoom, let cover derive).
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py swiobc
+
+[no-cd]
+normalize:
+    uv run python source_stage.py swiobc
     uv run python source_normalize.py swiobc --crs EPSG:4326
     uv run python source_bounds.py swiobc
     uv run python source_polygonize.py swiobc 8

--- a/sources/uk_surfzone/Justfile
+++ b/sources/uk_surfzone/Justfile
@@ -10,8 +10,14 @@
 # COGs (one-time, on a build runner). Regenerate file_list.txt with harvest.py if the dspui key
 # rotates or the EA ships a new vintage.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py uk_surfzone
+
+[no-cd]
+normalize:
     uv run python source_unzip.py uk_surfzone
     uv run python source_normalize.py uk_surfzone --crs EPSG:27700
     uv run python source_bounds.py uk_surfzone

--- a/sources/vaklodingen/Justfile
+++ b/sources/vaklodingen/Justfile
@@ -3,8 +3,15 @@
 # like GEBCO) → no datum transform. EPSG:28992 is embedded; normalize re-asserts it and
 # the warp to web mercator happens later in aggregation.
 [no-cd]
-default:
+default: download normalize
+
+[no-cd]
+download:
     uv run python source_download.py vaklodingen
+
+[no-cd]
+normalize:
+    uv run python source_stage.py vaklodingen
     uv run python source_normalize.py vaklodingen --crs EPSG:28992
     uv run python source_bounds.py vaklodingen
     uv run python source_polygonize.py vaklodingen 8


### PR DESCRIPTION
Plan + implementation, shipping together per the `docs/plans` convention. Based off `mosaic-5b` (the only mosaic branch — the ask said `mosaic-b`).

## What

Decouples raw fetch from the datum/normalize transform chain. Raw bytes fetch once into `store/download/<id>/` (a cache later phases never mutate); the transform chain regenerates `store/source/<id>/` from that cache. So iterating on datum/masking (the WSV DGM-W motivation) reruns `just source-normalize <id>` in seconds with no network, instead of forcing a full re-download.

Plan: `docs/plans/2026-07-13-source-download-normalize-split.md`.

## Changes

- **`source_download.py`** — fetch into `store/download/<id>/`, skip cached files, add `--force`. Bespoke `source_download_*` fetchers repoint to the same cache dir.
- **`source_unzip.py`** — read archives from the cache, extract into `store/source/<id>/` (clearing it first), stop deleting the zip.
- **`source_stage.py`** (new) — copy `*.tif`/`*.nc` from the cache into `store/source/<id>/` for non-zip sources, so the in-place datum/normalize mutation never touches raw.
- **every `sources/*/Justfile`** — `default` splits into `download:` + `normalize:` groups (`default` composes both). Mirrored sources (`cudem`, `cudem_third`, `noaa_s102`) map `download: source_mirror` with an empty `normalize`.
- **top-level `Justfile`** — `source-download` / `source-normalize` recipes, `source` composes both + the catalog tail, plus `clean-download`. The CI `just source <id>` invocation is unchanged.

## Verification

- New offline self-checks (`source_download.py --check`, `source_stage.py --check`) pass and are wired into `just test-sources`.
- Every one of the 23 `sources/*/Justfile` parses (`just --summary` → `default download normalize`); `just source <id>` dry-runs to download → normalize → catalog in order, from `pipelines/`.
- `source_remote.py` / `source_catalog.py --check` still green. `test_source_stage.py` and `source_mirror.py --check` couldn't run here (this box has no `gdal_translate`/`gdalinfo` binary) — both exercise code this PR doesn't touch; CI has GDAL.