### PR TITLE
Exclude marine water polygons from the land mask

### DIFF
--- a/pipelines/build.smk
+++ b/pipelines/build.smk
@@ -245,7 +245,8 @@ def fork_inputs(wc):
 
 rule contour_tile:
     input:
-        fork_inputs
+        fork_inputs,
+        masks=MASKS,
     output:
         "store/contour/{stem}.fgb"
     params:
@@ -266,7 +267,8 @@ rule contour_tile:
 
 rule soundings_tile:
     input:
-        fork_inputs
+        fork_inputs,
+        masks=MASKS,
     output:
         "store/soundings/{stem}.geojson"
     params:

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -31,6 +31,7 @@ import mercantile
 
 import aggregation_covering
 import config
+import landmask
 import utils
 from aggregation_reproject import get_resolution
 
@@ -156,6 +157,10 @@ def tile(stem):
     dem = mosaic.window_dem(stem, f"{tmp}/dem.tiff")
     if not os.environ.get("SKIP_SMOOTH"):
         smooth.smooth_tiff(dem)
+    # After smoothing: it smears sea negatives back across clamp-flattened islands, and
+    # the warp-time clamp's centre-sampled mask misses narrow rims — either puts
+    # isobaths on land.
+    landmask.clamp_dem_to_land(dem)
     final = _contour_dem(dem, mercantile.Tile(x=x, y=y, z=z), child_z, tmp, stem)
     os.makedirs(os.path.dirname(out), exist_ok=True)
     if final:
@@ -246,9 +251,13 @@ def _tippecanoe(fgbs, minz, maxz, out):
             ["tippecanoe", "-o", out, "-f", "-l", "contours",
              "-n", "Bathymetric contours", "-A", utils.ATTRIBUTION,
              "-Z", str(minz), "-z", str(maxz), "-P", "-q", "--drop-densest-as-needed",
-             # Aggressive low-zoom vertex thinning (tolerance scales with zoom distance from
-             # maxz, so maxz detail is untouched). Env-tunable to dial on a re-bundle.
+             # Aggressive low-zoom vertex thinning. -S alone ALSO applies at maxzoom
+             # (~76 m tolerance at z10), which cut isobaths across islands the DEM-level
+             # land clamp had already routed around — pin maxzoom near-lossless so the
+             # deepest tier keeps the clamped shoreline. Env-tunable to dial on a re-bundle.
              "--simplification", os.environ.get("CONTOUR_SIMPLIFICATION", "8"),
+             "--simplification-at-maximum-zoom",
+             os.environ.get("CONTOUR_SIMPLIFICATION_MAXZOOM", "1"),
              "-y", "depth_m", "-y", "depth_abs_m", "-y", "sys", "-y", "depth_ft", "-y", "depth_fm",
              # FlatGeobuf Integer64 attributes otherwise land in the MVT as strings.
              "-T", "depth_abs_m:int", "-T", "depth_ft:int", "-T", "depth_fm:int",

--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -13,7 +13,9 @@ its own sign flips (aggregation_merge), so no second, source-blind clamp runs af
 the merge to re-flatten trusted data by geography.
 
 Inland water: the mask subtracts an OSM-derived inland-water polygon layer (rivers,
-lakes, canals, reservoirs — not the ocean, which the land polygons already bound) so a
+lakes, canals, reservoirs — not the ocean, which the land polygons already bound, and not
+Overture's marine 'physical' polygons: bays/straits are drawn without island holes, so
+subtracting them erases real islands while opening nothing the coastline hasn't) so a
 flagged source keeps its genuine negative depths inside mapped water (EMODnet's Elbe
 fairway, GEBCO's Amazon channel) instead of flattening them to 0. Worst case inside a
 real water polygon is a coarse depth where water truly exists; the old worst case was
@@ -199,11 +201,14 @@ def prep_water(processes=8):
                 f"-nln water {merged} {t}", silent=True)
         # _water_tile's -clipsrc runs AFTER its polygon filter, so a clipped feature can
         # re-enter as a collection/empty; those crash tippecanoe's FlatGeobuf reader
-        # (exit 106) and leave the header untyped. Final conversion re-filters + types.
+        # (exit 106) and leave the header untyped. Final conversion re-filters + types,
+        # and re-drops 'physical' (marine bays/straits) in case the tile pass predates
+        # that filter.
         utils.run_command(
             f"ogr2ogr -f FlatGeobuf -overwrite -nln water -nlt PROMOTE_TO_MULTI "
             f"-dialect SQLITE -sql \"SELECT * FROM water WHERE "
-            f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry)\" "
+            f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry) "
+            f"AND kind <> 'physical'\" "
             f"{out} {merged}", silent=False)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -240,10 +245,14 @@ def tiles(out=LAND_TILES):
             # so sanitize through it: polygonal + non-empty only, header typed via promote.
             # land.fgb needs none of this: its header is typed Polygon, so nothing
             # non-conforming could have been written into it.
