### PR TITLE
Filter non-chart water from the watermask harvest

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -248,6 +248,8 @@ rule landraster:
 rule watermask:
     output:
         "store/landmask/water.fgb"
+    params:
+        version=1, # increment to force a rebuild
     priority: 10_000_000  # see landmask
     retries: 2
     threads: 8  # the planet read is tiled + parallel (landmask._water_tile); IO-bound S3 reads

--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -164,9 +164,10 @@ def prep_water(processes=8):
 
     Chart-relevant means two filters on top of polygons-only: EXCLUDED_SUBTYPES drops the kinds
     that are never chart water (ocean/physical are covered by the land polygons; human_made is
-    swimming pools/fountains/basins; wastewater and spring likewise), and MIN_AREA_M2 floors the
-    compact kinds — channel kinds (river/canal/stream) are exempt, since a tiny fragment there is
-    usually a segment of a connected waterway where a gap does real damage.
+    swimming pools/fountains/basins; wastewater and spring likewise), and MIN_AREA_M2 floors
+    every kind except CHANNEL_KINDS (river/canal/stream) — a tiny channel polygon is usually a
+    segment of a connected waterway where a gap does real damage, while flooring by default
+    keeps a future Overture subtype's small junk from leaking in unexamined.
 
     Each feature keeps its Overture `subtype` as `kind` plus `class`, `is_salt`, and
     `is_intermittent` for finer product decisions downstream: the rasterize burns geometry only

--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -43,12 +43,12 @@ water polygon (Dead Sea, Salton) still flatten to 0 — accepted ceiling, dedica
 lake/river sources are the path if any is ever wanted.
 
 Local layout (store/landmask/): land.fgb — the prepared EPSG:3857 land mask; water.fgb
