### PR TITLE
Persistent Hetzner volume as the build store — the cache outlives the box

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,20 +17,21 @@ name: Build
 # keepalive tuning, and the `build.env` + `%q` quoting: secrets now flow as native job `env:`,
 # which removes the sourced-file code-injection vector by construction (no file is ever `source`d).
 #
-# The store lives in R2 under bathymetry/ as an IMMUTABLE, CONTENT-ADDRESSED store: every artifact
-# carries its content-hash key (pipelines/keys.py) IN its filename (<stem>-<key12>.<ext>), so a
-# stage skips artifacts whose name is present and a code/config change writes a NEW name — the old
-# one becomes unreferenced garbage the GC (gc.yml) collects. Nothing is ever mutated or deleted in
-# place. Each planet build assembles a STORE MANIFEST (the content name of every artifact it left)
-# and flips a one-object pointer (store/manifest.json) LAST — one atomic PUT — so the next build's
-# hydrate and the GC see the whole old world or the whole new one. Source registration/mirroring +
-# the land/water masks are sources.yml — a build never contacts an upstream; it reads every byte
-# (sources + masks) from R2 over /vsicurl.
-# Final bundles land in build/<sha>/; a release promotes that build (release.yml).
+# The STORE lives on a PERSISTENT Hetzner volume (env.STORE_VOLUME) attached to each build box: an
+# IMMUTABLE, CONTENT-ADDRESSED cache where every artifact carries its content-hash key
+# (pipelines/keys.py) IN its filename (<stem>-<key12>.<ext>), so a stage skips artifacts whose name
+# is present and a code/config change writes a NEW name. Because the volume outlives the box, every
+# run — completed OR interrupted — leaves durable progress the next run reuses with zero hydrate or
+# resume machinery; the volume is a CACHE (sources + code regenerate it), so losing it costs one
+# forced rebuild, never data. R2 keeps what it is right for: the stage-1 sources mirror (synced
+# down to the volume incrementally), and the published PRODUCTS — the mosaic (tiles + GTI,
+# pointer-last atomic publish) and the per-build bundles in build/<sha>/ (release.yml promotes
+# them). Source registration/mirroring + the land/water masks are sources.yml — a build never
+# contacts an upstream.
 #
 # Dispatch-only (a shared store shouldn't be mutated by routine pushes); any branch can trigger
-# one. A `bbox` builds a self-contained regional slice (no volume, no store push, no manifest/
-# pointer, never released). Deletion is out-of-band: gc.yml, sharing this concurrency group, is the
+# one. A `bbox` builds a self-contained regional slice (no volume — NVMe scratch store, never
+# released). Deletion is out-of-band: gc.yml, sharing this concurrency group, is the
 # only path. The light per-commit checks are ci.yml.
 
 on:
@@ -59,6 +60,13 @@ env:
   SERVER_TYPE: ${{ github.event.inputs.server_type }}
   SERVER_IMAGE: ubuntu-24.04
   SERVER_LOCATION: fsn1
+  # The PERSISTENT store volume (planet builds): the content-addressed store + hydrated sources
+  # survive between runs, so builds resume from whatever any prior run finished — completed or not.
+  # It is a CACHE, not a product: sources + code regenerate all of it, so losing it costs one forced
+  # rebuild, never data. Lives in SERVER_LOCATION (volumes attach same-location only). Sized for
+  # store (~100 GiB) + sources (~250 GiB) + bundle peak (~100 GiB); resizable live via console.
+  STORE_VOLUME: seascape-store
+  STORE_VOLUME_GB: "500"
   # Server hostname AND runner label (Cyclenerd/hcloud-github-runner registers the runner with
   # --labels "<name>,hetzner").
   NAME: seascape-build-${{ github.run_id }}
@@ -104,10 +112,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Boot an on-demand Hetzner box and register it as a self-hosted runner for this repo. The store
-  # lives on the box's local NVMe root disk — no attached volume — so this job just boots + registers.
-  # server_id is emitted by the action BEFORE its registration wait, so it is available to
-  # delete-runner even if registration times out — teardown still runs.
+  # Boot an on-demand Hetzner box, register it as a self-hosted runner for this repo, and (planet
+  # builds) attach the persistent store volume. server_id is emitted by the action BEFORE its
+  # registration wait, so it is available to delete-runner even if registration times out —
+  # teardown still runs.
   create-runner:
     runs-on: ubuntu-latest
     permissions: { contents: read }
@@ -129,12 +137,38 @@ jobs:
           server_type: ${{ env.SERVER_TYPE }}
           location: ${{ env.SERVER_LOCATION }}
           image: ${{ env.SERVER_IMAGE }}
-          # No attached volume: the store lives on the box's LOCAL NVMe root disk. ccx63 ships ~960 GB
-          # local NVMe — bigger AND faster than the old 400 GB network volume — so the build (~50 GiB
-          # store + ~240 GiB dirty-set sources + ~100 GiB bundle peak ≈ 400 GiB) fits with headroom on
-          # root. 'null' is the action's sentinel for "attach none" (an empty string fails its int check).
-          # The build job's df precheck fails loudly if a box ever has too small a root disk.
+          # 'null' = the action attaches no volume of its own ('' fails its int check). The PERSISTENT
+          # store volume is attached by the step below instead — the action's volume support only
+          # creates+deletes per-run volumes, which is the opposite of a persistent cache.
           volume: 'null'
+
+      # ── attach the PERSISTENT store volume (planet builds only) ── the build cache (content-
+      # addressed store + hydrated sources) lives on a long-lived Hetzner volume, so a fresh box
+      # starts with the previous run's store already present: no manifest hydrate, no line-rate
+      # source re-download (~10 min/run), and an INTERRUPTED run's finished tiles are reused by the
+      # next run's content keys with zero resume machinery. Created once here (create-if-missing =
+      # self-bootstrapping); never deleted by any workflow. Attach fails loudly if the volume is
+      # still attached elsewhere (a leaked server) — the r2-store concurrency group means no two
+      # builds race for it. bbox smokes keep the NVMe scratch store and may run in any location;
+      # the volume pins planet builds to SERVER_LOCATION.
+      - name: Attach persistent store volume (planet only)
+        if: ${{ github.event.inputs.bbox == '' }}
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SERVER_ID: ${{ steps.runner.outputs.server_id }}
+        run: |
+          set -euo pipefail
+          # Pinned + sha256-verified hcloud (this job holds HCLOUD_TOKEN — same discipline as delete-runner).
+          curl -fsSL -o /tmp/hcloud.tgz https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-amd64.tar.gz
+          echo "8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86  /tmp/hcloud.tgz" | sha256sum -c
+          tar xzf /tmp/hcloud.tgz -C /tmp hcloud
+          sudo mv /tmp/hcloud /usr/local/bin/
+          if ! hcloud volume describe "$STORE_VOLUME" >/dev/null 2>&1; then
+            echo "store volume $STORE_VOLUME does not exist — creating (${STORE_VOLUME_GB} GB, $SERVER_LOCATION; one-time bootstrap)"
+            hcloud volume create --name "$STORE_VOLUME" --size "$STORE_VOLUME_GB" --location "$SERVER_LOCATION"
+          fi
+          hcloud volume attach "$STORE_VOLUME" --server "$SERVER_ID"
+          echo "volume $STORE_VOLUME attached to server $SERVER_ID"
 
   # Runs NATIVELY on the Hetzner box (runs-on: the runner label the action minted). No SSH, no
   # rsync, no build.env — secrets are native job env, and the pipeline is the same `just` stages
@@ -178,10 +212,10 @@ jobs:
           set -euo pipefail
           export DEBIAN_FRONTEND=noninteractive
           # ── docker + the PINNED sha256-verified rclone (apt's 1.60.1 501s on R2's version-id
-          #    responses — same pin as sources.yml/release.yml). jq: read the store pointer +
-          #    manifest. The runner runs as root, so no sudo. ──
+          #    responses — same pin as sources.yml/release.yml). The runner runs as root, so no
+          #    sudo. ──
           apt-get update -qq
-          apt-get install -y -qq unzip jq
+          apt-get install -y -qq unzip
           command -v docker >/dev/null || curl -fsSL https://get.docker.com | sh
           curl -fsSL -o /tmp/rclone.zip "https://downloads.rclone.org/v1.74.4/rclone-v1.74.4-linux-amd64.zip"
           echo "fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d  /tmp/rclone.zip" | sha256sum -c
@@ -196,16 +230,38 @@ jobs:
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"
 
-          # ── store on the box's LOCAL NVMe root disk (no attached volume) ── ccx63 has ~960 GB
-          #    local NVMe, faster than a network volume. A planet build needs ~400 GiB (store +
-          #    dirty-set sources + bundle peak); precheck the root filesystem has room and FAIL LOUD
-          #    if a box is ever too small, rather than running out mid-build. bbox is far smaller.
-          STORE="$GITHUB_WORKSPACE/pipelines/store"
-          mkdir -p "$STORE"
+          # ── store on the PERSISTENT volume (planet) / local NVMe (bbox) ── create-runner attached
+          #    the long-lived volume; mount it and point STORE there. The store survives the box, so
+          #    content keys skip everything ANY prior run finished — the hydrate/push-loop/resume
+          #    machinery this replaces is deleted below. First boot: blank volume → mkfs (one-time).
+          #    AGGREGATION SCRATCH stays on the box's local NVMe: store/aggregation holds only the
+          #    per-run covering plan + each tile's multi-GB reproject/merge tmp churn — regenerated
+          #    every run, never worth persisting, and its IO (TBs across a planet run) would saturate
+          #    a Ceph-backed volume (~300 MB/s) that shrugs at the durable artifacts' write rate.
+          #    dr() nested-binds it over the volume mount, so the pipeline sees one store path.
+          SCRATCH="$GITHUB_WORKSPACE/pipelines/store-scratch"
+          mkdir -p "$SCRATCH"
           if [ -z "${BBOX:-}" ]; then
