### PR TITLE
Mask below-sea-level land in overview terrain tiles

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,7 @@ preview bbox="-74.30,40.40,-73.75,40.80":
     export SOURCE_VSI_BASE="${SOURCE_VSI_BASE:-/vsicurl/https://data.openwaters.io/bathymetry/source}"
     export LANDMASK="${LANDMASK:-/vsicurl/https://data.openwaters.io/bathymetry/landmask/land.fgb}"
     export WATERMASK="${WATERMASK:-/vsicurl/https://data.openwaters.io/bathymetry/landmask/water.fgb}"
+    export LANDRASTER="${LANDRASTER:-/vsicurl/https://data.openwaters.io/bathymetry/landmask/land-z8.tif}"
     # One invocation: the `cover` checkpoint runs inside the bundles build (streamed sources),
     # then the DAG re-evaluates into the per-stem mosaic/fork/terrain jobs.
     # mem_gb budget from the actual environment (the Docker VM's memory, not the host's), minus

--- a/Snakefile
+++ b/Snakefile
@@ -225,6 +225,26 @@ rule landmask:
         "{PY}/landmask.py prep 2> {log}"
 
 
+# Effective land (land ∖ water) rasterized once onto the z8 render grid — the overview
+# terrain stems' mask (a continental vector clip per coarse stem would re-read the whole
+# multi-GB FGB; this is windowed instead).
+rule landraster:
+    input:
+        "store/landmask/land.fgb",
+        "store/landmask/water.fgb",
+    output:
+        "store/landmask/land-z8.tif"
+    priority: 10_000_000  # see landmask
+    resources:
+        mem_gb=8  # planet gdal_rasterize + mode overviews
+    benchmark:
+        f"{TMP}/bench/landraster.tsv"
+    log:
+        f"{TMP}/logs/landraster.log"
+    shell:
+        "{PY}/landmask.py prep-raster 2> {log}"
+
+
 rule watermask:
     output:
         "store/landmask/water.fgb"

--- a/pipelines/build.smk
+++ b/pipelines/build.smk
@@ -31,6 +31,7 @@ import utils
 # Mask inputs only when they are local files — a /vsicurl mask (streamed preview) has no
 # file to track; its identity rides in the mask content, tracked via its input file.
 MASKS = [p for p in (landmask.path(), landmask.water_path()) if not p.startswith("/vsi")]
+RASTER_MASK = [] if landmask.raster_path().startswith("/vsi") else [landmask.raster_path()]
 
 # depare rides only when SKIP_DEPARE is unset — an env gate, known at parse, so it decides which
 # depare rules even EXIST (an empty input list would break the bundle rules). The stem set behind
@@ -449,10 +450,11 @@ TERRAIN_FACTOR = 1.3
 def terrain_inputs(wc):
     """cz>=8 renders read a per-stem VRT of their halo-buffered tile set, so they run the
     moment their neighborhood merges; cz<8 needs the GTI's planet-z8-COG fall-through. The masks
-    ride too: the render rasterizes the land mask to nudge land-side exact-0 pixels to land."""
+    ride too: cz>=8 rasterizes the vector land mask to nudge land-side exact-0 pixels to land,
+    cz<8 windows the prepped land-z8 raster for the same nudge."""
     if int(wc.stem.split("-")[3]) >= 8:
         return [f"store/mosaic/tiles/{s}.tif" for s in terrain_mod.window_tiles(wc.stem)] + MASKS
-    return list(rules.mosaic_index.output) + MASKS
+    return list(rules.mosaic_index.output) + MASKS + RASTER_MASK
 
 
 rule terrain_render:

--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -45,13 +45,16 @@ lake/river sources are the path if any is ever wanted.
 Local layout (store/landmask/): land.fgb — the prepared EPSG:3857 land mask; water.fgb
 — the inland-water polygons subtracted from it, each carrying its Overture `kind`
 (river/lake/canal/reservoir) for the depare nodata layer (optional: absent -> land-only
-mask, i.e. today's behavior, no crash). Both are spatial-indexed and HTTP-range friendly.
-LANDMASK / WATERMASK override the paths (defaults store/landmask/{land,water}.fgb).
+mask, i.e. today's behavior, no crash); land-z8.tif — the effective land (land ∖ water)
+rasterized onto the z8 render grid for the overview terrain stems (optional: absent ->
+maskless encode). All are spatial-indexed / tiled and HTTP-range friendly.
+LANDMASK / WATERMASK / LANDRASTER override the paths.
 
-  python landmask.py prep        download -> unzip -> convert the land mask (run once)
-  python landmask.py prep-water  download -> convert the inland-water mask (run once)
-  python landmask.py tiles       tile the masks into store/bundle/land.pmtiles
-  python landmask.py --check     self-check
+  python landmask.py prep         download -> unzip -> convert the land mask (run once)
+  python landmask.py prep-water   download -> convert the inland-water mask (run once)
+  python landmask.py prep-raster  rasterize effective land onto the z8 grid (run once)
+  python landmask.py tiles        tile the masks into store/bundle/land.pmtiles
+  python landmask.py --check      self-check
 """
 
 import os