-— the inland-water polygons subtracted from it, each carrying its Overture `kind`
-(river/lake/canal/reservoir) for the depare nodata layer (optional: absent -> land-only
-mask, i.e. today's behavior, no crash); land-z8.tif — the effective land (land ∖ water)
-rasterized onto the z8 render grid for the overview terrain stems (optional: absent ->
-maskless encode). All are spatial-indexed / tiled and HTTP-range friendly.
-LANDMASK / WATERMASK / LANDRASTER override the paths.
+— the chart-relevant inland-water polygons subtracted from it, each carrying its Overture
+`kind` (river/lake/canal/reservoir/...) plus `class`/`is_salt`/`is_intermittent` for the
+depare nodata layer (optional: absent -> land-only mask, no crash); land-z8.tif — the
+effective land (land ∖ water) rasterized onto the z8 render grid for the overview terrain
+stems (optional: absent -> maskless encode). All are spatial-indexed / tiled and
+HTTP-range friendly. LANDMASK / WATERMASK / LANDRASTER override the paths.
 
   python landmask.py prep         download -> unzip -> convert the land mask (run once)
   python landmask.py prep-water   download -> convert the inland-water mask (run once)
@@ -157,16 +157,22 @@ def prep():
 
 
 def prep_water(processes=8):
-    """Build the inland-water mask once: read the Overture water parquet, keep only polygonal
-    non-ocean features (rivers/lakes/canals/reservoirs — the ocean is already bounded by the
-    land polygons), reproject to EPSG:3857, and write one spatial-indexed FlatGeobuf at
+    """Build the inland-water mask once: read the Overture water parquet, keep only chart-relevant
+    polygonal water, reproject to EPSG:3857, and write one spatial-indexed FlatGeobuf at
     water_path(). The land clamp's rasterize subtracts it per tile, so a flagged coarse source
     keeps its genuine depths inside mapped water. Guarded so a re-run is a no-op.
 
-    Each feature keeps its Overture `subtype` as `kind` (river/lake/canal/reservoir): the
-    rasterize burns geometry only (so Part 2's clamp is unaffected), but the depare nodata layer
-    passes `kind` through to label unknown-depth water. Two passes. The remote pass pulls
-    non-ocean rows with the one filter the parquet reader can push down (`subtype <> 'ocean'`);
+    Chart-relevant means two filters on top of polygons-only: EXCLUDED_SUBTYPES drops the kinds
+    that are never chart water (ocean/physical are covered by the land polygons; human_made is
+    swimming pools/fountains/basins; wastewater and spring likewise), and MIN_AREA_M2 floors the
+    compact kinds — channel kinds (river/canal/stream) are exempt, since a tiny fragment there is
+    usually a segment of a connected waterway where a gap does real damage.
+
+    Each feature keeps its Overture `subtype` as `kind` plus `class`, `is_salt`, and
+    `is_intermittent` for finer product decisions downstream: the rasterize burns geometry only
+    (so Part 2's clamp is unaffected), but the depare nodata layer passes `kind` through to
+    label unknown-depth water. Two passes. The remote pass pulls
+    rows with the one filter the parquet reader can push down (the subtype exclusion);
     geometry-type predicates (OGR_GEOMETRY / ST_GeometryType) silently match nothing through that
     read path, so dropping the linear river/stream centerlines Overture also carries (a burned
     line would punch a spurious 1-px water gap across land) happens in a local pass — SQLite
@@ -213,13 +219,15 @@ def prep_water(processes=8):
         # _water_tile's -clipsrc runs AFTER its polygon filter, so a clipped feature can
         # re-enter as a collection/empty; those crash tippecanoe's FlatGeobuf reader
         # (exit 106) and leave the header untyped. Final conversion re-filters + types,
-        # and re-drops 'physical' (marine bays/straits) in case the tile pass predates
-        # that filter.
+        # re-applies the kind drops in case the tile pass predates them, and applies the
+        # area floor. ST_Area here is EPSG:3857 m² (lat-inflated), so the floor loosens
+        # toward the poles — the conservative direction, more features kept.
         utils.run_command(
             f"ogr2ogr -f FlatGeobuf -overwrite -nln water -nlt PROMOTE_TO_MULTI "
             f"-dialect SQLITE -sql \"SELECT * FROM water WHERE "
             f"GeometryType(geometry) LIKE '%POLYGON%' AND NOT ST_IsEmpty(geometry) "
-            f"AND kind <> 'physical'\" "
+            f"AND kind NOT IN {EXCLUDED_SUBTYPES} "
+            f"AND (kind IN {CHANNEL_KINDS} OR ST_Area(geometry) >= {MIN_AREA_M2})\" "
             f"{out} {merged}", silent=False)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -281,6 +289,18 @@ def tiles(out=LAND_TILES):
 # handful of dense land tiles (Europe/Asia rivers) dominate, most tiles are near-empty ocean.
 WATER_TILE_DEG = int(os.environ.get("WATER_TILE_DEG", "20"))
 
+# Overture subtypes that are never chart water: ocean/physical are already bounded by the land
+# polygons; human_made is 2.6M features, 98% under 1000 m² (swimming pools, fountains, basins).
+EXCLUDED_SUBTYPES = "('ocean','physical','human_made','wastewater','spring')"
+
+# Kinds exempt from the area floor: a tiny river/canal/stream polygon is usually a segment of a
+# connected waterway, and a dropped segment punches a gap in the channel.
+CHANNEL_KINDS = "('river','canal','stream')"
+
+# Area floor (EPSG:3857 m²) for compact kinds — sub-pixel even at z14, and dominated by
+# retention ponds and farm dams that read as noise on a chart.
+MIN_AREA_M2 = 1000
+
 
 def _water_grid(step):
     """(w, s, e, n) windows tiling the whole lon range and the web-mercator lat band, clamped so no
@@ -304,13 +324,13 @@ def _water_tile(job):
     utils.run_command(
         "AWS_NO_SIGN_REQUEST=YES AWS_DEFAULT_REGION=us-west-2 "
         f"ogr2ogr -f GPKG -overwrite -nln water_raw -lco SPATIAL_INDEX=NO "
-        f"-spat {w} {s} {e} {n} -where \"subtype NOT IN ('ocean','physical')\" {raw} {WATER_PARQUET_URL}",
+        f"-spat {w} {s} {e} {n} -where \"subtype NOT IN {EXCLUDED_SUBTYPES}\" {raw} {WATER_PARQUET_URL}",
         silent=True)
     if not os.path.isfile(raw):
         return None  # open ocean: the read selected nothing
     utils.run_command(
         f"ogr2ogr -f GPKG -t_srs EPSG:3857 -overwrite -nln water -dialect SQLITE "
-        "-sql \"SELECT geometry, subtype AS kind FROM water_raw "
+        "-sql \"SELECT geometry, subtype AS kind, class, is_salt, is_intermittent FROM water_raw "
         "WHERE GeometryType(geometry) LIKE '%POLYGON%'\" "
         f"-clipsrc {w} {s} {e} {n} {tile} {raw}",
         silent=True)


### PR DESCRIPTION
The chart renders a lot of water that has no business on a chart: the depare nodata layer turns every water.fgb feature into an unknown-depth-water polygon, and the harvest kept all 25.8M polygonal non-ocean Overture features — swimming pools included.

A full scan of the current planet water.fgb says where the junk lives:

| kind | features | % under 1 ha |
|---|---|---|
| water (untyped) | 17.56M | 50% |
| pond | 3.18M | 85% |
| human_made | 2.61M | 99.6% |
| reservoir | 1.06M | 67% |
| lake | 647k | 8% |
| river | 516k | 23% |

`human_made` (2.6M features, 98% under 1,000 m²) is the swimming-pool/fountain/basin bucket and holds ~0.1% of mapped water area.

## Changes

- Drop `human_made`, `wastewater`, and `spring` subtypes at the parquet read, alongside the existing `ocean`/`physical` exclusions.
- Floor compact kinds (`water`, `pond`, `reservoir`, `lake`) at 1,000 m² (EPSG:3857, so the floor loosens toward the poles — the conservative direction). These features are sub-pixel even at z14.
- Exempt `river`/`canal`/`stream` from the floor: a tiny polygon there is usually a segment of a connected waterway, and dropping it punches a gap in the channel.
- Keep Overture's `class`, `is_salt`, and `is_intermittent` columns so finer product calls (salt ponds, ditches under `canal`, intermittent water) are possible without another harvest.
- `version=1` on the `watermask` rule forces the re-harvest on the next build; the rebuilt mask then cascades through the normal invalidation (clamps, land.pmtiles, depare nodata).

The conservative floor removes ~5.5M features (21%). Validated end to end on a small NYC bbox against the live Overture parquet: output carries the new columns, no excluded kinds, no sub-floor compact features. The mask consumers only burn geometry, so the clamp behavior change is limited to no longer re-opening sub-pixel ponds inside coarse sources — which exposed noise, not data.