### PR TITLE
worker: 404 an unstaged preview sha instead of an unhandled 500

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -31,7 +31,13 @@ import { style as seascapeStyle } from "@openwaters/seascape";
 import { CachedSource, contentEtag, OVERZOOM_TAG_VERSION } from "./cache";
 import { coverageTileJSON } from "./coverage";
 import { unpackTerrarium, packTerrariumInto, cubicBSpline } from "./terrarium";
-import { OverlayIndex, overlayFor, previewRoute } from "./overlay";
+import {
+  OverlayIndex,
+  overlayFor,
+  previewRoute,
+  ManifestMissing,
+  isPreviewMiss,
+} from "./overlay";
 import { limiter } from "./semaphore";
 // jSquash on Workers: WASM must be imported as a module and passed to init()
 // (no fetch-based instantiation in the Workers runtime).
@@ -129,7 +135,7 @@ async function manifest(env: Env): Promise<Manifest> {
   const cacheable = !!env.RELEASE_PREFIX && !env.PREVIEW;
   if (manifestCache && cacheable) return manifestCache;
   const obj = await env.TILES.get((env.RELEASE_PREFIX ?? "") + "manifest.json");
-  if (!obj) throw new Error("manifest.json missing");
+  if (!obj) throw new ManifestMissing("manifest.json missing");
   const m: Manifest = JSON.parse(await obj.text());
   // Tolerate a pre-grid manifest (old release / local seed): planet-only, no 500s.
   m.overlay ??= { split_z: 0, cells: {} };
@@ -297,8 +303,14 @@ export default {
   ): Promise<Response> {
     // An uncaught throw becomes the runtime's bare 500 with no CORS headers,
     // which browsers report as a CORS block (masking the real status) and
-    // MapLibre then won't retry cleanly. Catch everything and answer with CORS.
+    // MapLibre then won't retry cleanly. Catch everything and answer with CORS;
+    // an unstaged preview sha (typed miss) answers 404 instead of the 500.
     return this.handle(req, env, ctx).catch((e: unknown) => {
+      if (isPreviewMiss(e, !!env.PREVIEW))
+        return new Response(
+          "no build staged at this path — never published, or expired by the build/ lifecycle",
+          { status: 404, headers: { "cache-control": "no-store", ...CORS } },
+        );
       console.log(`unhandled: ${e}`);
       return new Response("internal error", {
         status: 500,

--- a/worker/src/overlay.test.mjs
+++ b/worker/src/overlay.test.mjs
@@ -1,6 +1,11 @@
 // Run: node src/overlay.test.mjs   (Node ≥22.18 strips the imported .ts)
 import assert from "node:assert/strict";
-import { overlayFor, previewRoute } from "./overlay.ts";
+import {
+  overlayFor,
+  previewRoute,
+  ManifestMissing,
+  isPreviewMiss,
+} from "./overlay.ts";
 
 const ov = {
   split_z: 5,
@@ -61,3 +66,9 @@ assert.equal(previewRoute(`/${sha}-bbox/3/1/2.webp`, B).rel, "/3/1/2.webp");
 assert.equal(previewRoute(`/${sha}-bogus/0/0/0.pbf`, B), null); // unknown suffix → 404
 
 console.log("previewRoute ok — sha peel, rel/mount rewrite, hex+length guard");
+
+// ── isPreviewMiss: a missing manifest 404s ONLY on preview — prod keeps its 500 ──
+assert.equal(isPreviewMiss(new ManifestMissing("m"), true), true);
+assert.equal(isPreviewMiss(new ManifestMissing("m"), false), false); // prod: loud 500
+assert.equal(isPreviewMiss(new Error("other"), true), false); // real bugs stay 500
+console.log("isPreviewMiss ok — preview-only 404 for the typed manifest miss");

--- a/worker/src/overlay.ts
+++ b/worker/src/overlay.ts
@@ -44,3 +44,13 @@ export function previewRoute(
     mount: `${mount}/${sha}`,
   };
 }
+
+/** Missing manifest.json under the resolved prefix. Thrown by the manifest loader;
+ * on preview it is an expected state (a sha never staged, or expired by the build/
+ * 7-day lifecycle) → 404, while production keeps its loud 500 (a broken release). */
+export class ManifestMissing extends Error {}
+
+/** Should this handler error answer as a preview 404 instead of a 500? */
+export function isPreviewMiss(e: unknown, preview: boolean): boolean {
+  return preview && e instanceof ManifestMissing;
+}


### PR DESCRIPTION
Follow-up to #100's preview work. A preview request for a sha with no staged build — never published (the pre-#100 bbox gap), a typo, or expired by the `build/` 7-day lifecycle — threw `Error: manifest.json missing` into the terminal catch and answered a bare `internal error` 500 (observed live in the `seascape-preview` Cloudflare logs).

- `ManifestMissing` (typed, in `overlay.ts`) replaces the bare throw in the manifest loader.
- The terminal catch maps it to a **404 with a self-explanatory body on preview only** (`isPreviewMiss`); a missing manifest in production is a broken release and keeps the loud 500.
- The decision predicate lives in `overlay.ts` so it's unit-testable bare-node like the rest (`index.ts` imports wasm and can't be) — 3 assertions added to `overlay.test.mjs`: preview miss → 404, prod miss → 500, unrelated errors → 500.

Verified: `node worker/src/overlay.test.mjs` green, `npx tsc --noEmit` (CI's worker typecheck) clean. Deploys via the existing push-to-main trigger on merge.