@@ -89,6 +92,7 @@ MERC_LAT = 85.06
 
 DEFAULT_LANDMASK = "store/landmask/land.fgb"
 DEFAULT_WATERMASK = "store/landmask/water.fgb"
+DEFAULT_LANDRASTER = "store/landmask/land-z8.tif"
 
 
 def path():
@@ -103,6 +107,13 @@ def water_path():
     store/landmask/water.fgb). Optional: when it points nowhere the mask degrades to land-only.
     Read per call for the same reason path() is — a caller setting WATERMASK after import wins."""
     return os.environ.get("WATERMASK", DEFAULT_WATERMASK)
+
+
+def raster_path():
+    """The rasterized effective-land mask (prep_raster), read from LANDRASTER at *call time*
+    (default store/landmask/land-z8.tif). Optional like the water mask: absent -> overview
+    terrain stems encode maskless."""
+    return os.environ.get("LANDRASTER", DEFAULT_LANDRASTER)
 
 
 def require():
@@ -413,6 +424,83 @@ def rasterize_water(bounds_3857, res, out_tif, water_src=None):
                 os.remove(f)
 
 
+# The z8 render grid prep_raster burns on: 2**8 tiles of 512 px across the 3857 world — the
+# same pixel size aggregation_reproject.get_resolution(8) derives. Overview render windows
+# (cz<8) are exact power-of-two decimations of this grid, so extract_raster reads align with
+# the internal overviews pixel-for-pixel.
+MERC_X = 20037508.342789244
+Z8_RES = 2 * MERC_X / (2 ** 8 * 512)
+
+
+def prep_raster(te=(-MERC_X, -MERC_X, MERC_X, MERC_X), res=Z8_RES):
+    """Rasterize the effective-land mask once onto the global z8 render grid (1=land, 0=water,
+    the same land-then-water composite rasterize() burns per stem) with mode-decimated internal
+    overviews, at raster_path(). Overview terrain stems window this instead of vector-rasterizing:
+    a continental -spat clip selects most of the planet's polygons, so every coarse stem would
+    re-read nearly the whole multi-GB FGB. No -spat pre-clip here for the same reason — the
+    planet extent selects everything, so the burns read the FGBs directly. Guarded so a re-run
+    is a no-op; a binary sparse mask compresses to tens of MB. Water optional, like everywhere."""
+    out = raster_path()
+    if os.path.isfile(out):
+        print(f"land raster already present: {out}")
+        return
+    land = path()
+    if not _present(land):
+        raise SystemExit(f"land mask {land} not found — run `landmask.py prep` first")
+    utils.create_folder(os.path.dirname(out) or ".")
+    water = water_path()
+    tmp_out = out + ".tmp.tif"
+    try:
+        utils.run_command(
+            f"gdal_rasterize -burn 1 -ot Byte -init 0 -te {te[0]} {te[1]} {te[2]} {te[3]} "
+            f"-tr {res} {res} -co COMPRESS=DEFLATE -co BIGTIFF=IF_SAFER -co TILED=YES "
+            f"-co SPARSE_OK=YES {land} {tmp_out}")
+        if _present(water):
+            # kind <> 'physical': same marine-bay exclusion as rasterize() — burning holeless
+            # bays back to water would erase real islands.
+            utils.run_command(
+                f"gdal_rasterize -burn 0 -where \"kind <> 'physical'\" {water} {tmp_out}")
+        # Overviews down to a 512-px planet (level 256 = the z0 render window); mode keeps a
+        # majority-land block land instead of nearest's coin flip. Levels that would undershoot
+        # one 512 block are dropped (only reachable on the tiny self-check grid).
+        width = round((te[2] - te[0]) / res)
+        levels = [2 ** k for k in range(1, 9) if width >> k >= 512]
+        if levels:
+            utils.run_command(
+                f"gdaladdo -r mode --config COMPRESS_OVERVIEW DEFLATE {tmp_out} "
+                + " ".join(str(l) for l in levels))
+        os.replace(tmp_out, out)
+    finally:
+        if os.path.isfile(tmp_out):
+            os.remove(tmp_out)
+    print(f"land raster ready: {out}")
+
+
+def raster_available():
+    """Like _present, but a /vsi raster is probed with a real open: the artifact is optional
+    (absent -> maskless overview encode), so a streamed preview pointing at a not-yet-published
+    URL must degrade like a missing local file, not die mid-render."""
+    p = raster_path()
+    if not p.startswith("/vsi"):
+        return os.path.isfile(p)
+    try:
+        with rasterio.open(p):
+            return True
+    except rasterio.errors.RasterioIOError:
+        return False
+
+
+def extract_raster(bounds_3857, res, out_tif):
+    """Cut a window of the prepped effective-land raster onto the given grid — the overview
+    stems' mask path, same 1=land/0=water contract as rasterize(). gdalwarp -te/-tr guarantees
+    the output grid matches the render window exactly (the encode dims guard); -r near on the
+    mode-built overviews makes decimated reads aligned block copies, not resampling."""
+    xmin, ymin, xmax, ymax = bounds_3857
+    utils.run_command(
+        f"gdalwarp -overwrite -te {xmin} {ymin} {xmax} {ymax} -tr {res} {res} -r near "
+        f"-co COMPRESS=DEFLATE -co TILED=YES -co SPARSE_OK=YES {raster_path()} {out_tif}")
+
+
 def _clamp_negative_land(dem_path, mask_tif, valid):
     """Shared windowed clamp: where land (mask==1) AND valid(ds, win, a) AND value<0, set 0.
     Mask-first — read the cheap Byte mask window and skip landless blocks before decoding the
