### PR TITLE
Sanitize water mask before tippecanoe to fix the land rule crash

### DIFF
--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -197,7 +197,14 @@ def prep_water(processes=8):
             utils.run_command(
                 f"ogr2ogr -f GPKG {'-overwrite' if i == 0 else '-update -append'} "
                 f"-nln water {merged} {t}", silent=True)
-        utils.run_command(f"ogr2ogr -f FlatGeobuf -overwrite -nln water {out} {merged}", silent=False)
+        # _water_tile's -clipsrc runs AFTER its polygon filter, so a clipped feature can
+        # re-enter as a collection/empty; those crash tippecanoe's FlatGeobuf reader
+        # (exit 106) and leave the header untyped. Final conversion re-filters + types.
+        utils.run_command(
+            f"ogr2ogr -f FlatGeobuf -overwrite -nln water -nlt PROMOTE_TO_MULTI "
+            f"-dialect SQLITE -sql \"SELECT * FROM water WHERE "
+            f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry)\" "
+            f"{out} {merged}", silent=False)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     print(f"inland-water mask ready: {out}")
@@ -222,16 +229,31 @@ def tiles(out=LAND_TILES):
         raise SystemExit(f"land mask {land} not found — run `landmask.py prep` first")
     utils.create_folder(os.path.dirname(out) or ".")
     water = water_path()
-    layers = f"-L land:{land}" + (f" -L water:{water}" if _present(water) else "")
     tmp = out + ".tmp.pmtiles"
+    tmp_water = out + ".water.fgb"
     try:
+        layers = f"-L land:{land}"
+        if _present(water):
+            # An already-published water.fgb can carry clip artifacts (empty/collection
+            # geometries an older container GDAL wrote) that tippecanoe's FlatGeobuf reader
+            # hard-fails on ("unsupported geometry type 0", exit 106) — GDAL reads them fine,
+            # so sanitize through it: polygonal + non-empty only, header typed via promote.
+            # land.fgb needs none of this: its header is typed Polygon, so nothing
+            # non-conforming could have been written into it.
+            utils.run_command(
+                f"ogr2ogr -f FlatGeobuf -overwrite -nln water -nlt PROMOTE_TO_MULTI "
+                f"-dialect SQLITE -sql \"SELECT * FROM water WHERE "
+                f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry)\" "
+                f"{tmp_water} {water}")
+            layers += f" -L water:{tmp_water}"
         utils.run_command(
             f"tippecanoe -f -o {tmp} {layers} --projection=EPSG:3857 -Z0 -z12 --coalesce",
             silent=False)
         os.replace(tmp, out)
     finally:
-        if os.path.isfile(tmp):
-            os.remove(tmp)
+        for f in (tmp, tmp_water):
+            if os.path.isfile(f):
+                os.remove(f)
     print(f"land tiles ready: {out}")
 
 
@@ -541,7 +563,10 @@ def _check():
                    "properties": {"kind": "lake"}, "geometry": {"type": "Polygon", "coordinates":
                                 [[[1.4, 1.4], [1.6, 1.4], [1.6, 1.6], [1.4, 1.6], [1.4, 1.4]]]}}]}, f)
     water_fgb = f"{d}/water.fgb"
-    utils.run_command(f"ogr2ogr -f FlatGeobuf -t_srs EPSG:3857 -overwrite {water_fgb} {wgj}")
+    # -nlt GEOMETRY leaves the FGB header untyped like the published planet water.fgb,
+    # so the tiles() sanitize pre-pass is genuinely exercised below.
+    utils.run_command(
+        f"ogr2ogr -f FlatGeobuf -t_srs EPSG:3857 -nlt GEOMETRY -overwrite {water_fgb} {wgj}")
     absent = f"{d}/no-such-water.fgb"  # never created — the degrade-to-land-only baseline
 
     # A grid spanning the box + margin (lon/lat 0.5..2.5), ~1 km pixels.


### PR DESCRIPTION
The first `sources` run with the new `land` rule ([run 30051348256](https://github.com/openwatersio/seascape/actions/runs/30051348256)) failed with tippecanoe exit 106: `flatgeobuf has unsupported geometry type 0`, ~130k features into the planet `water.fgb`.

Root cause: the published `water.fgb` carries feature-level clip artifacts — empty/collection geometries an older container GDAL wrote through `-clipsrc` (`_water_tile`'s polygon filter runs *before* its clip, so a clipped feature can re-enter as a collection). The current GDAL FGB writer refuses to write such features (verified: both `NULL` and `POLYGON EMPTY` are rejected outright), and tippecanoe's FGB reader hard-fails on reading them — but GDAL *reads* them fine, as the daily clamp rasterize of this exact file proves. Reproduction detail: an untyped-header FGB with clean features passes the same tippecanoe v2.79.0, so it's the features, not the header.

Two changes in `landmask.py`:

- `tiles()` sanitizes the water input through ogr2ogr into a typed temp before tippecanoe: SQLite-dialect select of polygonal, non-empty geometries, `-nlt PROMOTE_TO_MULTI`. This makes the rule work against the already-published mask indefinitely — no re-prep or R2 migration needed. `land.fgb` needs no pass: its header is typed `Polygon`, so nothing non-conforming could have been written into it.
- `prep_water()`'s final GPKG→FGB conversion applies the same filter + promote, so future preps publish a clean, typed mask at the source.

The self-check fixture now writes its water FGB with an untyped header (`-nlt GEOMETRY`, matching the published file) so the sanitize path is genuinely exercised; `landmask.py --check` passes including a fresh tippecanoe build through the pre-pass.

After merge: re-dispatch `sources` (no force) — the `land` rule re-runs on its missing output alone.