+            dev=""
+            for _ in $(seq 1 30); do
+              for d in /dev/disk/by-id/scsi-0HC_Volume_*; do [ -e "$d" ] && dev="$d" && break; done
+              [ -n "$dev" ] && break
+              sleep 2
+            done
+            [ -n "$dev" ] || { echo "store volume device never appeared — was the attach step skipped or the volume attached elsewhere?" >&2; exit 1; }
+            blkid "$dev" >/dev/null 2>&1 || { echo "blank volume — one-time mkfs"; mkfs.ext4 -q -L seascape-store "$dev"; }
+            mkdir -p /mnt/seascape-store
+            mount -o noatime "$dev" /mnt/seascape-store
+            STORE="/mnt/seascape-store/store"
+            mkdir -p "$STORE"
             avail_gb=$(df -BG --output=avail "$STORE" | tail -1 | tr -dc '0-9')
-            [ "${avail_gb:-0}" -ge 450 ] || { echo "root disk has only ${avail_gb:-?} GiB free at $STORE — a planet build needs ~450; use a box with a bigger local NVMe (ccx63 = ~960)" >&2; exit 1; }
-            echo "store on local NVMe: ${avail_gb} GiB free at $STORE"
+            [ "${avail_gb:-0}" -ge 100 ] || { echo "store volume has only ${avail_gb:-?} GiB free — grow $STORE_VOLUME in the console (resizable live)" >&2; exit 1; }
+            scratch_gb=$(df -BG --output=avail "$SCRATCH" | tail -1 | tr -dc '0-9')
+            [ "${scratch_gb:-0}" -ge 300 ] || { echo "root NVMe has only ${scratch_gb:-?} GiB free for aggregation scratch — a planet build churns ~300; use a bigger box" >&2; exit 1; }
+            echo "store on volume $STORE_VOLUME: ${avail_gb} GiB free at $STORE; scratch on NVMe: ${scratch_gb} GiB free"
+          else
+            STORE="$GITHUB_WORKSPACE/pipelines/store"
+            mkdir -p "$STORE"
           fi
 
           # ── swap SAFETY NET (planet builds only; the LOCAL NVMe root disk, never the attached
@@ -239,8 +295,8 @@ jobs:
           #        from (scheduler.reserve) across its tile's memory-peak section, sized to
           #        weight(tile). This BOUNDS THE CONCURRENT HEAVY-TILE PEAK: the densest coastal
           #        macrotiles can't all merge at once (the OOM), while cores stay full of light tiles.
-          #    RESERVE (~40) covers OS/docker + the periodic push that share the box during aggregate
-          #    (coverage is sequential now — run #6's OOM was the two overlapping). The budget is sized to PHYSICAL RAM only — the
+          #    RESERVE (~40) covers OS/docker + page cache for the volume writes during aggregate
+          #    (coverage is sequential — run #6's OOM was the two overlapping; the push loop is gone). The budget is sized to PHYSICAL RAM only — the
           #    64 GB swap above is a safety net for a tile that peaks past its estimate, NOT budget
           #    headroom (swapping the hot merge arrays would thrash). ccx63 (48/192): pool 48, budget
           #    ~150 GB. ccx33 (8/32): reserve shrinks with RAM so a small box still gets a real budget.
@@ -301,7 +357,10 @@ jobs:
 
           # docker run wrapper: repo code at /app, the store bind-mounted, BBOX/FORCE/TOOLCHAIN
           # forwarded (+ BUNDLE_PROCESSES — only bundle.py reads it; harmless elsewhere).
+          # store/aggregation is NESTED-bound to NVMe scratch over the volume mount (see the store
+          # block above): the pipeline sees one store path, the volume never sees the tmp churn.
           dr() { docker run --rm -v "$GITHUB_WORKSPACE:/app" -v "$STORE:/app/pipelines/store" \
+            -v "$SCRATCH:/app/pipelines/store/aggregation" \
             -e BBOX -e FORCE_REBUILD -e TOOLCHAIN -e BUNDLE_PROCESSES \
             -e TERRAIN_PROCESSES -e TERRAIN_MEM_BUDGET_GB -e AGG_MEM_FACTOR \
             -e GDAL_CACHEMAX "$IMAGE:$IMAGE_TAG" just "$@"; }
@@ -321,40 +380,16 @@ jobs:
           push() { rclone copy "$STORE/$1" "$R2/$2" "${XFER[@]}" "${@:3}"; }
           push_build() { rclone copyto "$STORE/bundle/$1" "$R2/build/$SHA/$1" "${XFER[@]}"; }
 
-          # ── HYDRATE (planet only): MANIFEST-DRIVEN. Read the store pointer, fetch the manifest
-          #    it names, and rclone copy EXACTLY the artifacts it references (--files-from) — so
-          #    unreferenced garbage in the prefixes (superseded keys awaiting GC) costs no hydrate
-          #    bytes. Plus each source's bounds.csv + catalog.json (the tile keys read the item's
-          #    recipe hash + flags) + the footprint gpkgs. Source COGs + masks are hydrated
-          #    selectively AFTER cover (the dirty-set list doesn't exist yet — see the
-          #    sources-manifest block below). Bootstrap: no pointer yet = the FIRST immutable
-          #    build — hydrate nothing and clean-rebuild (the phase-4 rename makes every phase-3
-          #    artifact stale anyway, so a full re-key rebuild happens regardless; adopting the
-          #    old mutable names by renaming is not worth the fragility). Once this build's
-          #    manifest lands, the legacy names become GC debris. A bbox build rebuilds its window
-          #    from scratch and streams sources — bounds + catalog + footprints only, never a
-          #    planet-scoped pointer. ──
-          if [ -z "${BBOX:-}" ]; then
-            echo "── hydrate ──"
-            if rclone cat "$R2/store/manifest.json" > /tmp/pointer.json 2>/dev/null && [ -s /tmp/pointer.json ]; then
-              mref=$(jq -r '.manifest // empty' /tmp/pointer.json)
-              [ -n "$mref" ] || { echo "store pointer exists but names no manifest — corrupt pointer.json, refusing to guess" >&2; exit 1; }
-              rclone cat "$R2/store/$mref" > /tmp/manifest.json \
-                || { echo "pointer names $mref but it failed to fetch — pointer/manifest mismatch, refusing to hydrate" >&2; exit 1; }
-              jq -r '.entries[].name' /tmp/manifest.json > /tmp/hydrate-files.txt
-              n=$(wc -l < /tmp/hydrate-files.txt)
-              [ "$n" -gt 0 ] || { echo "store manifest $mref references 0 artifacts — refusing to hydrate an empty world" >&2; exit 1; }
-              echo "hydrating $n referenced store artifacts (manifest $mref)"
-              rclone copy "$R2" "$STORE" "${XFER[@]}" --files-from /tmp/hydrate-files.txt
-            else
-              echo "no store pointer in R2 — first immutable build, clean rebuild (nothing to hydrate)"
-            fi
-            hydrate source source --include '*/bounds.csv' --include '*/catalog.json'
-            hydrate polygon polygon
-          else
-            hydrate source source --include '*/bounds.csv' --include '*/catalog.json'
-            hydrate polygon polygon
-          fi
+          # ── NO STORE HYDRATE. The store IS the volume — whatever any prior run finished (completed
+          #    or interrupted) is already at $STORE, and the content-addressed names are
+          #    self-certifying (key in the filename; local writes are atomic), so freshness checks
+          #    skip it directly. The old manifest-driven R2 hydrate, its bootstrap branch, and the
+          #    resume problem are all deleted, not ported. What still syncs FROM R2 is stage-1 state
+          #    the volume doesn't own: bounds/catalog (source identity), footprints, masks, and the
+          #    dirty-set source files (below, after cover) — all incremental, mostly no-ops once the
+          #    volume is warm. A bbox build keeps the NVMe scratch store and streams sources. ──
+          hydrate source source --include '*/bounds.csv' --include '*/catalog.json'
+          hydrate polygon polygon
 
           # ── aggregate env. Planet builds read sources + masks from LOCAL disk (hydrated
           #    below, after cover names the dirty tiles): two real runs streaming per tile
@@ -432,29 +467,14 @@ jobs:
           fi
 
           echo "── aggregate ──"