+            # kind <> 'physical': Overture's marine polygons (bays/straits/fjärdar) are
+            # drawn without island holes, so subtracting them erases real islands from
+            # the mask; genuine inland water is lake/pond/river/canal/reservoir.
             utils.run_command(
                 f"ogr2ogr -f FlatGeobuf -overwrite -nln water -nlt PROMOTE_TO_MULTI "
                 f"-dialect SQLITE -sql \"SELECT * FROM water WHERE "
-                f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry)\" "
+                f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry) "
+                f"AND kind <> 'physical'\" "
                 f"{tmp_water} {water}")
             layers += f" -L water:{tmp_water}"
         utils.run_command(
@@ -284,7 +293,7 @@ def _water_tile(job):
     utils.run_command(
         "AWS_NO_SIGN_REQUEST=YES AWS_DEFAULT_REGION=us-west-2 "
         f"ogr2ogr -f GPKG -overwrite -nln water_raw -lco SPATIAL_INDEX=NO "
-        f"-spat {w} {s} {e} {n} -where \"subtype <> 'ocean'\" {raw} {WATER_PARQUET_URL}",
+        f"-spat {w} {s} {e} {n} -where \"subtype NOT IN ('ocean','physical')\" {raw} {WATER_PARQUET_URL}",
         silent=True)
     if not os.path.isfile(raw):
         return None  # open ocean: the read selected nothing
@@ -349,8 +358,12 @@ def rasterize(bounds_3857, res, out_tif, src=None, water_src=None):
             f"-tr {res} {res} -co COMPRESS=DEFLATE -co TILED=YES -co SPARSE_OK=YES "
             f"{clip} {tmp_out}")
         if _present(water):
+            # kind <> 'physical': marine bays/straits are mapped without island holes, so
+            # burning them back to water would erase real islands (they can open nothing
+            # else — seaward of the coastline is already water). Inland kinds only.
             utils.run_command(
-                f"ogr2ogr -f GPKG -overwrite -spat {xmin} {ymin} {xmax} {ymax} {water_clip} {water}")
+                f"ogr2ogr -f GPKG -overwrite -where \"kind <> 'physical'\" "
+                f"-spat {xmin} {ymin} {xmax} {ymax} {water_clip} {water}")
             utils.run_command(f"gdal_rasterize -burn 0 {water_clip} {tmp_out}")
         os.replace(tmp_out, out_tif)  # atomic: out_tif only ever exists complete
     finally:
@@ -375,8 +388,11 @@ def rasterize_water(bounds_3857, res, out_tif, water_src=None):
     clip = out_tif + ".clip.gpkg"
     tmp_out = out_tif + ".tmp.tif"
     try:
+        # Same marine exclusion as rasterize(): a bay polygon over an island would key the
+        # #24 nodata clamp onto dry land.
         utils.run_command(
-            f"ogr2ogr -f GPKG -overwrite -spat {xmin} {ymin} {xmax} {ymax} {clip} {water}")
+            f"ogr2ogr -f GPKG -overwrite -where \"kind <> 'physical'\" "
+            f"-spat {xmin} {ymin} {xmax} {ymax} {clip} {water}")
         utils.run_command(
             f"gdal_rasterize -burn 1 -ot Byte -init 0 -te {xmin} {ymin} {xmax} {ymax} "
             f"-tr {res} {res} -co COMPRESS=DEFLATE -co TILED=YES -co SPARSE_OK=YES "
@@ -561,7 +577,12 @@ def _check():
     with open(wgj, "w") as f:
         json.dump({"type": "FeatureCollection", "features": [{"type": "Feature",
                    "properties": {"kind": "lake"}, "geometry": {"type": "Polygon", "coordinates":
-                                [[[1.4, 1.4], [1.6, 1.4], [1.6, 1.6], [1.4, 1.6], [1.4, 1.4]]]}}]}, f)
+                                [[[1.4, 1.4], [1.6, 1.4], [1.6, 1.6], [1.4, 1.6], [1.4, 1.4]]]}},
+                  # A marine bay overlapping the land box's corner — an "island" under a
+                  # holeless bay polygon. Must never subtract from the mask.
+                  {"type": "Feature", "properties": {"kind": "physical"},
+                   "geometry": {"type": "Polygon", "coordinates":
+                                [[[0.8, 0.8], [1.2, 0.8], [1.2, 1.2], [0.8, 1.2], [0.8, 0.8]]]}}]}, f)
     water_fgb = f"{d}/water.fgb"
     # -nlt GEOMETRY leaves the FGB header untyped like the published planet water.fgb,
     # so the tiles() sanitize pre-pass is genuinely exercised below.
