### PR TITLE
sources: force re-registers from warm raw; overlap object mirror; capture memory series

### DIFF
--- a/.github/workflows/sources.yml
+++ b/.github/workflows/sources.yml
@@ -16,9 +16,13 @@ on:
         required: false
         default: ""
       force:
-        description: "Force re-registration: -F (rebuild everything) + ignore the volatile shrink guard"
+        description: "Force re-registration from warm raw (re-run prep + catalog, NO refetch) + ignore the volatile shrink guard"
         type: boolean
         default: false
+      snakemake_args:
+        description: "Extra snakemake args, e.g. -R cover (aggregation-code changes) or -F (true cold rebuild incl. refetch)"
+        required: false
+        default: ""
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
@@ -162,13 +166,22 @@ jobs:
         env:
           INPUT_SOURCE: ${{ github.event.inputs.source }}
           INPUT_FORCE: ${{ github.event.inputs.force }}
+          INPUT_ARGS: ${{ github.event.inputs.snakemake_args }}
           # LOCAL-disk per-run scratch (docker.sh mounts it at /app/tmp): logs + benchmarks land
           # here, off the network store volume. Step-scoped to avoid redirecting other steps'
           # Python tempfile writes.
           TMP: /var/tmp/seascape-tmp
         run: |
           set -euo pipefail
-          mkdir -p "$TMP"
+          mkdir -p "$TMP/logs"
+          # Memory/swap time series (Hetzner's metrics API has neither) — logs/ ships in the
+          # artifact. Same sampler build.yml runs, minus the progress heartbeat (no build status).
+          ( while sleep 60; do
+              free -m | awk -v t="$(date -u +%FT%TZ)" 'NR==2{u=$3;a=$7} NR==3{print t" used_mb="u" avail_mb="a" swap_used_mb="$3}' \
+                >> "$TMP/logs/memory.log"
+            done ) &
+          mem=$!
+          trap 'kill "$mem" 2>/dev/null || true' EXIT
           # Optional target args, collected into an array so an empty one contributes nothing
           # (no unquoted word-splitting) and a source id can't smuggle extra tokens.
           extra=(--config workdir=/app/state tmp=/app/tmp)
@@ -180,7 +193,13 @@ jobs:
             esac
             extra+=("source=$INPUT_SOURCE")
           fi
-          if [ "$INPUT_FORCE" = "true" ]; then extra+=(-F); fi
+          # Re-register from warm raw: fetch_asset is upstream of prep_source, so --forcerun
+          # re-runs prep + catalog (+ downstream) without refetching. Cold rebuild: -F via snakemake_args.
+          if [ "$INPUT_FORCE" = "true" ]; then extra+=(-R prep_source catalog_item); fi
+          # Extra args reach the command as separate words; reject anything shell-active.
+          case "$INPUT_ARGS" in *[!-A-Za-z0-9_=\ .]*) echo "invalid snakemake_args" >&2; exit 1 ;; esac
+          read -r -a xargs <<<"$INPUT_ARGS"
+          extra+=("${xargs[@]}")
           # Two invocations: the forced re-listing first, alone — across the invocation
           # boundary the engine's input checksums cure unchanged registrations, so the
           # main invocation cascades (catalog → cover → coverage → publish) only on real

--- a/Snakefile
+++ b/Snakefile
@@ -93,9 +93,14 @@ rule prep_source:
 # a forced producer schedules all dependents at plan time, but across an invocation
 # boundary the engine's checksums cure unchanged registrations, so the main invocation
 # cascades only on real upstream drift.
+# The objects push rides here too: mirror_objects is on the mirror.txt branch, NOT the
+# catalog cascade the boundary suppresses, so pulling it into this invocation overlaps each
+# source's ~190 GB copy with the next source's re-listing instead of stranding it behind the
+# barrier. Objects stay additive and land before catalog.json, so cross-boundary atomicity holds.
 rule refresh:
     input:
         expand("store/source/{source}/bounds.csv", source=MIRRORED),
+        expand("store/meta/publish/{source}.objects", source=MIRRORED),
 
 
 # Volatile mirrored collections register objects/<key> rows off the public bucket.


### PR DESCRIPTION
## Why

A `source=nz_coastal` + `force=true` dispatch ran ~2h before being cancelled. Root cause: `force=true` mapped to `-F`, which forces the **entire DAG** reachable from the always-run `catalogs` target. Since `catalogs → cover` depends on *every* source (the covering), the `source=` scope was bypassed and the run cold-refetched **all 1939 raw assets** (uk_surfzone alone is 1305 tiles), then stalled on the single-threaded covering/coverage aggregation.

## Changes

- **Force re-registers, doesn't re-download.** `force=true` now emits `-R prep_source catalog_item` instead of `-F`. `fetch_asset` is upstream of `prep_source`, so `--forcerun` re-runs prep + catalog (+ downstream cover/coverage/publish) from the warm raw on the volume and never refetches. Turns the forced path from ~2h back into the ~40-min class.
- **`snakemake_args` input** (mirrors build.yml) for the escape hatches force gives up: `-F` for a true cold rebuild, `-R cover` for aggregation-code changes. Validated against the same shell-active-char whitelist.
- **`mirror_objects` folded into the refresh invocation.** It's on the `mirror.txt` branch, not the catalog cascade the invocation boundary suppresses, so each source's ~190 GB copy now overlaps the next source's re-listing instead of waiting behind the barrier.
- **Memory/swap sampler** during the run → `logs/memory.log`, matching build.yml (the Hetzner metrics API has no memory/swap series; the artifact already ships `logs/`).

## Effect on usage

- Add a source: `source=<id>` alone (no force) — fetches only that source's missing raw.
- Prep/catalog code change: `force=true` — re-register everything from warm raw, no planet re-download.
- Hard cold rebuild: `snakemake_args: -F`.