-          # Periodic background pushes while aggregate runs, so a long stage makes durable net
-          # progress instead of holding every tile until its end. rclone copy is idempotent
-          # (finished tiles skip), so the loop is cheap. A file caught mid-write copies torn, but
-          # the next pass overwrites it and the final post-stage push (under set -e) is
-          # authoritative — acceptable residual. Loop failures never abort the build.
-          # Aggregate now produces the stage-2 MOSAIC tiles + the vector forks (NOT terrain pmtiles
-          # — those are stage 3's per-zoom render). Push only mosaic/tiles here (immutable, content-
-          # addressed, delta-sized); the mosaic index + the mosaic.gti pointer are pushed LATER,
-          # after mosaic-index builds them, with the pointer last.
-          push_agg() { push mosaic/tiles mosaic/tiles; push contour contour; push soundings soundings; push depare depare; }
-          PUSH_LOOP=
-          if [ -z "${BBOX:-}" ]; then
-            ( while sleep 1200; do push_agg || true; done ) & PUSH_LOOP=$!
-          fi
-          agg_rc=0
+          # Aggregate produces the stage-2 MOSAIC tiles + the vector forks (NOT terrain pmtiles —
+          # those are stage 3's per-zoom render) straight onto the persistent volume, so every
+          # finished tile is durable the moment it lands. The old 20-min push_agg loop (mid-build
+          # R2 durability, torn-copy caveats and all) is deleted — its entire job is now a property
+          # of the storage. R2 sees mosaic tiles only at the mosaic-publish step below.
           docker run --rm -v "$GITHUB_WORKSPACE:/app" -v "$STORE:/app/pipelines/store" \
-            -e BBOX -e FORCE_REBUILD -e TOOLCHAIN "${AGG_ENV[@]}" "$IMAGE:$IMAGE_TAG" just aggregate || agg_rc=$?
-          # Kill the loop on BOTH exits (success or failure) before anything else runs.
-          if [ -n "$PUSH_LOOP" ]; then kill "$PUSH_LOOP" 2>/dev/null || true; wait "$PUSH_LOOP" 2>/dev/null || true; fi
-          if [ "$agg_rc" -ne 0 ]; then exit "$agg_rc"; fi
-          if [ -z "${BBOX:-}" ]; then
-            push_agg
-          fi
+            -v "$SCRATCH:/app/pipelines/store/aggregation" \
+            -e BBOX -e FORCE_REBUILD -e TOOLCHAIN "${AGG_ENV[@]}" "$IMAGE:$IMAGE_TAG" just aggregate
 
           # ── coverage ── SEQUENTIAL, after aggregate: run #6 proved the two can't share the box —
           # full-speed aggregate (~110 GB across 48 workers) + the planet tippecanoe (~130 GB,
@@ -480,10 +500,12 @@ jobs:
           echo "── terrain (per-zoom render from the mosaic) ──"
           dr terrain
           if [ -z "${BBOX:-}" ]; then
-            # The served terrain pmtiles. No covering publish: content names carry all incremental
-            # state, and a re-dispatch hydrates the last manifest's artifacts + re-renders only what
-            # never landed.
-            push pmtiles pmtiles
+            # No terrain-pmtiles or store push: those prefixes were R2-store STATE for the deleted
+            # hydrate, and the store now persists on the volume. The store manifest + pointer flip
+            # are deleted with it — the manifest existed to name a consistent hydrate set; the only
+            # R2 publishes left are PRODUCTS: the mosaic (below, pointer-last) and build/<sha>/.
+            # (gc.yml re-rooting onto mosaic indexes + build manifests is a follow-up — do not run
+            # GC until that lands.)
 
             # ── MOSAIC PUBLISH ── the mosaic is a GDAL-openable published product (QGIS QA,
             #    preview-from-mosaic, third parties). Re-run mosaic-index with MOSAIC_VSI_BASE so the
@@ -493,32 +515,14 @@ jobs:
             #    + index) BEFORE flipping the mosaic.gti pointer — pointer-last atomic publish.
             echo "── mosaic publish (/vsicurl index) ──"
             docker run --rm -v "$GITHUB_WORKSPACE:/app" -v "$STORE:/app/pipelines/store" \
+              -v "$SCRATCH:/app/pipelines/store/aggregation" \
               -e TOOLCHAIN -e MOSAIC_VSI_BASE="/vsicurl/$PUBLIC_BASE/mosaic/tiles" \
               "$IMAGE:$IMAGE_TAG" just mosaic-index
-            push mosaic/tiles mosaic/tiles                 # immutable tile COGs (dedup; push_agg already sent these)
+            push mosaic/tiles mosaic/tiles                 # immutable tile COGs (delta-sized: unchanged keys skip)
             push mosaic mosaic --include 'planet-z8-*.tif' # the z8 overview COG (the .gti <Overview>)
             push mosaic/index mosaic/index                 # the /vsicurl GeoParquet index
             rclone copyto "$STORE/mosaic/mosaic.gti" "$R2/mosaic/mosaic.gti" "${XFER[@]}"  # pointer LAST
             echo "mosaic published: tiles + planet-z8 + index pushed, mosaic.gti pointer flipped"
-
-            # ── STORE PUBLISH: the content-addressed store (mosaic tiles + vector forks + terrain
-            #    pmtiles) is complete after terrain. Assemble the manifest (a walk of the local
-            #    store, in aggregate's key-affecting env so its recomputed keys match the content
-            #    names — it now records mosaic + terrain + vector entries), push it, then flip the
-            #    one-object pointer LAST — one atomic PUT. A reader (the next hydrate, the GC) sees
-            #    the whole old world or the whole new one; a crash before the flip leaves the old
-            #    pointer over a complete old store, and this build's pushed-but-unreferenced objects
-            #    are GC debris. The bounds.csv-last / catalog-last pattern, generalized. ──
-            echo "── store manifest + pointer ──"
-            MANIFEST_ID=$(docker run --rm -v "$GITHUB_WORKSPACE:/app" -v "$STORE:/app/pipelines/store" \
-              -e BBOX -e FORCE_REBUILD -e TOOLCHAIN "${AGG_ENV[@]}" "$IMAGE:$IMAGE_TAG" just store-manifest | tail -1)
-            [ -n "$MANIFEST_ID" ] || { echo "store-manifest produced no id" >&2; exit 1; }
-            rclone copy "$STORE/manifests" "$R2/store/manifests" "${XFER[@]}"
-            n=$(jq -r '.entries | length' "$STORE/manifests/$MANIFEST_ID.json")
-            [ "$n" -gt 0 ] || { echo "store manifest $MANIFEST_ID references 0 artifacts — refusing to flip the pointer" >&2; exit 1; }
-            printf '{"manifest":"manifests/%s.json","sha":"%s","entries":%s}\n' "$MANIFEST_ID" "$SHA" "$n" \
-              | rclone rcat "$R2/store/manifest.json"
-            echo "store published: manifest $MANIFEST_ID ($n artifacts), pointer flipped"
           fi
 
           echo "── bundle (terrain) ──"
@@ -551,9 +555,11 @@ jobs:
 
   # Destroy the box + deregister the runner, ALWAYS — on build success, build failure, OR a
   # create-runner failure (server_id is emitted before the registration wait, so it is present even
-  # if the runner never registered). No volume to destroy (store is on the box's local NVMe, gone
-  # with the box). LOUD-DESTROY discipline: a still-present server after teardown is a leaked
-  # billable resource and fails the step (also flags a stray volume, though none is created now).
+  # if the runner never registered). The PERSISTENT store volume ($STORE_VOLUME) is deliberately
+  # NEVER deleted; Hetzner auto-detaches it when the server is deleted, freeing it for the next
+  # build. LOUD-DESTROY discipline: a still-present server after teardown is a leaked billable
+  # resource and fails the step (a stray per-run volume named after the server is flagged too;
+  # $STORE_VOLUME never matches that name).
   delete-runner:
     needs: [create-runner, build]
     if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ env:
   # rebuild, never data. Lives in SERVER_LOCATION (volumes attach same-location only). Sized for
   # store (~100 GiB) + sources (~250 GiB) + bundle peak (~100 GiB); resizable live via console.
   STORE_VOLUME: seascape-store
-  STORE_VOLUME_GB: "500"
+  STORE_VOLUME_GB: "750"
   # Server hostname AND runner label (Cyclenerd/hcloud-github-runner registers the runner with
   # --labels "<name>,hetzner").
   NAME: seascape-build-${{ github.run_id }}
@@ -383,39 +383,41 @@ jobs:
           push() { rclone copy "$STORE/$1" "$R2/$2" "${XFER[@]}" "${@:3}"; }
           push_build() { rclone copyto "$STORE/bundle/$1" "$R2/build/$SHA/$1" "${XFER[@]}"; }
 
-          # ── NO STORE HYDRATE. The store IS the volume — whatever any prior run finished (completed
-          #    or interrupted) is already at $STORE, and the content-addressed names are
-          #    self-certifying (key in the filename; local writes are atomic), so freshness checks
-          #    skip it directly. The old manifest-driven R2 hydrate, its bootstrap branch, and the
-          #    resume problem are all deleted, not ported. What still syncs FROM R2 is stage-1 state
-          #    the volume doesn't own: bounds/catalog (source identity), footprints, masks, and the
-          #    dirty-set source files (below, after cover) — all incremental, mostly no-ops once the
-          #    volume is warm. A bbox build keeps the NVMe scratch store and streams sources. ──
+          # ── NO STORE HYDRATE, NO SOURCE HYDRATE (planet). The store IS the volume — whatever any
+          #    prior run finished (completed or interrupted) is already at $STORE, and the
+          #    content-addressed names are self-certifying (key in the filename; local writes are
+          #    atomic), so freshness checks skip it directly. Sources, masks, and footprints are
+          #    ALSO on the volume — sources.yml runs on a box with this same volume attached and
+          #    writes them there — so a planet build reads NOTHING from R2/data.openwaters.io. The
+          #    old manifest hydrate, the selective dirty-set source hydrate, and the resume problem
+          #    are all deleted, not ported. A bbox build keeps the NVMe scratch store, hydrates
+          #    bounds/catalog/footprints from the R2 mirror, and streams source bytes. ──
 
           # ── ONE-TIME SEED from R2 (first boot of a blank volume only, marker-gated) ── the old