@@ -617,6 +638,15 @@ def _check():
     assert (land[changed] == 1).all() and (lw[changed] == 0).all(), \
         "the water burn must only turn land->water, never water->land"
     assert not ((land == 0) & (lw == 1)).any(), "the water burn must not create land over water"
+
+    # The marine 'physical' bay overlapping the land corner must NOT subtract: probe a
+    # point inside both the land box and the bay box (lon/lat 1.1,1.1).
+    from rasterio.transform import rowcol
+    from rasterio.warp import transform as _tf
+    (bx,), (by,) = _tf("EPSG:4326", "EPSG:3857", [1.1], [1.1])
+    br, bc = rowcol(tr, bx, by)
+    assert land[br, bc] == 1 and lw[br, bc] == 1, \
+        "a marine 'physical' polygon must never erase land from the mask"
 
     # Seam determinism (with the water burn active): the same world cells rasterize identically
     # from a shifted (still grid-aligned) extent — the overlap is byte-identical, so tile halos

--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -313,9 +313,15 @@ def _present(p):
     return p.startswith("/vsi") or os.path.isfile(p)
 
 
-def rasterize(bounds_3857, res, out_tif, src=None, water_src=None):
+def rasterize(bounds_3857, res, out_tif, src=None, water_src=None, all_touched=False):
     """Burn the land mask onto a Byte raster (1=land, 0=water) on the given 3857 grid, then
     subtract inland water (burn 0 over land) where a water mask is present.
+
+    all_touched burns both passes with -at: every pixel a polygon touches, not just pixel
+    centres. At a coarse grid a narrow island rim slips through centre sampling and keeps
+    its false negative depths — the contour/soundings clamp uses -at so the whole rim
+    clamps (over-clamping errs bias-shallow, the chart-safe direction; -at on the water
+    burn symmetrically keeps narrow river channels open).
 
     Pass the SAME -te/-tr gdalwarp uses for the tile, so the mask aligns pixel-for-pixel
     with the warped raster and neighbouring tiles rasterize their shared halo identically
@@ -350,11 +356,12 @@ def rasterize(bounds_3857, res, out_tif, src=None, water_src=None):
     clip = out_tif + ".clip.gpkg"
     water_clip = out_tif + ".water.gpkg"
     tmp_out = out_tif + ".tmp.tif"
+    at = "-at " if all_touched else ""
     try:
         utils.run_command(
             f"ogr2ogr -f GPKG -overwrite -spat {xmin} {ymin} {xmax} {ymax} {clip} {src}")
         utils.run_command(
-            f"gdal_rasterize -burn 1 -ot Byte -init 0 -te {xmin} {ymin} {xmax} {ymax} "
+            f"gdal_rasterize {at}-burn 1 -ot Byte -init 0 -te {xmin} {ymin} {xmax} {ymax} "
             f"-tr {res} {res} -co COMPRESS=DEFLATE -co TILED=YES -co SPARSE_OK=YES "
             f"{clip} {tmp_out}")
         if _present(water):
@@ -364,7 +371,7 @@ def rasterize(bounds_3857, res, out_tif, src=None, water_src=None):
             utils.run_command(
                 f"ogr2ogr -f GPKG -overwrite -where \"kind <> 'physical'\" "
                 f"-spat {xmin} {ymin} {xmax} {ymax} {water_clip} {water}")
-            utils.run_command(f"gdal_rasterize -burn 0 {water_clip} {tmp_out}")
+            utils.run_command(f"gdal_rasterize {at}-burn 0 {water_clip} {tmp_out}")
         os.replace(tmp_out, out_tif)  # atomic: out_tif only ever exists complete
     finally:
         for f in (clip, water_clip, tmp_out):
@@ -431,6 +438,27 @@ def _clamp_negative_land(dem_path, mask_tif, valid):
                     if hit.any():
                         a[hit] = 0
                         ds.write(a, 1, window=win)
+
+
+def clamp_dem_to_land(dem_path):
+    """Post-smooth land clamp for a derived stage-3 DEM (contours/soundings): re-cut
+    negative-under-land to 0 on the DEM's OWN grid before isolines/minima are extracted.
+    The warp-time clamp runs at source resolution with centre sampling, so narrow island
+    rims keep false negatives, and the pre-contour smoothing smears them back across
+    clamped interiors — isobaths and soundings then land on islands. all_touched here so
+    the whole rim clamps (bias-shallow). No-op without a land mask, like everything else."""
+    if not _present(path()):
+        return
+    with rasterio.open(dem_path) as ds:
+        b = ds.bounds
+        res = ds.res[0]
+    mask_tif = dem_path + ".landmask.tif"
+    try:
+        rasterize((b.left, b.bottom, b.right, b.top), res, mask_tif, all_touched=True)
+        clamp(dem_path, mask_tif)
+    finally:
+        if os.path.isfile(mask_tif):
+            os.remove(mask_tif)
 
 
 def clamp(cog_path, mask_tif):

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -31,6 +31,7 @@ import sys
 import mercantile
 
 import contour_run
+import landmask
 import utils
 
 NODATA = -9999
@@ -184,6 +185,9 @@ def tile(stem):
     dem = mosaic.window_dem(stem, f"{tmp}/dem.tiff")
     if not os.environ.get("SKIP_SMOOTH"):
         smooth.smooth_tiff(dem)
+    # Same post-smooth land clamp as contour_tile: without it, smeared/rim negatives
+    # under the land mask mint soundings on islands.
+    landmask.clamp_dem_to_land(dem)
     res = _sound_dem(dem, mercantile.Tile(x=x, y=y, z=z), z, child_z, tmp, stem)
     os.makedirs(os.path.dirname(out), exist_ok=True)
     if res:

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -159,16 +159,41 @@ async function tile(
 // a rollback, or unseeded dev) — a failed header read means "no mask this release". Cached
 // in prod only, mirroring manifest(): a release is immutable, but dev/preview reseed under
 // the running Worker so the negative must not pin.
-let landInfoCache: { maxZoom: number } | null | undefined;
-async function landInfo(env: Env): Promise<{ maxZoom: number } | null> {
+interface LandInfo {
+  maxZoom: number;
+  bbox: readonly [number, number, number, number]; // w, s, e, n
+}
+let landInfoCache: LandInfo | null | undefined;
+async function landInfo(env: Env): Promise<LandInfo | null> {
   const cacheable = !!env.RELEASE_PREFIX && !env.PREVIEW;
   if (landInfoCache !== undefined && cacheable) return landInfoCache;
   const info = await pm(env, "land.pmtiles")
     .getHeader()
-    .then((h) => ({ maxZoom: h.maxZoom }))
+    .then((h) => ({
+      maxZoom: h.maxZoom,
+      bbox: [h.minLon, h.minLat, h.maxLon, h.maxLat] as const,
+    }))
     .catch(() => null);
   if (cacheable) landInfoCache = info;
   return info;
+}
+
+// "Absent mask tile = open ocean" is only valid INSIDE the archive's coverage — outside
+// its header bbox (a partial mask: a bbox preview build) the assumption would knock every
+// land pixel down to unknown-water. CONTAINMENT, not intersection: a tile straddling the
+// bbox edge still has unmasked-territory pixels, so it serves unmasked too.
+function inMaskBounds(
+  bbox: readonly [number, number, number, number],
+  z: number,
+  x: number,
+  y: number,
+): boolean {
+  const n = 1 << z;
+  const lonW = (x / n) * 360 - 180;
+  const lonE = ((x + 1) / n) * 360 - 180;
+  const latN = (Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n))) * 180) / Math.PI;
+  const latS = (Math.atan(Math.sinh(Math.PI * (1 - (2 * (y + 1)) / n))) * 180) / Math.PI;
+  return lonW >= bbox[0] && lonE <= bbox[2] && latS >= bbox[1] && latN <= bbox[3];
 }
 
 // Three outcomes kept distinct (plan Part 3): tile bytes → rasterize; tile absent within a
@@ -189,7 +214,7 @@ async function fetchMask(
   y: number,
 ): Promise<MaskFetch> {
   const info = await landInfo(env);
-  if (!info) return { mask: noMask, bytes: EMPTY };
+  if (!info || !inMaskBounds(info.bbox, z, x, y)) return { mask: noMask, bytes: EMPTY };
   const levels = z - Math.min(z, info.maxZoom);
   try {
     const t = await tile(env, "land.pmtiles", z - levels, x >> levels, y >> levels);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -188,7 +188,9 @@ function inMaskBounds(
   x: number,
   y: number,
 ): boolean {
-  const n = 1 << z;
+  // 2 ** z, not 1 << z: shifts are 32-bit signed, so a junk z >= 31 in the URL would
+  // wrap n and mask/unmask arbitrarily; exponentiation matches the x/y range check.
+  const n = 2 ** z;
   const lonW = (x / n) * 360 - 180;
   const lonE = ((x + 1) / n) * 360 - 180;
   const latN = (Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n))) * 180) / Math.PI;


### PR DESCRIPTION
Review findings on the serve-time land mask (#101): islands covered by Overture marine polygons rendered as open water (Edesön in the Stockholm archipelago showed as a deep basin with soundings over it), isobaths and soundings drew across islands, and a partial mask archive could turn whole coasts into unknown-water wash. Four commits, each fixing one layer:

## 1. Exclude marine `physical` water from the mask (`ff2c79e`)

`water.fgb` includes Overture subtype `physical` — bays, straits, fjärdar — mapped as polygons **without island holes**. In the Baltic test clip that's 1,780 km² across 334 features (largest 595 km²) versus 79 km² of actual lakes. The land∖water burn subtracts them from the mask, erasing every island a bay polygon covers, while opening nothing the coastline doesn't already bound. The build-time clamp consumes the same file, so the mosaic itself carried depths across these islands.

Filtered at every consumer, so it works against the **already-published** `water.fgb` with no Overture re-prep: the Overture pull (`subtype NOT IN ('ocean','physical')`), `prep_water`'s final conversion, `tiles()`'s sanitize pass, and both `rasterize()`/`rasterize_water()` clips (the GEBCO/EMODnet clamp, the #24 nodata clamp, and the 4th-quadrant ocean clamp). Self-check adds a holeless "bay" over the land fixture and asserts it never subtracts.

## 2. Land-clamp the derived DEM for contours/soundings (`d363044`)

Even with a correct mask, isobaths and soundings still minted on islands: the warp-time clamp samples its mask at source resolution by pixel centre, so narrow island rims keep false negatives, and the pre-contour smoothing smears them back across the clamped interior. Fix: `landmask.clamp_dem_to_land()` after smoothing in the contour and soundings lanes — rasterize the mask on the derived DEM's own grid with `ALL_TOUCHED` (rims can't slip through; over-clamping errs bias-shallow) and re-cut negatives to 0. Depare deliberately untouched: it reads the unclamped mosaic by design and the drying redesign converges it by vector cut. The contour/soundings rules now declare the masks as inputs so mask *data* changes rerun them (code changes still need a force, like the warp clamp itself).

## 3. Keep maxzoom contour detail through tippecanoe (`d363044`)

`-S 8` also simplifies **at maxzoom** (~76 m tolerance at z10), cutting the now-clean isobaths back across islands in the archive — despite the comment claiming maxzoom detail was untouched. Pinned `--simplification-at-maximum-zoom 1` so the deepest tier keeps the clamped shoreline; low-zoom thinning unchanged.

## 4. Serve unmasked outside the mask archive's bbox (`4c81243`)

The worker's "absent mask tile = open ocean" assumption is only valid inside `land.pmtiles`' coverage — against a partial archive (a bbox preview build) it knocks every out-of-coverage land pixel down to unknown-depth water. Masking now requires the target tile to be **contained** in the archive's header bbox; outside, the worker serves unmasked, the same degrade posture as an absent archive. Production's planet-wide mask is unaffected (only the ±85.06° edge rows fall outside, where no synthesized tile exists).

## Verification (Baltic preview build, Stockholm archipelago)

- Edesön raster tiles go 0% → 19.2% land at z14; served raster matches the GDAL reference mask exactly at z11–z14; the island renders as land, all isobaths offshore at z15.
- Contour FGB **and** served z10 MVT measure zero isobath length inside the island interior (shapely intersection against the OSM island polygon, 30 m inset).
- A marsh-area tile outside the original clip (with the widened local mask): 13% → 44% land, fake drying 18.5% → 4.3%, unknown wash 19.4% → 5.1%, real depths byte-identical.
- `landmask.py --check`, `bundle.py --check`, `test_build.py`, worker suite + `tsc` all green.

## Deploy notes

- Re-dispatch `sources` with `snakemake_args="-R land"` after merge — the published `land.pmtiles` predates the marine filter (Snakemake deletes the output before a forced run, which clears the `tiles()` already-present guard).
- The clamp changes affect warped-COG and stage-3 state that nothing marks dirty (the known code-only rebuild caveat): coarse-source regions need their aggregation + contour/soundings state cleared or forced before the next full build.