@@ -669,6 +757,29 @@ def _check():
         "the water burn must only turn land->water, never water->land"
     assert not ((land == 0) & (lw == 1)).any(), "the water burn must not create land over water"
 
+    # The raster-mask path (overview terrain stems): prep the artifact on this same grid, window
+    # it back with extract_raster, and require the exact composite rasterize() burns — land,
+    # water subtracted, the physical bay ignored. Then a 2x-decimated read must keep the grid
+    # contract (halved dims) with both classes present.
+    raster = f"{d}/land-z8.tif"
+    env_prev = {k: os.environ.get(k) for k in ("LANDMASK", "WATERMASK", "LANDRASTER")}
+    os.environ.update(LANDMASK=land_fgb, WATERMASK=water_fgb, LANDRASTER=raster)
+    try:
+        prep_raster(te=te, res=res)
+        ext = f"{d}/extract.tif"
+        extract_raster(te, res, ext)
+        with rasterio.open(ext) as m:
+            full = m.read(1)
+        assert np.array_equal(full, lw), "extract_raster must reproduce rasterize()'s composite"
+        extract_raster(te, res * 2, ext)
+        with rasterio.open(ext) as m:
+            half = m.read(1)
+        assert half.shape == (h // 2, w // 2), "decimated extract must keep the -te/-tr grid"
+        assert (half == 1).any() and (half == 0).any(), "decimated mask must keep both classes"
+    finally:
+        for k, v in env_prev.items():
+            os.environ.pop(k, None) if v is None else os.environ.update({k: v})
+
     # The marine 'physical' bay overlapping the land corner must NOT subtract: probe a
     # point inside both the land box and the bay box (lon/lat 1.1,1.1).
     from rasterio.transform import rowcol
@@ -770,9 +881,11 @@ if __name__ == "__main__":
         prep()
     elif sys.argv[1:2] == ["prep-water"]:
         prep_water(int(sys.argv[2]) if len(sys.argv) > 2 else 8)
+    elif sys.argv[1:2] == ["prep-raster"]:
+        prep_raster()
     elif sys.argv[1:2] == ["tiles"]:
         tiles()
     elif sys.argv[1:2] == ["--check"]:
         _check()
     else:
-        sys.exit("usage: landmask.py prep | prep-water | tiles | --check")
+        sys.exit("usage: landmask.py prep | prep-water | prep-raster | tiles | --check")

--- a/pipelines/publish.smk
+++ b/pipelines/publish.smk
@@ -94,6 +94,7 @@ rule publish_masks:
     input:
         land="store/landmask/land.fgb",
         water="store/landmask/water.fgb",
+        raster="store/landmask/land-z8.tif",
     output:
         touch("store/meta/publish/landmask")
     log:
@@ -101,7 +102,8 @@ rule publish_masks:
     shell:
         "( " + PUBLISH_GUARD +
         'rclone copyto "{input.land}" "{DEST}/landmask/land.fgb" --retries 5; '
-        'rclone copyto "{input.water}" "{DEST}/landmask/water.fgb" --retries 5 ) 2> {log}'
+        'rclone copyto "{input.water}" "{DEST}/landmask/water.fgb" --retries 5; '
+        'rclone copyto "{input.raster}" "{DEST}/landmask/land-z8.tif" --retries 5 ) 2> {log}'
 
 
 # A single-source dispatch publishes only that source; full runs add coverage + masks.

--- a/pipelines/terrain.py
+++ b/pipelines/terrain.py
@@ -185,18 +185,21 @@ def _render(stem, out_pmtiles):
     if not os.environ.get("SKIP_SMOOTH"):
         smooth.smooth_tiff(window)  # the ONE f(depth,zoom); halo makes interior identical to whole
 
-    # Rasterize the combined land mask on the window's exact grid so _encode_tile can nudge
-    # land-side exact-0 pixels (clamped polders, beyond-build land fringe) to land, keeping decoded
-    # 0 unambiguously water. Same #24 machinery, degrades to no-nudge when no mask is published.
-    # Regional windows only (cz>=8, the per-tile VRT path): a planet-scale window's -spat clip
-    # streams the entire vector mask (GBs) instead of an indexed subset. At z<=7 a land-side
-    # exact-0 area is a few pixels; a rasterized planet-z8 mask artifact is the upgrade path.
+    # Land mask on the window's exact grid so _encode_tile can nudge land-side exact-0 pixels
+    # (clamped polders, the below-sea-level Caspian Depression, beyond-build land fringe) to
+    # land, keeping decoded 0 unambiguously water. Same #24 machinery, degrades to no-nudge
+    # when no mask is published. cz>=8 rasterizes the vector mask per window (indexed -spat
+    # reads); coarser stems window the prepped planet-z8 raster instead — a continental -spat
+    # clip selects most of the planet's polygons, re-reading the whole multi-GB FGB per stem.
     mask = None
+    with rasterio.open(window) as w:
+        b, wres = w.bounds, w.res[0]
     if cz >= 8 and landmask._present(landmask.path()):
         mask = f"{tmp}/landmask.tif"
-        with rasterio.open(window) as w:
-            b, wres = w.bounds, w.res[0]
         landmask.rasterize((b.left, b.bottom, b.right, b.top), wres, mask)
+    elif cz < 8 and landmask.raster_available():
+        mask = f"{tmp}/landmask.tif"
+        landmask.extract_raster((b.left, b.bottom, b.right, b.top), wres, mask)
 
     x_min, y_min = x * span, y * span
     from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
Fixes #109: below viewport z7.5 the Caspian Depression (and any below-sea-level land) renders as opaque unknown-depth water, because the encoder's land reclassification of exact-0 pixels only runs for native stems.

The chain: the landmask clamp writes below-sea-level land as exact 0.0; exact 0 is the categorical unknown-depth-water code (`#1f86cb`); the nudge that reclassifies land-side exact-0 to the land code needs the landmask, and rasterizing the vector FGB for a coarse stem means a continental `-spat` clip that re-reads nearly the whole multi-GB file — so cz<8 stems encoded maskless. Measured on prod: tile `7/81/44` is 96.2% exact-0 while its z8 child is 99.1% land sentinel. The z7.5 flip is MapLibre's 512px tile-zoom rounding (7.49 → tile z7, 7.5 → z8).

## Approach

Pay the vector parse once instead of per stem. `prep_raster` burns effective land (land = 1, then inland water re-opened to 0 — the same composite the per-stem vector rasterize produces) onto the global z8 render grid as a sparse DEFLATE GTiff with mode-decimated internal overviews. Overview stems then window it with `gdalwarp -te/-tr` (`extract_raster`), which guarantees the encode dims contract; overview render grids are exact power-of-two decimations of the z8 grid, so decimated reads are aligned block copies. Native stems (cz>=8) keep the exact-grid vector rasterize, unchanged.

Built and verified against the full local FGBs: the planet artifact is 97 MB and takes about two minutes to rasterize; the depression sample points classify as land while the north and mid Caspian stay water, at native and decimated resolutions. The landmask and terrain self-checks cover the new path (composite equality with the vector burn, dims contract on decimated extracts).

## Degrade path

The raster is optional like the other masks. `raster_available()` probes `/vsi` paths with a real open, so a streamed preview pointing at the not-yet-published R2 URL falls back to maskless encoding (the current behavior) instead of failing mid-render, and picks the mask up automatically once a build publishes it. `publish_masks` now ships `land-z8.tif` next to the FGBs, and the `landraster` rule feeds cz<8 terrain renders, so a landmask update re-renders overview tiles — which previously went silently stale.

Only reclassification of exact-0 pixels changes; real water never encodes to exact 0 (the encoder floors it at −LSB), so no depth values are affected. Overview tiles re-render once when this lands, which is the repair.