-          #    push loop left thousands of finished tiles' artifacts in these prefixes (runs #6-#8
-          #    banked ~1900+ tiles that no run could ever see again); same code = same content keys,
-          #    so seeding them onto the volume makes the first volume build skip that work outright.
-          #    This is NOT run #5's per-run prefix-scan mistake: it runs ONCE ever (the marker),
-          #    transfers real data at line rate, and every later boot skips it entirely. It also
-          #    copies superseded-key garbage (~one GC generation's worth) — harmless cache bloat the
-          #    first forced rebuild orphans and a volume cleanup can drop.
-          if [ ! -e "$STORE/.seeded-from-r2" ]; then
-            echo "── one-time seed: prior runs' aggregate output from R2 ──"
-            for p in mosaic/tiles contour soundings depare; do hydrate "$p" "$p"; done
+          #    push loops left thousands of finished tiles' artifacts AND the full prepared-source
+          #    mirror in R2 (runs #6-#8 banked ~1900+ tiles no run could see again); same code =
+          #    same content keys, so seeding the volume makes the first volume build skip that work
+          #    and spares sources.yml a from-upstream re-prep of every source. This is NOT run #5's
+          #    per-run prefix-scan mistake: it runs ONCE ever (the marker), transfers real data at
+          #    line rate, and every later boot skips it entirely. It also copies superseded-key
+          #    garbage (~one GC generation's worth) — harmless cache bloat a volume cleanup can drop.
+          if [ -z "${BBOX:-}" ] && [ ! -e "$STORE/.seeded-from-r2" ]; then
+            echo "── one-time seed: prior runs' aggregate output + the source mirror from R2 ──"
+            for p in mosaic/tiles contour soundings depare source polygon landmask; do hydrate "$p" "$p"; done
             touch "$STORE/.seeded-from-r2"
           fi
+          if [ -n "${BBOX:-}" ]; then
+            hydrate source source --include '*/bounds.csv' --include '*/catalog.json'
+            hydrate polygon polygon
+          fi
 
-          hydrate source source --include '*/bounds.csv' --include '*/catalog.json'
-          hydrate polygon polygon
-
-          # ── aggregate env. Planet builds read sources + masks from LOCAL disk (hydrated
-          #    below, after cover names the dirty tiles): two real runs streaming per tile
+          # ── aggregate env. Planet builds read sources + masks from LOCAL disk (the volume,
+          #    populated by sources.yml + the one-time seed): two real runs streaming per tile
           #    banked ZERO tiles in 2.5-3.9 healthy hours — a coastal macrotile re-reads the
           #    same S-102/CUDEM bytes over /vsicurl for every tile, >2.5 h each. With no
           #    SOURCE_VSI_BASE / LANDMASK / WATERMASK set, config.source_path and the landmask
           #    defaults resolve store/source/<id>/<file> and store/landmask/{land,water}.fgb —
-          #    the hydrated local copies (the preview-local read path). A legacy bounds row
+          #    the volume's local copies (the preview-local read path). A legacy bounds row
           #    whose filename is already an absolute /vsi path passes through source_path
           #    untouched and still streams — acceptable fallback. bbox builds are
           #    self-contained (no volume) and keep streaming everything, as before. ──
@@ -457,31 +459,14 @@ jobs:
           echo "── cover ──"
           dr cover                        # writes the covering (the tiling plan; keys drive dirtiness)
 
-          # ── selective source hydrate (planet only) ──
-          # Pull exactly the source files the stale tiles reference, so aggregate reads them
-          # from local disk: sources-manifest derives the (source, filename) union with the
-          # same key-based dirty derivation the run itself uses (FORCE_REBUILD included).
-          # The MASKS hydrate FIRST, before sources-manifest: local mask content hashes enter
-          # every fork key, so the manifest and aggregate must see identical mask state — a
-          # mask-less manifest run would compute different keys, call every tile stale, and
-          # hydrate the full planet source set. They land at the container's DEFAULT
-          # store/landmask paths, so aggregate needs no LANDMASK/WATERMASK env: land.fgb is
-          # required (flagged coarse sources exist planet-wide — fail here, not per-tile),
-          # water.fgb optional (absent → the clamp degrades to land-only, the old behavior).
-          # Legacy rows whose filename is an absolute /vsi path aren't R2 keys — filter them
-          # out of the files-from list; source_path streams them untouched (the AGG_ENV note).
+          # ── sources are ALREADY LOCAL (planet) ── sources.yml writes every prepared source,
+          #    mask, and footprint straight onto this volume (the one-time seed above covers the
+          #    pre-volume backlog), so the old selective dirty-set hydrate (sources-manifest +
+          #    files-from pull) is deleted — there is nothing to pull. Fail fast if the masks are
+          #    missing (flagged coarse sources exist planet-wide; a mask-less run would clamp
+          #    nothing) rather than per-tile deep in the pool.
           if [ -z "${BBOX:-}" ]; then
-            echo "── hydrate dirty-set sources ──"
-            hydrate landmask landmask --include 'land.fgb' --include 'water.fgb'
-            [ -f "$STORE/landmask/land.fgb" ] || { echo "no land.fgb in R2 — flagged coarse sources need the land mask" >&2; exit 1; }
-            dr sources-manifest
-            grep -v -e '://' -e '/vsi' "$STORE/source-manifest.txt" > /tmp/source-files.txt || true
-            legacy=$(grep -c -e '://' -e '/vsi' "$STORE/source-manifest.txt" || true)
-            if [ "${legacy:-0}" -gt 0 ]; then
-              echo "$legacy legacy absolute-path row(s) keep streaming via /vsicurl"
-            fi
-            echo "hydrating $(wc -l < /tmp/source-files.txt) of $(wc -l < "$STORE/source-manifest.txt") referenced source file(s)"
-            rclone copy "$R2/source" "$STORE/source" --files-from /tmp/source-files.txt "${XFER[@]}"
+            [ -f "$STORE/landmask/land.fgb" ] || { echo "no land.fgb on the volume — run sources.yml (landmask job) first" >&2; exit 1; }
           fi
 
           echo "── aggregate ──"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,12 +172,15 @@ jobs:
 
   # Runs NATIVELY on the Hetzner box (runs-on: the runner label the action minted). No SSH, no
   # rsync, no build.env — secrets are native job env, and the pipeline is the same `just` stages
