### PR TITLE
Clamp great_lakes negative values under land

### DIFF
--- a/sources/great_lakes/file_list.txt
+++ b/sources/great_lakes/file_list.txt
@@ -2,6 +2,11 @@
 # Full open-lake grids (US + Canadian sides), direct HTTP .tar.gz, no login. This covers all
 # SIX Great Lakes water bodies: NGDC's Erie grid is "Lake Erie AND Lake Saint Clair", so
 # St. Clair is included in erie_lld (confirmed ~4.6 m at the lake centre) — no separate grid.
+# The grids carry land topography across their full rectangles, each relative to its OWN
+# lake's LWD, and the rectangles overlap other lakes' shores — land below a neighbour's LWD
+# reads negative (huron_lld charts Hamilton, ON at −77 m). clamp_positive can't catch that,
+# hence land_clamp: the warp-time mask zeroes negative-under-land; the lakes themselves stay
+# open through the inland-water subtraction.
 https://www.ngdc.noaa.gov/mgg/greatlakes/superior/data/geotiff/superior_lld.geotiff.tar.gz
 https://www.ngdc.noaa.gov/mgg/greatlakes/michigan/data/geotiff/michigan_lld.geotiff.tar.gz
 https://www.ngdc.noaa.gov/mgg/greatlakes/huron/data/geotiff/huron_lld.geotiff.tar.gz

--- a/sources/great_lakes/metadata.json
+++ b/sources/great_lakes/metadata.json
@@ -6,6 +6,7 @@
     "max_zoom": 10,
     "datum": "Low Water Datum (LWD) per lake — a low-water / chart-datum analog",
     "clamp_positive": true,
+    "land_clamp": true,
     "crs": "EPSG:4269",
     "unpack": "tar.gz:*_lld.tif!1"
 }


### PR DESCRIPTION
Terrain webps chart downtown Hamilton at −72 m and Dundas at −80 m while the vector layers over the same ground are correct (#110). The five NCEI Great Lakes grids carry land topography across their full rectangular extents, each referenced to its own lake's Low Water Datum, and the rectangles overlap neighbouring lakes' shores. Michigan–Huron LWD is 176.0 m ASL and huron_lld's rectangle reaches southeast over the west end of Lake Ontario, so land below 176 m reads negative there: downtown Hamilton (~99 m ASL) is −77.1 in the prepared file. The ingest clamp_positive only drops cells above zero, so these survive as plausible depths.

In the source VRT, ontario_lld wins wherever it has data, which keeps the lake and Hamilton Harbour correct. Over the city it is nodata (its own land was clamped at ingest) and Dundas sits west of its extent, so huron's values are the group's only valid data there. A valid pixel means GEBCO's correct land fill (+104 m at downtown) never applies, and the fake depth reaches the mosaic. The vector fork re-clamps with clamp_dem_to_land; the terrain render has no land clamp of its own, so the webps serve lakebed over the city.

The fix is to flag the source land_clamp. The warp-time clamp zeroes negative-under-land, and the lakes themselves stay open through the inland-water subtraction, the same path GEBCO already relies on over these lakes. The source's land cells are garbage by construction (each grid's "land" is topography offset by that lake's LWD), so the clamp removes nothing real. It also covers the milder Erie overlap on the Niagara interior.

Verified values: raw NCEI ontario grid +24.7 at downtown Hamilton, prepared ontario nodata, prepared huron −77.06, GEBCO +104, mosaic −76.6. The clean/wet boundary reported in #110 is the 176 m contour at the escarpment brow, which happens to fall near the z10 tile edge.

## Rollout

No source re-prep: the clamp runs at aggregation warp time. This needs a re-registration of great_lakes, a rebuild of the aggregation and mosaic tiles that include it, and the terrain re-render cascade including planet-z8.

Fixes #110