### PR TITLE
Add CUDEM territory sources (HI/PR/USVI/Guam/AmSam/CNMI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ MapLibre's attribution control credits the sources automatically.
 Sources are merged by priority: resolution-derived (finer data wins where they overlap), except a datum-authoritative source (`priority` in metadata — e.g. S-102, already on a chart datum) wins the overlap even over a finer one. Each is built under [`sources/`](sources/):
 
 - **[NOAA S-102](sources/noaa_s102/)** — ~4–16 m, US navigable · NOAA Office of Coast Survey · public domain · already MLLW + per-node uncertainty
-- **[NOAA CUDEM 1/9″](sources/cudem/)** — ~3 m, US coast · NOAA NCEI · public domain
-- **[NOAA CUDEM 1/3″](sources/cudem_third/)** — ~10 m, US coast · NOAA NCEI · public domain
+- **[NOAA CUDEM 1/9″](sources/cudem/)** — ~3 m, US coast + territories (HI/PR/USVI/Guam/AmSam/CNMI) · NOAA NCEI · public domain
+- **[NOAA CUDEM 1/3″](sources/cudem_third/)** — ~10 m, US coast + territories · NOAA NCEI · public domain
 - **[Danmarks Dybdemodel (DDM)](sources/ddm/)** — 50 m, Danish waters · SDFI / Dataforsyningen
 - **[EMODnet Bathymetry 2024](sources/emodnet/)** — ~115 m, European waters · EMODnet Bathymetry Consortium · CC-BY 4.0
 - **[GEBCO 2026 Grid](sources/gebco/)** — 15″ (~450 m), global base · GEBCO Compilation Group / BODC · public domain

--- a/docs/plans/2026-07-13-cudem-territories.md
+++ b/docs/plans/2026-07-13-cudem-territories.md
@@ -46,14 +46,19 @@ shared `source_catalog.py` tail generates the catalog item.
 
 ## Gotchas
 
-- **Vertical datum varies per territory.** Unlike CONUS (uniform NAVD88), each
-  nearshore product ships its own local datum — verified in the tile headers:
-  HI = MSL (EPSG:9705), PR = PRVD02, USVI = VIVD09, Guam = GUVD04, AmSam = ASVD02,
-  CNMI = NAVD88. The 1/3″ Pacific offshore band (Guam/AmSam/CNMI) is labeled NAVD88.
+- **Vertical datum varies per territory, and per tier.** Unlike CONUS (uniform
+  NAVD88), each territory ships its own local datum — verified in the tile headers.
+  The two tiers do **not** agree for the Pacific territories, so keep them separate:
+  - 1/9″ (nearshore): HI = MSL (EPSG:9705), PR = PRVD02, USVI = VIVD09,
+    Guam = GUVD04, AmSam = ASVD02, CNMI = NAVD88.
+  - 1/3″ (offshore band): HI = MSL, PR = PRVD02, USVI = VIVD09, and Guam / AmSam /
+    CNMI are labeled NAVD88.
+
   All are local-MSL-family, so ingesting **as-is** — no normalize, exactly like CONUS
   NAVD88 — is consistent with current behavior. When [#16](https://github.com/openwatersio/seascape/issues/16)'s
-  low-water offset lands, each territory needs its **own** offset (distinct datums);
-  the per-territory datum is recorded in the `file_list.txt` header for that reason.
+  low-water offset lands, each territory needs its **own** offset (distinct datums),
+  and it must read the datum from the correct tier; the per-territory datum is
+  recorded in each `file_list.txt` header for that reason.
 - **NoData varies per tile** (`-9999` and `-999999`, vs CONUS `-99999`). Not a
   problem: `gdalwarp` reads each tile's nodata + CRS at reproject and remaps to the
   pipeline's `-dstnodata -9999`, so no per-tile handling is needed.

--- a/docs/plans/2026-07-13-cudem-territories.md
+++ b/docs/plans/2026-07-13-cudem-territories.md
@@ -1,0 +1,82 @@
+# CUDEM territory products (HI / PR / USVI / Guam / AmSam / CNMI) — planning doc
+
+Ingest the six NOAA CUDEM territory topobathy products at both resolution tiers.
+Closes [#32](https://github.com/openwatersio/seascape/issues/32).
+
+## Problem: CONUS is built, the territories are not
+
+`sources/cudem` (1/9″) and `sources/cudem_third` (1/3″) mirror NOAA's national
+topobathy manifests, but the six territory products — Hawaii, Puerto Rico, US Virgin
+Islands, Guam, American Samoa, CNMI — are separate NCEI datasets that were never
+listed. The NCEI page carries all six at both resolutions.
+
+## Approach: extend the two existing filelists
+
+They live on the **same bucket** (`noaa-nos-coastal-lidar-pds`), as the **same COG
+tiles**, reached by the **same** `source_mirror.py` mirrored path. `file_list.txt`
+already accepts multiple manifest lines and `enumerate_keys` already enforces a
+single bucket across them — so the whole change is twelve `urllist<ID>.txt` URLs
+appended to the two existing filelists. No new source directories, no new code.
+
+Grouping into the existing two sources (rather than sibling `cudem_territories*`
+dirs, or twelve per-territory dirs) keeps this at the repo's existing granularity —
+CONUS already lumps 18 regions under one source. Split later only if a territory
+churns and trips the shrink guard (see Gotchas).
+
+### Dataset IDs
+
+1/9″ (→ z13): Hawaii `9428`, PuertoRico `9525`, USVI `9529`, Guam `9462`,
+AmSam `9460`, CNMI `9560` — **106** tiles.
+
+1/3″ (→ z12): Hawaii `9429`, PuertoRico `9524`, USVI `9528`, Guam `9463`,
+AmSam `9461`, CNMI `9561` — **136** tiles.
+
+Each `urllist` also names STAC `.json`, `.html`, `.xml`, and a tileindex `.zip`; the
+existing `.tif`/`.tiff` filter in `enumerate_keys` drops them, exactly as it does for
+CONUS.
+
+## Concrete changes
+
+- `sources/cudem/file_list.txt` — 6 territory 1/9″ urllist URLs + header note.
+- `sources/cudem_third/file_list.txt` — 6 territory 1/3″ urllist URLs + header note.
+- `sources/README.md`, `README.md` — coverage now "US coast + territories".
+
+Nothing else: sources auto-register via `config.sources()` (directory glob), and the
+shared `source_catalog.py` tail generates the catalog item.
+
+## Gotchas
+
+- **Vertical datum varies per territory.** Unlike CONUS (uniform NAVD88), each
+  nearshore product ships its own local datum — verified in the tile headers:
+  HI = MSL (EPSG:9705), PR = PRVD02, USVI = VIVD09, Guam = GUVD04, AmSam = ASVD02,
+  CNMI = NAVD88. The 1/3″ Pacific offshore band (Guam/AmSam/CNMI) is labeled NAVD88.
+  All are local-MSL-family, so ingesting **as-is** — no normalize, exactly like CONUS
+  NAVD88 — is consistent with current behavior. When [#16](https://github.com/openwatersio/seascape/issues/16)'s
+  low-water offset lands, each territory needs its **own** offset (distinct datums);
+  the per-territory datum is recorded in the `file_list.txt` header for that reason.
+- **NoData varies per tile** (`-9999` and `-999999`, vs CONUS `-99999`). Not a
+  problem: `gdalwarp` reads each tile's nodata + CRS at reproject and remaps to the
+  pipeline's `-dstnodata -9999`, so no per-tile handling is needed.
+- **Shrink guard is per-source.** Lumping six territories into one source means one
+  territory's dataset being re-IDed is a ~1/7 drop — past `SHRINK_TOLERANCE` (5%), so
+  the whole source would refuse to publish until re-listed (or `MIRROR_ALLOW_SHRINK=1`).
+  Acceptable for stable published editions; the escape hatch if it recurs is to split
+  the territories into their own sibling source.
+
+## Validation
+
+1. `enumerate_keys('cudem')` / `('cudem_third')` — confirmed single bucket, no dupe
+   keys, totals 1036 (930 CONUS + 106 territory) and 509 (373 + 136). ✔
+2. Opened a sample tile from every territory at both tiers — all COGs (512 px tiles,
+   overviews), CRS defined, so `source_mirror` header reads and aggregation range
+   reads work unchanged. ✔
+3. Territories are spatially disjoint from CONUS, so z13-vs-z13 priority never
+   collides.
+
+The full mirror run (header reads on the ~242 new keys + object copy to the data
+bucket) happens in the scheduled sources workflow / build box, not locally.
+
+## Open questions
+
+- Whether the local territory datums warrant a per-territory low-water offset now, or
+  stay deferred to #16 alongside the CONUS NAVD88 offset. Deferred here.

--- a/sources/README.md
+++ b/sources/README.md
@@ -16,8 +16,8 @@ Selection rule: **resolution sets the zoom cap, an openly-redistributable licens
 | [GEBCO 2026](gebco/)                                               | ~450 m      | ~z8       | global                              | MSL                     |
 | [EMODnet 2024](emodnet/)                                           | ~115 m      | z11       | European seas                       | LAT (confirm)           |
 | [DDM (Denmark)](ddm/)                                              | 50 m        | z12       | Danish EEZ                          | MSL (DKMSL2022)         |
-| [CUDEM 1/9](cudem/)                                                | ~3.4 m      | z13       | US coast                            | NAVD88                  |
-| [CUDEM 1/3](cudem_third/)                                          | ~10 m       | z12       | US coast (broader)                  | NAVD88                  |
+| [CUDEM 1/9](cudem/)                                                | ~3.4 m      | z13       | US coast + territories              | NAVD88 / local (terr.)  |
+| [CUDEM 1/3](cudem_third/)                                          | ~10 m       | z12       | US coast + territories (broader)    | NAVD88 / local (terr.)  |
 | [NOAA S-102](noaa_s102/)                                           | ~4–16 m     | z14       | US navigable                        | MLLW (+ uncertainty)    |
 | [Vaklodingen](vaklodingen/)                                        | 20 m        | z12       | Netherlands                         | NAP (~MSL)              |
 | INFOMAR ([10 m](infomar_10m/), [25 m](infomar_25m/))               | 10 m / 25 m | z13 / z11 | Ireland inshore + shelf             | **LAT**                 |

--- a/sources/cudem/file_list.txt
+++ b/sources/cudem/file_list.txt
@@ -8,7 +8,7 @@
 https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_2014_8483/urllist8483.txt
 
 # Territory topobathy (issue #32): Hawaii, Puerto Rico, USVI, Guam, American Samoa,
-# CNMI — same NCEI bucket family, same COG tiles, ~250 more tiles. Each nearshore
+# CNMI — same NCEI bucket family, same COG tiles, 106 more tiles. Each nearshore
 # product carries its OWN local vertical datum, not NAVD88: HI=MSL, PR=PRVD02,
 # USVI=VIVD09, Guam=GUVD04, AmSam=ASVD02, CNMI=NAVD88 (all local-MSL-family, verified
 # in the tile headers). NoData varies per tile (-9999 / -999999); gdalwarp reads each

--- a/sources/cudem/file_list.txt
+++ b/sources/cudem/file_list.txt
@@ -6,3 +6,18 @@
 # NAVD88 vertical / NAD83 (EPSG:4269) horizontal. NOAA regenerates the manifest as
 # tiles are re-surveyed, so coverage stays current without re-listing here.
 https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_2014_8483/urllist8483.txt
+
+# Territory topobathy (issue #32): Hawaii, Puerto Rico, USVI, Guam, American Samoa,
+# CNMI — same NCEI bucket family, same COG tiles, ~250 more tiles. Each nearshore
+# product carries its OWN local vertical datum, not NAVD88: HI=MSL, PR=PRVD02,
+# USVI=VIVD09, Guam=GUVD04, AmSam=ASVD02, CNMI=NAVD88 (all local-MSL-family, verified
+# in the tile headers). NoData varies per tile (-9999 / -999999); gdalwarp reads each
+# tile's nodata + CRS at reproject, so they ingest as-is exactly like CONUS. When #16's
+# low-water offset lands each territory needs its own offset (distinct datums) — that's
+# why the header keeps the per-territory datum on record.
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_Hawaii_9428/urllist9428.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_PuertoRico_9525/urllist9525.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_USVI_9529/urllist9529.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_Guam_9462/urllist9462.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_AmSam_9460/urllist9460.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_ninth_Topobathy_CNMI_9560/urllist9560.txt

--- a/sources/cudem_third/file_list.txt
+++ b/sources/cudem_third/file_list.txt
@@ -6,3 +6,18 @@
 # (header reads for newly-listed tiles only) + a mirror manifest; the bytes are copied
 # into the store's object mirror — no build-time NOAA reads.
 https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_2014_8580/urllist8580.txt
+
+# Territory topobathy (issue #32): Hawaii, Puerto Rico, USVI, Guam, American Samoa,
+# CNMI — same NCEI bucket family, same COG tiles, ~155 more tiles. Vertical datum is
+# local-MSL-family and varies per territory (verified in the tile headers): HI=MSL,
+# PR=PRVD02, USVI=VIVD09, and the Pacific offshore band (Guam/AmSam/CNMI) is labeled
+# NAVD88. NoData varies per tile (-9999 / -999999); gdalwarp reads each tile's nodata
+# + CRS at reproject, so they ingest as-is exactly like CONUS. When #16's low-water
+# offset lands each territory needs its own offset — that's why the header keeps the
+# per-territory datum on record.
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_Hawaii_9429/urllist9429.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_PuertoRico_9524/urllist9524.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_USVI_9528/urllist9528.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_Guam_9463/urllist9463.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_AmSam_9461/urllist9461.txt
+https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_CNMI_9561/urllist9561.txt

--- a/sources/cudem_third/file_list.txt
+++ b/sources/cudem_third/file_list.txt
@@ -8,7 +8,7 @@
 https://noaa-nos-coastal-lidar-pds.s3.amazonaws.com/dem/NCEI_third_Topobathy_2014_8580/urllist8580.txt
 
 # Territory topobathy (issue #32): Hawaii, Puerto Rico, USVI, Guam, American Samoa,
-# CNMI — same NCEI bucket family, same COG tiles, ~155 more tiles. Vertical datum is
+# CNMI — same NCEI bucket family, same COG tiles, 136 more tiles. Vertical datum is
 # local-MSL-family and varies per territory (verified in the tile headers): HI=MSL,
 # PR=PRVD02, USVI=VIVD09, and the Pacific offshore band (Guam/AmSam/CNMI) is labeled
 # NAVD88. NoData varies per tile (-9999 / -999999); gdalwarp reads each tile's nodata


### PR DESCRIPTION
Closes #32.

CONUS CUDEM is already built; this adds the six territory topobathy products — Hawaii, Puerto Rico, USVI, Guam, American Samoa, CNMI — at both the 1/9″ and 1/3″ tiers.

They sit on the same NCEI bucket as CONUS, as the same COG tiles, reached by the same mirrored `source_mirror` path. `file_list.txt` already takes multiple manifest lines and `enumerate_keys` already enforces a single bucket, so the change is just twelve `urllist` URLs appended to the two existing filelists — no new source dirs, no new code. I kept them in the existing two sources rather than sibling dirs to match current granularity (CONUS already lumps 18 regions under one source); we can split later if a territory ever trips the shrink guard.

Adds 106 tiles (1/9″) and 136 (1/3″). The `.tif` filter drops the STAC json/html/tileindex sidecars, same as CONUS.

One wrinkle worth a look in review: vertical datum varies per territory, unlike CONUS's uniform NAVD88 — HI=MSL, PR=PRVD02, USVI=VIVD09, Guam=GUVD04, AmSam=ASVD02, CNMI=NAVD88, all verified in the tile headers. They're all local-MSL-family, so I ingested them as-is exactly like CONUS NAVD88, and recorded the datum per-territory in the filelist headers so #16's low-water offset work has what it needs. NoData also varies per tile (-9999/-999999) but gdalwarp reads it per-tile, so nothing to handle.

**Validation:** `enumerate_keys` confirms single bucket, no dupe keys, totals 1036 (930 CONUS + 106 territory) and 509 (373 + 136); I opened a sample tile from every territory at both tiers — all COGs with defined CRS. The full mirror run (header reads + object copy to the data bucket) happens in the scheduled sources workflow, not locally.

Plan doc: `docs/plans/2026-07-13-cudem-territories.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)