-  # the old SSH heredoc ran, in the same order, with the same pushes interleaved. No timeout-
-  # minutes: a self-hosted job isn't subject to the 6 h hosted cap; the ceiling is the 72 h
-  # workflow limit, effectively non-binding, so a forced full planet rebuild runs to completion.
+  # the old SSH heredoc ran, in the same order, with the same pushes interleaved.
+  # timeout-minutes is REQUIRED even on self-hosted: self-hosted escapes the 6 h HOSTED-runner
+  # platform cap, but the per-job DEFAULT timeout is 360 min on every runner type — omitting the
+  # key guillotined a healthy planet build at exactly 6 h (run 29371657768, 61% done). 48 h is a
+  # runaway backstop (box costs ~€2/hr), far above any real build.
   build:
     needs: [image, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
+    timeout-minutes: 2880
     permissions: { contents: read, packages: read }
     env:
       # Native job env — no build.env, no `%q`, nothing is ever `source`d, so the sourced-file
@@ -388,6 +391,21 @@ jobs:
           #    the volume doesn't own: bounds/catalog (source identity), footprints, masks, and the
           #    dirty-set source files (below, after cover) — all incremental, mostly no-ops once the
           #    volume is warm. A bbox build keeps the NVMe scratch store and streams sources. ──
+
+          # ── ONE-TIME SEED from R2 (first boot of a blank volume only, marker-gated) ── the old
+          #    push loop left thousands of finished tiles' artifacts in these prefixes (runs #6-#8
+          #    banked ~1900+ tiles that no run could ever see again); same code = same content keys,
+          #    so seeding them onto the volume makes the first volume build skip that work outright.
+          #    This is NOT run #5's per-run prefix-scan mistake: it runs ONCE ever (the marker),
+          #    transfers real data at line rate, and every later boot skips it entirely. It also
+          #    copies superseded-key garbage (~one GC generation's worth) — harmless cache bloat the
+          #    first forced rebuild orphans and a volume cleanup can drop.
+          if [ ! -e "$STORE/.seeded-from-r2" ]; then
+            echo "── one-time seed: prior runs' aggregate output from R2 ──"
+            for p in mosaic/tiles contour soundings depare; do hydrate "$p" "$p"; done
+            touch "$STORE/.seeded-from-r2"
+          fi
+
           hydrate source source --include '*/bounds.csv' --include '*/catalog.json'
           hydrate polygon polygon
 

--- a/.github/workflows/sources.yml
+++ b/.github/workflows/sources.yml
@@ -209,6 +209,17 @@ jobs:
           STORE=/mnt/seascape-store/store
           mkdir -p "$STORE"
           echo "STORE=$STORE" >> "$GITHUB_ENV"
+          # One-time seed of a BLANK volume from the R2 mirror (order-independent bootstrap:
+          # build.yml's fuller seed sets its own marker, which this respects — whichever workflow
+          # touches a blank volume first pays a line-rate R2 copy instead of a from-upstream
+          # re-prep of every source). Marker-gated: every later boot is a no-op.
+          if [ ! -e "$STORE/.seeded-sources-from-r2" ] && [ ! -e "$STORE/.seeded-from-r2" ]; then
+            echo "one-time seed: source mirror + masks + footprints from R2"
+            for p in source polygon landmask; do
+              rclone copy "r2:$DATA_BUCKET/bathymetry/$p" "$STORE/$p" --transfers 32 --checkers 64 --fast-list --retries 5 --stats 30s --stats-one-line
+            done
+            touch "$STORE/.seeded-sources-from-r2"
+          fi
       - uses: ./.github/actions/ghcr-login
       - name: Ensure land + water masks on the volume + R2
         env:
@@ -300,6 +311,17 @@ jobs:
           STORE=/mnt/seascape-store/store
           mkdir -p "$STORE"
           echo "STORE=$STORE" >> "$GITHUB_ENV"
+          # One-time seed of a BLANK volume from the R2 mirror (order-independent bootstrap:
+          # build.yml's fuller seed sets its own marker, which this respects — whichever workflow
+          # touches a blank volume first pays a line-rate R2 copy instead of a from-upstream
+          # re-prep of every source). Marker-gated: every later boot is a no-op.
+          if [ ! -e "$STORE/.seeded-sources-from-r2" ] && [ ! -e "$STORE/.seeded-from-r2" ]; then
+            echo "one-time seed: source mirror + masks + footprints from R2"
+            for p in source polygon landmask; do
+              rclone copy "r2:$DATA_BUCKET/bathymetry/$p" "$STORE/$p" --transfers 32 --checkers 64 --fast-list --retries 5 --stats 30s --stats-one-line
+            done
+            touch "$STORE/.seeded-sources-from-r2"
+          fi
       - uses: ./.github/actions/ghcr-login
       # Volatile sources re-register on EVERY run — their upstream drifts under an
       # unchanged recipe, and tracking that drift is this workflow's whole purpose.

--- a/.github/workflows/sources.yml
+++ b/.github/workflows/sources.yml
@@ -2,12 +2,16 @@ name: Sources
 
 # Source registration + preparation, split out of the build (see
 # docs/plans/2026-07-08-sources-mirror.md): builds must never contact a source
-# upstream, so this workflow owns everything under bathymetry/source/ in R2.
-# Prepared sources are fetched → normalized → pushed exactly as they were in
-# build.yml (recipe-hash-gated, so an unchanged source is a no-op). Volatile
-# sources (NOAA S-102, CUDEM — upstream catalogs that drift) re-register on every
-# run: enumerate the public bucket → MIRROR the objects into the data bucket →
-# push registration files → publish bounds.csv → publish catalog.json LAST.
+# upstream, so this workflow owns all source state. It runs on an on-demand
+# Hetzner box with the PERSISTENT STORE VOLUME attached and writes sources,
+# masks, and footprints THERE — the volume is what planet builds read (local
+# files, zero build-time R2/data.openwaters.io reads) — then pushes the same
+# state to R2, the publish mirror that laptops (`just preview`) and bbox smokes
+# stream from. Prepared sources are fetched → normalized → written to the volume
+# → mirrored to R2 (recipe-hash-gated, so an unchanged source is a no-op).
+# Volatile sources (NOAA S-102, CUDEM — upstream catalogs that drift) re-register
+# on every run: enumerate the public bucket → mirror the objects to the volume →
+# push objects + registration files to R2 → publish bounds.csv → catalog.json LAST.
 #
 # That publish order is the atomicity mechanism. bounds.csv drives the build's
 # covering, and every object a row references is verified-present in R2 before the
@@ -45,21 +49,31 @@ on:
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
-  # The public "data" bucket (data.openwaters.io) — the same store build.yml
-  # reads; see build.yml for the bucket layout.
+  # The public "data" bucket (data.openwaters.io). R2 is now the PUBLISH MIRROR only —
+  # laptops (`just preview`) and bbox smokes stream from it; planet builds read sources
+  # from the persistent volume this workflow populates. See build.yml for the layout.
   DATA_BUCKET: data
   # Volatile registration refuses to publish a >5% row shrink (a mass upstream
   # disappearance) unless deliberately forced — see pipelines/source_mirror.py.
   MIRROR_ALLOW_SHRINK: ${{ github.event.inputs.force == 'true' && '1' || '' }}
-  # R2 via the S3 API (aws-cli v2 honours AWS_ENDPOINT_URL).
-  AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: auto
-  AWS_ENDPOINT_URL: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-  # R2 occasionally returns a transient 500 InternalError; the CLI default (~3 tries)
-  # gives up mid-sync. Adaptive retry + a high ceiling rides it out across every aws s3 call.
-  AWS_RETRY_MODE: adaptive
-  AWS_MAX_ATTEMPTS: "10"
+  # R2 via rclone's env-var remote (remote "r2" exists ambiently in every rclone call —
+  # no config file, no aws-cli on the box).
+  RCLONE_CONFIG_R2_TYPE: s3
+  RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+  RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
+  # The Hetzner box + the persistent store volume (shared with build.yml — same
+  # SERVER_LOCATION pinning, same volume; the r2-store concurrency group guarantees
+  # this workflow and a build never race for the attach). Sources prep is network-
+  # and single-file-CPU-bound — ccx33 (8 vCPU/32 GB) is plenty.
+  SERVER_TYPE: ccx33
+  SERVER_IMAGE: ubuntu-24.04
+  SERVER_LOCATION: fsn1
+  STORE_VOLUME: seascape-store
+  STORE_VOLUME_GB: "750"
+  NAME: seascape-sources-${{ github.run_id }}
 
 # The store is shared with the build: prepared-source syncs use --delete, which
 # must never run under an active build's aggregate shards — so this workflow and
@@ -99,7 +113,50 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Mirror the OSM land mask AND the Overture inland-water mask to R2, rebuilding both when
+  # Boot the Hetzner box that runs every store-writing job below (the landmask + the per-source
+  # matrix serialize onto this ONE runner — the action registers it non-ephemerally, so queued
+  # jobs reuse it) and attach the persistent store volume. Same pattern as build.yml's
+  # create-runner; the r2-store concurrency group means a build can never hold the volume while
+  # this workflow wants it.
+  create-runner:
+    runs-on: ubuntu-latest
+    permissions: { contents: read }
+    outputs:
+      label: ${{ steps.runner.outputs.label }}
+      server_id: ${{ steps.runner.outputs.server_id }}
+    steps:
+      - name: Create runner
+        id: runner
+        uses: Cyclenerd/hcloud-github-runner@v1.4.1
+        with:
+          mode: create
+          github_token: ${{ secrets.RUNNER_PAT }}
+          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+          name: ${{ env.NAME }}
+          server_type: ${{ env.SERVER_TYPE }}
+          location: ${{ env.SERVER_LOCATION }}
+          image: ${{ env.SERVER_IMAGE }}
+          volume: 'null'
+      - name: Attach persistent store volume
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SERVER_ID: ${{ steps.runner.outputs.server_id }}
+        run: |
+          set -euo pipefail
+          # Pinned + sha256-verified hcloud (this job holds HCLOUD_TOKEN — same discipline as build.yml).
+          curl -fsSL -o /tmp/hcloud.tgz https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-amd64.tar.gz
+          echo "8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86  /tmp/hcloud.tgz" | sha256sum -c
+          tar xzf /tmp/hcloud.tgz -C /tmp hcloud
+          sudo mv /tmp/hcloud /usr/local/bin/
+          if ! hcloud volume describe "$STORE_VOLUME" >/dev/null 2>&1; then
+            echo "store volume $STORE_VOLUME does not exist — creating (${STORE_VOLUME_GB} GB, $SERVER_LOCATION; one-time bootstrap)"
+            hcloud volume create --name "$STORE_VOLUME" --size "$STORE_VOLUME_GB" --location "$SERVER_LOCATION"
+          fi
+          hcloud volume attach "$STORE_VOLUME" --server "$SERVER_ID"
+          echo "volume $STORE_VOLUME attached to server $SERVER_ID"
+
+  # Mirror the OSM land mask AND the Overture inland-water mask to the VOLUME (the planet
+  # build's source of truth) and R2 (the publish mirror laptops/bbox stream), rebuilding when
   # landmask.py's recipe changes. They belong here, not in the build: they are source-shaped
   # inputs fetched from upstream (OSM/Overture), on their own upstream cadence, and a build must
   # never fetch from an upstream — it consumes land.fgb/water.fgb from R2 via /vsicurl like any
@@ -115,46 +172,68 @@ jobs:
   # no force dispatch. This job keeps its own .recipe-hash object: the masks have no catalog item
   # to absorb it. force here doesn't apply: the pinned inputs can't drift under an unchanged recipe.
   landmask:
-    needs: image
-    runs-on: ubuntu-latest
+    needs: [image, create-runner]
+    runs-on: ${{ needs.create-runner.outputs.label }}
+    timeout-minutes: 720
     permissions: { contents: read, packages: read }
     steps:
       - uses: actions/checkout@v6
+      # Idempotent box setup — docker + pinned rclone + the store volume mount. Every box job
+      # (this + each per-source matrix job) carries this same step: they serialize onto ONE
+      # runner, so after the first job it's a few no-op checks. The old free-disk-space dance is
+      # gone — the box's NVMe holds the Overture .raw.gpkg spool with room to spare.
+      - name: Set up box (docker + rclone + store volume)
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          command -v unzip >/dev/null || { apt-get update -qq; apt-get install -y -qq unzip; }
+          command -v docker >/dev/null || curl -fsSL https://get.docker.com | sh
+          if ! command -v rclone >/dev/null; then
+            curl -fsSL -o /tmp/rclone.zip "https://downloads.rclone.org/v1.74.4/rclone-v1.74.4-linux-amd64.zip"
+            echo "fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d  /tmp/rclone.zip" | sha256sum -c
+            unzip -q -j /tmp/rclone.zip '*/rclone' -d /tmp/rclone-bin
+            install /tmp/rclone-bin/rclone /usr/local/bin/rclone
+          fi
+          if ! mountpoint -q /mnt/seascape-store; then
+            dev=""
+            for _ in $(seq 1 30); do
+              for d in /dev/disk/by-id/scsi-0HC_Volume_*; do [ -e "$d" ] && dev="$d" && break; done
+              [ -n "$dev" ] && break
+              sleep 2
+            done
+            [ -n "$dev" ] || { echo "store volume device never appeared — attach step skipped or volume held elsewhere?" >&2; exit 1; }
+            blkid "$dev" >/dev/null 2>&1 || { echo "blank volume — one-time mkfs"; mkfs.ext4 -q -L seascape-store "$dev"; }
+            mkdir -p /mnt/seascape-store
+            mount -o noatime "$dev" /mnt/seascape-store
+          fi
+          STORE=/mnt/seascape-store/store
+          mkdir -p "$STORE"
+          echo "STORE=$STORE" >> "$GITHUB_ENV"
       - uses: ./.github/actions/ghcr-login
-      # prep-water spools EVERY non-ocean Overture water feature (rivers, lakes, canals, plus the
-      # river/stream centerlines the second pass filters out) into a temp .raw.gpkg before the
-      # polygon-only filter — tens of GB planet-wide, more than a stock runner's free root disk.
-      # Free it, so the raw copy can't fill the disk mid-refresh. The recipe-skip path exits before
-      # writing anything, so running this unconditionally is harmless and off the hot path.
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-      - name: Ensure land + water masks in R2
+      - name: Ensure land + water masks on the volume + R2
         env:
           RECIPE_HASH: ${{ hashFiles('pipelines/landmask.py') }}
         run: |
-          have=$(aws s3 cp "s3://$DATA_BUCKET/bathymetry/landmask/.recipe-hash" - 2>/dev/null || true)
-          if [ -n "$RECIPE_HASH" ] && [ "$have" = "$RECIPE_HASH" ]; then
-            echo "land + water masks current in R2 (recipe unchanged)"; exit 0
+          # Current only when the recipe hash matches BOTH copies: the volume marker (what planet
+          # builds read) AND the R2 marker (what laptops/bbox stream) — so a crash between the two
+          # publishes heals on the next run instead of leaving one side stale forever.
+          have_v=$(cat "$STORE/landmask/.recipe-hash" 2>/dev/null || true)
+          have_r=$(rclone cat "r2:$DATA_BUCKET/bathymetry/landmask/.recipe-hash" 2>/dev/null || true)
+          if [ -n "$RECIPE_HASH" ] && [ "$have_v" = "$RECIPE_HASH" ] && [ "$have_r" = "$RECIPE_HASH" ] \
+             && [ -f "$STORE/landmask/land.fgb" ] && [ -f "$STORE/landmask/water.fgb" ]; then
+            echo "land + water masks current on volume + R2 (recipe unchanged)"; exit 0
           fi
-          echo "masks stale or missing (recipe=$RECIPE_HASH r2=${have:-none}) — rebuilding both"
-          mkdir -p store
+          echo "masks stale or missing (recipe=$RECIPE_HASH volume=${have_v:-none} r2=${have_r:-none}) — rebuilding both"
           # No `|| true` / continue-on-error on either build: a broken water mask fails the job
-          # exactly like a broken land mask, and the marker below is written last so a failure
+          # exactly like a broken land mask, and the markers below are written last so a failure
           # anywhere leaves the hash stale → next run retries instead of trusting a half-mirror.
-          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just landmask
-          docker run --rm -v "$PWD:/app" -v "$PWD/store:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just watermask
-          aws s3 cp store/landmask/land.fgb "s3://$DATA_BUCKET/bathymetry/landmask/land.fgb"
-          aws s3 cp store/landmask/water.fgb "s3://$DATA_BUCKET/bathymetry/landmask/water.fgb"
-          # Marker last, only after BOTH uploads land: a crash in between re-runs next time
-          # rather than parking a "current" hash over a missing/stale water.fgb.
-          printf '%s' "$RECIPE_HASH" | aws s3 cp - "s3://$DATA_BUCKET/bathymetry/landmask/.recipe-hash"
+          docker run --rm -v "$PWD:/app" -v "$STORE:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just landmask
+          docker run --rm -v "$PWD:/app" -v "$STORE:/app/pipelines/store" "$IMAGE:$IMAGE_TAG" just watermask
+          rclone copyto "$STORE/landmask/land.fgb" "r2:$DATA_BUCKET/bathymetry/landmask/land.fgb" --retries 5
+          rclone copyto "$STORE/landmask/water.fgb" "r2:$DATA_BUCKET/bathymetry/landmask/water.fgb" --retries 5
+          # Markers last, only after BOTH uploads land — volume then R2.
+          printf '%s' "$RECIPE_HASH" > "$STORE/landmask/.recipe-hash"
+          printf '%s' "$RECIPE_HASH" | rclone rcat "r2:$DATA_BUCKET/bathymetry/landmask/.recipe-hash"
 
   # Enumerate the sources (one dir per source) into a matrix.
   discover:
@@ -176,14 +255,16 @@ jobs:
           fi
           echo "sources=$(echo "$all" | jq -R -s -c 'split("\n")|map(select(length>0))')" >> "$GITHUB_OUTPUT"
 
-  # Prepare each source and push its store/source/<id> to R2. One source failing
-  # doesn't sink the rest (fail-fast: false): a failed source simply doesn't
-  # refresh its R2 state, so builds keep covering from its last successful
-  # bounds.csv. The recipe hash in the published catalog.json skips sources whose
-  # recipe (and, for non-volatile sources, data) can't have changed.
+  # Prepare each source ONTO THE VOLUME (the planet build's source of truth) and push it to R2
+  # (the publish mirror laptops/bbox stream). The matrix serializes onto the one box runner.
+  # One source failing doesn't sink the rest (fail-fast: false): a failed source simply doesn't
+  # refresh its state, so builds keep covering from its last successful bounds.csv. The recipe
+  # hash in the catalog.json skips sources whose recipe (and, for non-volatile sources, data)
+  # can't have changed.
   sources:
-    needs: [image, discover]
-    runs-on: ubuntu-latest
+    needs: [image, discover, create-runner]
+    runs-on: ${{ needs.create-runner.outputs.label }}
+    timeout-minutes: 720
     permissions: { contents: read, packages: read }
     strategy:
       fail-fast: false
@@ -191,48 +272,73 @@ jobs:
         source: ${{ fromJSON(needs.discover.outputs.sources) }}
     steps:
       - uses: actions/checkout@v6
+      # Same idempotent box setup as the landmask job — a no-op after the first job on the box.
+      - name: Set up box (docker + rclone + store volume)
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          command -v unzip >/dev/null || { apt-get update -qq; apt-get install -y -qq unzip; }
+          command -v docker >/dev/null || curl -fsSL https://get.docker.com | sh
+          if ! command -v rclone >/dev/null; then
+            curl -fsSL -o /tmp/rclone.zip "https://downloads.rclone.org/v1.74.4/rclone-v1.74.4-linux-amd64.zip"
+            echo "fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d  /tmp/rclone.zip" | sha256sum -c
+            unzip -q -j /tmp/rclone.zip '*/rclone' -d /tmp/rclone-bin
+            install /tmp/rclone-bin/rclone /usr/local/bin/rclone
+          fi
+          if ! mountpoint -q /mnt/seascape-store; then
+            dev=""
+            for _ in $(seq 1 30); do
+              for d in /dev/disk/by-id/scsi-0HC_Volume_*; do [ -e "$d" ] && dev="$d" && break; done
+              [ -n "$dev" ] && break
+              sleep 2
+            done
+            [ -n "$dev" ] || { echo "store volume device never appeared — attach step skipped or volume held elsewhere?" >&2; exit 1; }
+            blkid "$dev" >/dev/null 2>&1 || { echo "blank volume — one-time mkfs"; mkfs.ext4 -q -L seascape-store "$dev"; }
+            mkdir -p /mnt/seascape-store
+            mount -o noatime "$dev" /mnt/seascape-store
+          fi
+          STORE=/mnt/seascape-store/store
+          mkdir -p "$STORE"
+          echo "STORE=$STORE" >> "$GITHUB_ENV"
       - uses: ./.github/actions/ghcr-login
       # Volatile sources re-register on EVERY run — their upstream drifts under an
       # unchanged recipe, and tracking that drift is this workflow's whole purpose.
-      # The rest short-circuit when the recipe hash in R2 matches.
-      - name: Already current in R2?
+      # The rest short-circuit when the recipe hash matches BOTH the volume catalog
+      # (planet builds) and the R2 catalog (laptops/bbox) — a crash between the two
+      # publishes heals next run instead of leaving one side stale.
+      - name: Already current?
         id: check
         env:
           RECIPE_HASH: ${{ hashFiles(format('sources/{0}/**', matrix.source)) }}
           FORCE: ${{ github.event.inputs.force == 'true' && 'true' || 'false' }}
         run: |
           volatile=$(jq -r '.volatile // false' "sources/${{ matrix.source }}/metadata.json")
-          # The recipe hash lives IN the published catalog.json (seascape:recipe_hash — the
-          # retired .recipe-hash marker's successor). A source registered before the catalog
-          # existed, or whose catalog carries no hash, reads as stale and rebuilds once.
-          have=$(aws s3 cp "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/catalog.json" - 2>/dev/null \
+          # The recipe hash lives IN the catalog.json (seascape:recipe_hash). A source
+          # registered before the catalog existed, or whose catalog carries no hash,
+          # reads as stale and rebuilds once.
+          have_v=$(jq -r '.properties["seascape:recipe_hash"] // empty' \
+                   "$STORE/source/${{ matrix.source }}/catalog.json" 2>/dev/null || true)
+          have_r=$(rclone cat "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/catalog.json" 2>/dev/null \
                  | jq -r '.properties["seascape:recipe_hash"] // empty' 2>/dev/null || true)
-          # A source whose recipe polygonizes must have its footprint in R2 (the
-          # build's coverage tileset builds from bathymetry/polygon/). Missing means
-          # the source last built before the polygon push existed — rebuild once.
+          # A source whose recipe polygonizes must have its footprint on both sides (the
+          # coverage tileset builds from polygon/). Missing means it last built before
+          # the polygon push existed — rebuild once.
           poly_ok=true
           if grep -q source_polygonize "sources/${{ matrix.source }}/Justfile"; then
-            aws s3 ls "s3://$DATA_BUCKET/bathymetry/polygon/${{ matrix.source }}.gpkg" >/dev/null || poly_ok=false
+            [ -f "$STORE/polygon/${{ matrix.source }}.gpkg" ] || poly_ok=false
+            rclone lsf "r2:$DATA_BUCKET/bathymetry/polygon/${{ matrix.source }}.gpkg" 2>/dev/null | grep -q . || poly_ok=false
           fi
           if [ "$volatile" = "true" ] || [ "$FORCE" = "true" ]; then current=false
-          elif [ -n "$RECIPE_HASH" ] && [ "$have" = "$RECIPE_HASH" ] && [ "$poly_ok" = "true" ]; then current=true
+          elif [ -n "$RECIPE_HASH" ] && [ "$have_v" = "$RECIPE_HASH" ] && [ "$have_r" = "$RECIPE_HASH" ] && [ "$poly_ok" = "true" ]; then current=true
           else current=false; fi
           {
             echo "current=$current"
             echo "hash=$RECIPE_HASH"
             echo "volatile=$volatile"
           } >> "$GITHUB_OUTPUT"
-          echo "${{ matrix.source }}: recipe=$RECIPE_HASH r2=${have:-none} volatile=$volatile force=$FORCE → current=$current"
-      # Seed the previous bounds.csv so re-registration is incremental: a mirrored
-      # source carries every still-listed row forward with zero header reads, and
-      # the shrink guard has a baseline to diff against. Harmless for the rest: a
-      # prepared source overwrites it.
-      - name: Seed previous bounds
-        if: steps.check.outputs.current != 'true'
-        run: |
-          mkdir -p "store/source/${{ matrix.source }}"
-          aws s3 cp "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/bounds.csv" \
-            "store/source/${{ matrix.source }}/bounds.csv" 2>/dev/null || true
+          echo "${{ matrix.source }}: recipe=$RECIPE_HASH volume=${have_v:-none} r2=${have_r:-none} volatile=$volatile force=$FORCE → current=$current"
+      # (The old "Seed previous bounds" step is gone: bounds.csv now LIVES on the volume, so
+      # incremental re-registration and the shrink guard's baseline are automatic.)
       # `just source` ends in source_catalog.py, which stamps the source's recipe hash into
       # the generated catalog.json (the staleness marker the check above reads back). Pass it
       # in; the pipeline stays R2-agnostic — RECIPE_HASH is just "the recipe content hash" to
@@ -242,90 +348,113 @@ jobs:
         env:
           RECIPE_HASH: ${{ steps.check.outputs.hash }}
         run: |
-          mkdir -p store
           docker run --rm -v "$PWD:/app" -e MIRROR_ALLOW_SHRINK -e RECIPE_HASH \
-            -v "$PWD/store:/app/pipelines/store" \
+            -v "$STORE:/app/pipelines/store" \
             "$IMAGE:$IMAGE_TAG" just source ${{ matrix.source }}
-      # Mirror the upstream objects the registration just enumerated. mirror.txt is
-      # the FULL upstream key list (not just new keys), so a partial prior mirror
-      # self-heals here every refresh. rclone streams object→object with no runner
-      # disk (CUDEM is ~188 GB), skips keys already present (size + preserved
-      # upstream mtime), verifies each transfer against the upstream MD5 ETag
-      # (NOAA's objects are single-part uploads, so the ETag is a real MD5), and
-      # NEVER deletes — superseded objects are ~$3/month of hoarding, and pruning
-      # under a concurrent build would be a delete race.
-      - name: Mirror upstream objects to R2
+      # Mirror the upstream objects the registration just enumerated ONTO THE VOLUME (the
+      # planet build reads them as local files — no /vsicurl, no build-time R2), then push
+      # the same objects up to R2 for the laptops/bbox streaming mirror. mirror.txt is the
+      # FULL upstream key list (not just new keys), so a partial prior mirror self-heals
+      # every refresh; both copies skip keys already present (size + preserved upstream
+      # mtime) and NEVER delete — superseded objects are ~$3/month of hoarding, and pruning
+      # under a concurrent build would be a delete race. The upstream leg verifies against
+      # the upstream MD5 ETag (NOAA's objects are single-part uploads, so it's a real MD5).
+      - name: Mirror upstream objects to the volume + R2
         if: steps.check.outputs.current != 'true' && steps.check.outputs.volatile == 'true'
         run: |
           for f in mirror.txt mirror-bucket.txt; do
-            test -s "store/source/${{ matrix.source }}/$f" || {
+            test -s "$STORE/source/${{ matrix.source }}/$f" || {
               echo "volatile source produced no $f — registration is broken"; exit 1; }
           done
-          # Pinned release, sha256-verified — not apt: Ubuntu 24.04's rclone (1.60.1,
-          # 2022) records the x-amz-version-id R2 now returns on uploads, then 501s on
-          # its post-upload `HEAD ?versionId=` verification. The object still lands, so
-          # every transfer errors once and the retry pass goes green — noise that would
-          # bury a real failure.
-          curl -fsSL -o /tmp/rclone.zip "https://downloads.rclone.org/v1.74.4/rclone-v1.74.4-linux-amd64.zip"
-          echo "fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d  /tmp/rclone.zip" | sha256sum -c
-          unzip -q -j /tmp/rclone.zip '*/rclone' -d /tmp/rclone-bin
-          sudo install /tmp/rclone-bin/rclone /usr/local/bin/rclone
           # source_mirror enumerated the objects, enforced that they live on ONE
           # bucket, and wrote its name here — one URL parser, not a second in sed.
-          bucket=$(cat "store/source/${{ matrix.source }}/mirror-bucket.txt")
-          echo "mirroring $(wc -l < "store/source/${{ matrix.source }}/mirror.txt") objects from $bucket"
-          # Two remotes, no secrets on disk: the NOAA side is anonymous —
-          # env_auth=false so the R2 credentials in the env can't sign its requests —
-          # and the R2 side reads the standard AWS_* env vars + endpoint.
-          cat > /tmp/rclone.conf <<EOF
-          [upstream]
-          type = s3
-          provider = AWS
-          region = us-east-1
-          env_auth = false
-          [r2]
-          type = s3
-          provider = Cloudflare
-          env_auth = true
-          region = auto
-          endpoint = $AWS_ENDPOINT_URL
-          EOF
-          rclone --config /tmp/rclone.conf copy \
-            "upstream:$bucket" "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/objects" \
-            --files-from "store/source/${{ matrix.source }}/mirror.txt" \
+          bucket=$(cat "$STORE/source/${{ matrix.source }}/mirror-bucket.txt")
+          echo "mirroring $(wc -l < "$STORE/source/${{ matrix.source }}/mirror.txt") objects from $bucket"
+          # The upstream remote is anonymous (env_auth absent = false), defined in a temp
+          # config; the r2 remote exists ambiently via the RCLONE_CONFIG_R2_* env vars,
+          # which apply regardless of --config.
+          printf '[upstream]\ntype = s3\nprovider = AWS\nregion = us-east-1\n' > /tmp/upstream.conf
+          rclone --config /tmp/upstream.conf copy \
+            "upstream:$bucket" "$STORE/source/${{ matrix.source }}/objects" \
+            --files-from "$STORE/source/${{ matrix.source }}/mirror.txt" \
             --transfers 16 --checkers 32 --retries 5 --stats 60s --stats-one-line -v
-      # Push the registration files — everything EXCEPT bounds.csv and catalog.json, which
-      # publish last (below). Volatile sources sync without --delete: their objects/ tree
-      # lives under the same prefix and must never be swept by a registration sync.
-      # Prepared sources keep --delete so retired artifacts don't linger (this also sweeps
-      # the retired .recipe-hash object — its hash now rides inside catalog.json).
+          rclone copy "$STORE/source/${{ matrix.source }}/objects" \
+            "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/objects" \
+            --transfers 16 --checkers 32 --retries 5 --stats 60s --stats-one-line
+      # Push the registration files to the R2 mirror — everything EXCEPT bounds.csv and
+      # catalog.json, which publish last (below). Volatile sources copy without delete:
+      # their objects/ tree lives under the same prefix and must never be swept. Prepared
+      # sources sync (rclone sync deletes retired artifacts; excluded files are invisible
+      # to it, never deleted).
       - name: Push source to R2
         if: steps.check.outputs.current != 'true'
         run: |
           if [ "${{ steps.check.outputs.volatile }}" = "true" ]; then
-            aws s3 sync "store/source/${{ matrix.source }}" "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}" \
-              --exclude 'bounds.csv' --exclude 'catalog.json'
+            rclone copy "$STORE/source/${{ matrix.source }}" "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}" \
+              --exclude 'bounds.csv' --exclude 'catalog.json' --exclude 'objects/**' --retries 5
           else
-            aws s3 sync "store/source/${{ matrix.source }}" "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}" \
-              --delete --exclude 'bounds.csv' --exclude 'catalog.json'
+            rclone sync "$STORE/source/${{ matrix.source }}" "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}" \
+              --exclude 'bounds.csv' --exclude 'catalog.json' --retries 5
           fi
-          # Provenance footprint → bathymetry/polygon/ (the build's coverage tileset
-          # reads them all). Guarded: mirrored sources register remote objects and
-          # build none.
-          if [ -f "store/polygon/${{ matrix.source }}.gpkg" ]; then
-            aws s3 cp "store/polygon/${{ matrix.source }}.gpkg" "s3://$DATA_BUCKET/bathymetry/polygon/${{ matrix.source }}.gpkg"
+          # Provenance footprint → bathymetry/polygon/ (the coverage tileset reads them
+          # all). Guarded: mirrored sources register remote objects and build none.
+          if [ -f "$STORE/polygon/${{ matrix.source }}.gpkg" ]; then
+            rclone copyto "$STORE/polygon/${{ matrix.source }}.gpkg" "r2:$DATA_BUCKET/bathymetry/polygon/${{ matrix.source }}.gpkg" --retries 5
           fi
       # bounds.csv then catalog.json, in that order, LAST. bounds.csv is the atomic pointer
       # (every object a row references is already verified-present above, so a build
       # dispatched at any moment sees a complete registration). catalog.json lands after
-      # even that because its seascape:recipe_hash IS the staleness marker (the retired
-      # .recipe-hash): a crash anywhere above leaves the published hash stale, and the next
-      # run redoes the source instead of trusting a half-push. See the header comment for
-      # the (benign) bounds-ahead-of-catalog crash window this ordering accepts.
-      - name: Publish bounds.csv + catalog marker
+      # even that because its seascape:recipe_hash IS the staleness marker: a crash anywhere
+      # above leaves the published hash stale, and the next run redoes the source instead of
+      # trusting a half-push. The volume needs no publish ordering — its files land in place
+      # as `just source` writes them, and the volume catalog hash was stamped by the prepare.
+      - name: Publish bounds.csv + catalog marker to R2
         if: steps.check.outputs.current != 'true'
         run: |
-          aws s3 cp "store/source/${{ matrix.source }}/bounds.csv" \
-            "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/bounds.csv"
-          aws s3 cp "store/source/${{ matrix.source }}/catalog.json" \
-            "s3://$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/catalog.json"
+          rclone copyto "$STORE/source/${{ matrix.source }}/bounds.csv" \
+            "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/bounds.csv" --retries 5
+          rclone copyto "$STORE/source/${{ matrix.source }}/catalog.json" \
+            "r2:$DATA_BUCKET/bathymetry/source/${{ matrix.source }}/catalog.json" --retries 5
+
+  # Destroy the box + deregister the runner, ALWAYS — even if landmask or any matrix source
+  # failed (server_id is emitted before the registration wait). The persistent store volume is
+  # deliberately NEVER deleted; Hetzner auto-detaches it when the server is deleted. Same
+  # LOUD-DESTROY discipline as build.yml.
+  delete-runner:
+    needs: [create-runner, landmask, sources]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: { contents: read }
+    steps:
+      - name: Delete runner + server
+        if: ${{ needs.create-runner.outputs.server_id != '' }}
+        uses: Cyclenerd/hcloud-github-runner@v1.4.1
+        with:
+          mode: delete
+          github_token: ${{ secrets.RUNNER_PAT }}
+          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+          name: ${{ env.NAME }}
+          server_id: ${{ needs.create-runner.outputs.server_id }}
+      - name: Verify no leaked resources
+        if: always()
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/hcloud.tgz https://github.com/hetznercloud/cli/releases/download/v1.66.0/hcloud-linux-amd64.tar.gz
+          echo "8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86  /tmp/hcloud.tgz" | sha256sum -c
+          tar xzf /tmp/hcloud.tgz -C /tmp hcloud
+          sudo mv /tmp/hcloud /usr/local/bin/
+          # A still-present server after teardown is billable — fail loudly. The persistent
+          # $STORE_VOLUME is expected to survive; only a stray per-run volume named after the
+          # server would be a leak.
+          fail=0
+          if hcloud server describe "$NAME" >/dev/null 2>&1; then
+            echo "::error::leaked billable resource: Hetzner server $NAME still exists — delete it manually"
+            fail=1
+          fi
+          if hcloud volume describe "$NAME" >/dev/null 2>&1; then
+            echo "::error::leaked billable resource: Hetzner volume $NAME still exists — delete it manually"
+            fail=1
+          fi
+          exit "$fail"


### PR DESCRIPTION
The store — and now the **sources** — move from R2-hydrate-and-push to a long-lived Hetzner volume (`seascape-store`, created once by whichever workflow touches it first, attached per run, never deleted). **Planet builds read zero bytes from R2/data.openwaters.io.**

## Why

Content-addressed artifacts are self-certifying (the key is in the filename; local writes are atomic), so *any* prior run's finished tiles are safe to reuse — but the R2-as-store protocol only trusted the pointer published by a *completed* build, and no build had ever completed. The week's ledger:

- ~10 min of line-rate (1 Gbps, NIC-saturated) source download every boot — un-tunable by rclone flags
- run #5: 26 min of idle box burned on R2 prefix listings by a resume attempt
- run #6: crash mid-push-cycle lost every vector fork after the last 20-min push
- run #8: killed at exactly 6 h by the default `timeout-minutes` (360 applies to self-hosted too), 61% done, memory textbook — **all 1928 tiles' compute lost again**

With the volume, "what survived" and "what the next run sees" are the same filesystem. A re-dispatch redoes only unfinished tiles.

## What changes

**build.yml**
- create-runner attaches `seascape-store` (create-if-missing, pinned hcloud; planet only — bbox attaches nothing)
- store on the volume; **aggregation scratch stays on local NVMe** (nested docker bind — the covering + per-tile tmp is TBs of churn that would saturate Ceph)
- `timeout-minutes: 2880` (the default 360 killed run #8; self-hosted only escapes the *hosted* platform cap, not the per-job default)
- **one-time marker-gated seed** from R2: prior runs' pushed tiles (~1900+) + the full source mirror → first volume build skips that work
- deleted: manifest hydrate + bootstrap, the 20-min push_agg loop, terrain-pmtiles store push, store manifest + pointer publish, **and the entire selective source-hydrate block** — planet reads sources/masks/footprints as local volume files
- kept: mosaic publish (pointer-last, unchanged), `build/<sha>/` bundles, bbox streaming path

**sources.yml**
- runs on an on-demand Hetzner box (ccx33) with the same volume attached; the per-source matrix serializes onto the one non-ephemeral runner (per-source GH-UI granularity + `fail-fast: false` isolation preserved)
- prepared sources, volatile object mirrors (CUDEM/S-102), masks, footprints written **to the volume**, then pushed to R2 — R2 is now the *publish mirror* for laptops (`just preview`) and bbox smokes
- staleness = recipe hash matches **both** volume and R2 catalogs (crash between publishes self-heals); the seed-previous-bounds step is gone (bounds.csv lives on the volume)
- aws-cli fully replaced by the one pinned rclone; bounds.csv → catalog.json publish-last ordering unchanged

## Costs & risks
- ~€33/mo for 750 GB (resizable live); sources (~250 GiB) now live on it
- Both workflows pin to `SERVER_LOCATION` (fsn1) — volume attach is same-location-only; ccx63 stock there becomes a build dependency
- The volume is a **cache**: sources + code regenerate everything; losing it costs one forced rebuild + one sources.yml run
- Ceph read throughput for source reads during aggregate is the perf unknown — the `[res]` sampler shows it; escape hatch = copy hot sources to NVMe at boot
- The `r2-store` concurrency group serializes build/sources/GC, so the volume attach never races

## Follow-ups (before/after merge)
- **Before the next GC run:** re-root gc.yml onto mosaic indexes + build manifests (store manifests are no longer written)
- After one green planet: phase 5c (re-point vector forks at mosaic windows) so cartographic changes stop re-paying the merge tail

## Validation
- YAML parses; every `run:` script passes `bash -n`; actionlint via CI
- Runner non-ephemerality verified against the action's cloud-init (no `--ephemeral` — matrix jobs queue onto the one runner)
- Not yet exercised against a real box: merge after one green planet run from this branch (which doubles as the volume + sources bootstrap)