### PR TITLE
Add Mapterhorn land relief to the demo app

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,9 @@
           <input type="checkbox" id="toggle-hillshade" checked /> Hillshade
         </label>
         <label>
+          <input type="checkbox" id="toggle-land" checked /> Land relief
+        </label>
+        <label>
           <input type="checkbox" id="toggle-contours" checked /> Contours
         </label>
         <label>

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ const toggles = {
   "toggle-labels": ["contour-labels"],
   "toggle-soundings": ["soundings"],
   "toggle-osm": ["osm-base"],
+  "toggle-land": ["land-hillshade"],
   "toggle-sources": [
     "source-fill",
     "source-highlight",
@@ -77,6 +78,26 @@ const toggles = {
 };
 
 map.on("load", () => {
+  // Mapterhorn (mapterhorn.com): open global terrain DEM, far finer on land
+  // than the bathymetry mosaic. Ocean is flat 0 there, so a hillshade shades
+  // land only — attribution rides in via its TileJSON. Demo-only; the style
+  // package stays bathymetry.
+  map.addSource("mapterhorn", {
+    type: "raster-dem",
+    url: "https://tiles.mapterhorn.com/tilejson.json",
+    tileSize: 512,
+    encoding: "terrarium", // MapLibre doesn't read encoding from TileJSON
+  });
+  map.addLayer(
+    {
+      id: "land-hillshade",
+      type: "hillshade",
+      source: "mapterhorn",
+      paint: { "hillshade-exaggeration": 0.2 },
+    },
+    "contour-lines", // under the chart linework, over the land wash
+  );
+
   // Mariner settings — unit (m/ft/fm), safety depth (metres, 0 = off; drives the
   // hazard tint and black-sounding emphasis, S-52 style), and shading mode: relief
   // (raster ramp, continuous) vs bands (vector ENC depth areas — crisp isobath


### PR DESCRIPTION
The bathymetry DEM carries land only at GEBCO resolution, so land reads flat next to the shaded seafloor. This adds [Mapterhorn](https://mapterhorn.com) — the open global terrain tileset (terrarium-encoded, hosted zxy endpoint) — to the demo viewer:

- `mapterhorn` raster-dem source via their hosted TileJSON (`tiles.mapterhorn.com`); attribution comes along automatically
- `land-hillshade` layer inserted under the chart linework, over the land wash — Mapterhorn's ocean is flat 0, so only land gets shaded
- **Land relief** checkbox in the settings panel, on by default

Demo-only: the `@openwaters/seascape` style package stays pure bathymetry.

Verified with `just preview` over Big Sur: land ridges render, ocean shading untouched, toggle and attribution work.