### PR TITLE
Replace noisy build logs with one line per job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,16 +356,18 @@ jobs:
               mkdir -p "$TMP/logs"
               free -m | awk -v t="$(date -u +%FT%TZ)" 'NR==2{u=$3;a=$7} NR==3{print t" used_mb="u" avail_mb="a" swap_used_mb="$3}' \
                 >> "$TMP/logs/memory.log"
-              p=$(grep -oE "[0-9]+ of [0-9]+ steps" "$buildlog" | tail -1)
+              # The seascape logger closes every job line with the whole counter, so the
+              # status is one grep — no step arithmetic, and `running` is exact rather than
+              # inferred from unmatched jobids.
+              p=$(grep -oE "\[[0-9]+/[0-9]+, [0-9]+%, [0-9]+ running\]" "$buildlog" | tail -1)
               [ -n "$p" ] || continue
-              n=${p%% *}; m=${p##*of }; m=${m%% *}
-              run=$(( $(grep -oE "^    jobid: [0-9]+" "$buildlog" | sort -u | wc -l) - $(grep -oE "^Finished jobid: [0-9]+" "$buildlog" | sort -u | wc -l) ))
+              p=${p#[}; p=${p%]}
               # curl, not gh: the self-hosted box has no gh CLI. Failures land in the
               # artifact via heartbeat.log instead of /dev/null.
               curl -fsS -X POST -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
                 "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
-                -d "{\"state\":\"pending\",\"context\":\"build\",\"description\":\"root@$BOX_IP · $p ($((n * 100 / m))%), ~$run running\",\"target_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+                -d "{\"state\":\"pending\",\"context\":\"build\",\"description\":\"root@$BOX_IP · $p\",\"target_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
                 >/dev/null 2>>"$TMP/logs/heartbeat.log"
             done ) &
           hb=$!
@@ -412,6 +414,7 @@ jobs:
           # priority bands (index > merges > vector > terrain) order the chain instead.
           ./docker.sh snakemake "${targets[@]}" "${extra[@]}" "${force[@]}" \
             --keep-going --rerun-incomplete \
+            --logger seascape --logger-seascape-events /app/tmp/logs/events.jsonl \
             --cores "$cores" --resources mem_gb="$budget_gb" disk_mb="$disk_budget_mb" \
             --config workdir=/app/state tmp=/app/tmp 2>&1 | tee "$buildlog"
       # Close the `build` status to success so it never lingers at pending, pointing at the

--- a/.github/workflows/sources.yml
+++ b/.github/workflows/sources.yml
@@ -233,7 +233,10 @@ jobs:
           trap 'kill "$mem" 2>/dev/null || true' EXIT
           # Optional target args, collected into an array so an empty one contributes nothing
           # (no unquoted word-splitting) and a source id can't smuggle extra tokens.
-          extra=(--config workdir=/app/state tmp=/app/tmp)
+          # One line per job with its runtime and peak RSS, plus a JSONL event stream in the
+          # artifact; rides all three invocations, which append to the same file.
+          extra=(--logger seascape --logger-seascape-events /app/tmp/logs/events.jsonl
+                 --config workdir=/app/state tmp=/app/tmp)
           if [ -n "$INPUT_SOURCE" ]; then
             # source ids are directory names ([a-z0-9_]); reject anything else before it
             # reaches the docker/snakemake command line.

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,10 @@ RUN uv sync --frozen --no-install-project
 RUN uv pip install --python /opt/venv/bin/python py-spy==0.4.2 \
   && /opt/venv/bin/py-spy --version
 ENV PATH="/opt/venv/bin:${PATH}"
+# Snakemake discovers logger plugins by scanning sys.path for `snakemake_logger_plugin_*`
+# packages (pkgutil.iter_modules), and it chdirs to the workdir before doing so — the
+# mounted repo has to be on the path explicitly for `--logger seascape` to resolve.
+ENV PYTHONPATH=/app
 
 # The build is one Snakemake DAG (docker.sh fronts it). e.g.
 # `docker run -v "$PWD:/app" img snakemake planet` (BBOX=… scopes a region);

--- a/Justfile
+++ b/Justfile
@@ -86,6 +86,8 @@ test-engine:
     uv run python bundle.py --check
     uv run python test_build.py
     uv run python terrain.py --check
+    # Repo root: the logger plugin has to sit on sys.path under its discoverable name.
+    cd "{{justfile_directory()}}" && uv run python -m snakemake_logger_plugin_seascape --check
 
 # Lint the GitHub Actions workflows.
 test-workflows:

--- a/docs/build.md
+++ b/docs/build.md
@@ -67,6 +67,35 @@ There is **no prune step** — deletion of *store* artifacts is out-of-band (`gc
 
 **No `timeout-minutes`.** A self-hosted job is **not** subject to the 6 h cap that GitHub-*hosted* runners impose — the ceiling is now the 72 h workflow limit, which is effectively non-binding, so a forced full planet rebuild runs to completion in one window regardless of size (no resume-on-re-dispatch needed). The incremental store still makes re-dispatches cheap (a re-dispatch hydrates the last completed build's manifest and rebuilds only what changed), but a build no longer *has* to fit a window. `ccx63` (48 vCPU / 192 GB) is the default now the dedicated-vCPU quota is approved; `ccx33` is a cheaper smoke.
 
+## Watching a build
+
+The run log is produced by `snakemake_logger_plugin_seascape`, a logger plugin that
+replaces Snakemake's default console handler (`--logger seascape`, wired into build.yml
+and sources.yml; the container puts the repo on `PYTHONPATH` so Snakemake's plugin scan
+finds it). Snakemake's own output costs ~16 lines per job — a field block per job, a bare
+timestamp per event, `Select jobs to execute...` and `Execute N jobs...` per scheduling
+round — which is ~200k lines at planet scale, past what the GitHub UI serves, and it
+still never prints a job's runtime or peak RSS. `--quiet` can't trim it: `rules` also
+suppresses job errors, `progress` also suppresses the counter the heartbeat reads, and
+neither level reaches the two scheduler lines.
+
+What the plugin emits instead:
+
+- **One line per finished job** — `✓ mosaic_tile 8-70-105-15 25m08s rss=7.2G cpu=18m00s [2/113, 2%, 15 running]`. Runtime is measured by the handler (JOB_FINISHED carries only a jobid); RSS and CPU come from the job's own `benchmark:` TSV, which the job process flushes before the scheduler handles success. `--logger-seascape-starts` adds a `▸` line at job start with its `mem_gb`/`disk_mb` reservation.
+- **A failure line** naming the rule, its wildcards, and its log path. Snakemake reports each failure twice (once live, once in the exit summary, the second time without wildcards); the plugin keeps the first.
+- **A periodic status line** every 5 minutes (`--logger-seascape-status-interval`): elapsed, the counter, which rules are in flight, and the oldest running job — the line that says whether a build is progressing or wedged on one long-tail stem.
+- **An end-of-run rollup**: per-rule count, total, mean and max runtime, plus the failure list. GitHub truncates the middle of a long log but serves the end, so this always survives.
+- **A JSONL event stream** (`--logger-seascape-events`), written to `$TMP/logs/events.jsonl` and shipped in the `snakemake-bench-<run_id>` artifact alongside the benchmark TSVs. Every event carries its full record — jobid, rule, wildcards, reason, resources, duration, the whole benchmark row — so post-run analysis is `jq`, not log scraping. Long `input:`/`reason:` lists live here and never reach the console.
+
+The heartbeat reads the counter straight off the console line, and
+[`scripts/watch-build`](../scripts/watch-build) tails the box's container log filtered to
+`✓`/`✗`/status lines. Benchmarks are written with `--benchmark-extended`
+(`profiles/default/config.yaml`), so each TSV names its own jobid, rule, wildcards,
+threads and resources rather than relying on the filename.
+
+The scope-gate dry run deliberately keeps the default logger — it parses `^Job stats` and
+the `total` row out of that output.
+
 ## The incremental model
 
 Rebuilds are cheap because every store artifact is **content-addressed** ([pipelines/keys.py](../pipelines/keys.py)): its key — a short hash of its inputs ‖ the pipeline modules that produce it ‖ the resolved config the stage read ‖ the toolchain image tag — rides IN its filename (`<stem>-<key12>.<ext>`). Freshness is "the named file exists"; there is no sidecar to match. Anything that moves the key — changed input, code, config, bumped toolchain — writes a NEW name, and a stage rebuilds a name that isn't present. The old covering diff, its `.done` markers, the `.key` sidecars, and the downsample mtime cascade are all gone.

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -16,3 +16,6 @@ scheduler: greedy
 # Engine triggers match the declared policy: code changes are force-only (-R/-F),
 # never auto-invalidation — a shell-string edit must not re-merge the planet.
 rerun-triggers: [mtime, params, input, software-env]
+# Benchmark TSVs name their own job (jobid, rule, wildcards, threads, resources,
+# input_size_mb) instead of only the stem in the filename — the artifact reads standalone.
+benchmark-extended: true

--- a/scripts/watch-build
+++ b/scripts/watch-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Live view of a dispatched build. Resolves the box from the `build` commit status
-# (the heartbeat carries `root@<ip> · N of M steps`) and tails the build container's
+# (the heartbeat carries `root@<ip> · N/M, P%, R running`) and tails the build container's
 # log on the box. No arguments needed for the common case.
 #
 #   scripts/watch-build              # follow the current build for HEAD, errors + progress
@@ -27,10 +27,10 @@ SSH=(ssh -i "$HOME/.ssh/seascape-build"
      -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
      "root@$ip")
 if [ -n "$filter" ]; then
-  # Progress lines + anything that reads as trouble. The container name is Docker-random;
-  # the build container is the only one running.
+  # Job lines (✓/✗), periodic status, and anything that reads as trouble. The container
+  # name is Docker-random; the build container is the only one running.
   "${SSH[@]}" 'docker logs -f --tail 100 $(docker ps -lq) 2>&1' |
-    grep --line-buffered -E "of [0-9]+ steps|Error|error in rule|Traceback|MissingOutputException|failed|Killed|oom|Exception|reason:|Job stats|^total|did not simplify|fell back|WARNING"
+    grep --line-buffered -E "✓|✗|──|Error|Traceback|MissingOutputException|failed|Killed|oom|Exception|Job stats|^total|did not simplify|fell back|WARNING"
 else
   exec "${SSH[@]}" 'docker logs -f --tail 200 $(docker ps -lq) 2>&1'
 fi

--- a/snakemake_logger_plugin_seascape/__init__.py
+++ b/snakemake_logger_plugin_seascape/__init__.py
@@ -1,0 +1,432 @@
+"""Snakemake logger plugin: one line per job event, plus a JSONL event stream.
+
+Snakemake's default handler prints ~16 scaffolding lines per job (a field block per
+JOB_INFO, a bare timestamp line per event, `Select jobs to execute...`/`Execute N
+jobs...` per scheduling round). At planet scale that is ~200k lines, past what the
+GitHub Actions UI serves, and it still omits the numbers that decide whether a build
+is healthy: per-job wall time and peak RSS, and how many jobs are actually in flight.
+
+`--quiet` cannot express this: `rules` also suppresses JOB_ERROR, `progress` also
+suppresses the step counter the CI heartbeat reads, and neither level touches
+`Select jobs to execute...` (a plain logger.info with no event) or `Execute N jobs...`
+(JOB_STARTED, absent from snakemake's quietness map). Replacing the handler is the
+only lever.
+
+Declaring writes_to_stream makes snakemake skip its own stream handler entirely
+(snakemake/logging.py: _setup_plugins), so this is a replacement, not a filter.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from logging import LogRecord
+from typing import Any, Optional
+
+from snakemake_interface_logger_plugins.base import LogHandlerBase
+from snakemake_interface_logger_plugins.common import LogEvent
+from snakemake_interface_logger_plugins.settings import LogHandlerSettingsBase
+
+# Wall seconds between `──` status lines. Long enough that an hour-long build prints a
+# dozen, short enough to notice a stall.
+STATUS_INTERVAL = 300
+
+# Rule name column; wide enough for the longest rule (terrain_planet_bundle).
+RULE_WIDTH = 21
+# Wildcard column; a stem is `8-70-105-15`, a cell `8-70-105`.
+WILDCARD_WIDTH = 14
+
+# Rules the status line reports individually; more than this and the tail is summarized.
+STATUS_RULE_LIMIT = 4
+
+
+# Field annotations must stay real type objects — snakemake's plugin registry hands each
+# one to argparse, so `from __future__ import annotations` here breaks the CLI.
+@dataclass
+class LogHandlerSettings(LogHandlerSettingsBase):
+    events: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Write the JSONL event stream to this path (default: no JSONL).",
+            "env_var": True,
+        },
+    )
+    starts: bool = field(
+        default=False,
+        metadata={
+            "help": "Also print a line when each job starts, not only when it finishes.",
+            "env_var": True,
+        },
+    )
+    status_interval: int = field(
+        default=STATUS_INTERVAL,
+        metadata={"help": "Seconds between periodic status lines (0 disables).", "env_var": True},
+    )
+
+
+def _hms(seconds: float) -> str:
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m{s % 60:02d}s"
+    return f"{s // 3600}h{(s % 3600) // 60:02d}m"
+
+
+def _gb(value: Any, per_gb: float = 1) -> Optional[str]:
+    """A snakemake resource value -> a whole-gigabyte `26G`. Reservations are coarse by
+    nature, so decimals here only add width. Non-numeric resources are skipped."""
+    try:
+        n = float(value) / per_gb
+    except (TypeError, ValueError):
+        return None
+    return f"{n:.0f}G"
+
+
+def _mb_to_gb(value: str) -> Optional[str]:
+    """A benchmark TSV megabyte field -> `7.2G`. Sub-0.1G reads as unmeasured, not as a fact."""
+    try:
+        gb = float(value) / 1024
+    except (TypeError, ValueError):
+        return None
+    return f"{gb:.1f}G" if gb >= 0.1 else None
+
+
+def _seconds(value: str) -> Optional[float]:
+    """A benchmark TSV seconds field. Benchmarks write `-` for jobs too short to sample."""
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds >= 1 else None
+
+
+def read_benchmark(path: str) -> dict[str, str]:
+    """The header/value pair a snakemake `benchmark:` TSV holds for a finished job.
+
+    The job process flushes this before exiting, and JOB_FINISHED fires after the
+    scheduler has handled success, so it is on disk by the time this is called.
+    Anything unreadable (no benchmark: directive, a killed job) yields {}.
+    """
+    try:
+        with open(path) as f:
+            header = f.readline().strip().split("\t")
+            values = f.readline().strip().split("\t")
+    except OSError:
+        return {}
+    return dict(zip(header, values))
+
+
+def format_wildcards(wildcards: Any) -> str:
+    if not wildcards:
+        return ""
+    if isinstance(wildcards, dict):
+        return ",".join(str(v) for v in wildcards.values())
+    return str(wildcards)
+
+
+class Job:
+    __slots__ = ("jobid", "rule", "wildcards", "started", "resources", "benchmark", "log")
+
+    def __init__(self, record: LogRecord) -> None:
+        self.jobid = getattr(record, "jobid", None)
+        self.rule = getattr(record, "rule_name", "?")
+        self.wildcards = format_wildcards(getattr(record, "wildcards", None))
+        self.resources = dict(getattr(record, "resources", {}) or {})
+        self.benchmark = getattr(record, "benchmark", None)
+        self.log = list(getattr(record, "log", None) or [])
+        self.started = time.monotonic()
+
+    @property
+    def label(self) -> str:
+        return f"{self.rule:<{RULE_WIDTH}} {self.wildcards:<{WILDCARD_WIDTH}}"
+
+    @property
+    def elapsed(self) -> float:
+        return time.monotonic() - self.started
+
+
+class LogHandler(LogHandlerBase):
+    settings: LogHandlerSettings
+
+    def __post_init__(self) -> None:
+        # Snakemake sets stdout when the caller needs stderr kept clean.
+        self.stream = sys.stdout if getattr(self.common_settings, "stdout", False) else sys.stderr
+        self.printshellcmds = getattr(self.common_settings, "printshellcmds", False)
+        # In a dry run the per-job line IS the output — that's the plan being inspected.
+        self.starts = getattr(self.settings, "starts", False) or getattr(
+            self.common_settings, "dryrun", False
+        )
+        self.running: dict[Any, Job] = {}
+        self.done = 0
+        self.total = 0
+        self.failures: list[str] = []
+        self.failed_ids: set[Any] = set()
+        # Per-rule (count, total_seconds, max_seconds) for the end-of-run rollup.
+        self.stats: dict[str, list[float]] = {}
+        self.started = time.monotonic()
+        self.last_status = self.started
+        self.closed = False
+        self.events = None
+        path = getattr(self.settings, "events", None) if self.settings else None
+        if path:
+            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+            self.events = open(path, "a", buffering=1)
+
+    @property
+    def writes_to_stream(self) -> bool:
+        return True
+
+    @property
+    def writes_to_file(self) -> bool:
+        return False
+
+    @property
+    def has_filter(self) -> bool:
+        return True
+
+    @property
+    def has_formatter(self) -> bool:
+        return True
+
+    @property
+    def needs_rulegraph(self) -> bool:
+        return False
+
+    def emit(self, record: LogRecord) -> None:
+        try:
+            # logging.Handler's own RLock, reused deliberately: logging.shutdown() holds it
+            # across close(), so a non-reentrant lock of our own deadlocks at exit.
+            with self.lock:
+                self._emit(record)
+        except (KeyboardInterrupt, SystemExit, BrokenPipeError):
+            raise
+        except Exception:  # a logging handler must never take the build down
+            self.handleError(record)
+
+    def _emit(self, record: LogRecord) -> None:
+        event = getattr(record, "event", None)
+        handler = {
+            LogEvent.JOB_INFO: self._job_info,
+            LogEvent.JOB_FINISHED: self._job_finished,
+            LogEvent.JOB_ERROR: self._job_error,
+            LogEvent.PROGRESS: self._progress,
+            LogEvent.RUN_INFO: self._passthrough,
+            LogEvent.WORKFLOW_STARTED: self._workflow_started,
+        }.get(event, self._other)
+        handler(record)
+        self._maybe_status()
+
+    # Everything snakemake says that isn't a job event passes through — dropping by default
+    # would hide "Nothing to be done", the dry-run plan, and anything added upstream later.
+    # Only the two content-free scheduler lines are filtered.
+    def _other(self, record: LogRecord) -> None:
+        event = getattr(record, "event", None)
+        # `Execute N jobs...` — the count is already on every job line.
+        if event == LogEvent.JOB_STARTED:
+            return
+        # has_filter means snakemake attaches no filter of its own, so -p is ours to honor.
+        if event == LogEvent.SHELLCMD:
+            cmd = getattr(record, "cmd", None)
+            # Rules with no shell (a target rule) still emit the event, with cmd None.
+            if self.printshellcmds and cmd:
+                self._write(cmd)
+            return
+        message = record.getMessage()
+        if not message or message == "Select jobs to execute...":
+            return
+        self._write(message)
+        if record.levelno >= 30 or event in (LogEvent.ERROR, LogEvent.GROUP_ERROR):
+            self._event("message", level=record.levelname, msg=message)
+
+    def _passthrough(self, record: LogRecord) -> None:
+        message = record.getMessage()
+        if not message:
+            return
+        # RUN_INFO carries the job-stats table; its `total` row is the only place the DAG
+        # size appears before the first PROGRESS event, which lands after job one finishes.
+        match = re.search(r"^total\s+(\d+)\s*$", message, re.MULTILINE)
+        if match and not self.total:
+            self.total = int(match.group(1))
+        # Raw, not timestamped: the job-stats table is a block, and build.yml's scope gate
+        # matches `^Job stats` in it.
+        self.stream.write(message + "\n")
+        self.stream.flush()
+
+    def _workflow_started(self, record: LogRecord) -> None:
+        """The default banner is 16 lines; provenance fits on one, and the rest is in JSONL."""
+        version = getattr(record, "snakemake_version", "?")
+        workflow_id = str(getattr(record, "workflow_id", ""))
+        self._write(f"snakemake {version} · run {workflow_id} · {getattr(record, 'cmd', '')}")
+        self._event(
+            "workflow_started",
+            workflow_id=workflow_id,
+            snakemake_version=version,
+            cmd=getattr(record, "cmd", None),
+            config_md5=getattr(record, "config_md5", None),
+        )
+
+    def _job_info(self, record: LogRecord) -> None:
+        job = Job(record)
+        if job.jobid is None:
+            return
+        self.running[job.jobid] = job
+        self._event(
+            "job_started",
+            jobid=job.jobid,
+            rule=job.rule,
+            wildcards=job.wildcards,
+            resources={k: str(v) for k, v in job.resources.items()},
+            reason=getattr(record, "reason", None),
+            input=list(getattr(record, "input", None) or []),
+            output=list(getattr(record, "output", None) or []),
+        )
+        if self.starts:
+            self._write(f"▸ {job.label} {self._reservation(job)}".rstrip())
+
+    def _job_finished(self, record: LogRecord) -> None:
+        job = self.running.pop(getattr(record, "job_id", None), None)
+        if job is None:
+            return
+        elapsed = job.elapsed
+        bench = read_benchmark(job.benchmark) if job.benchmark else {}
+
+        # PROGRESS lands after this event, so counting here keeps the line self-consistent.
+        self.done += 1
+        stat = self.stats.setdefault(job.rule, [0, 0.0, 0.0])
+        stat[0] += 1
+        stat[1] += elapsed
+        stat[2] = max(stat[2], elapsed)
+
+        parts = [f"✓ {job.label} {_hms(elapsed):>7}"]
+        rss = _mb_to_gb(bench.get("max_rss", ""))
+        if rss:
+            parts.append(f"rss={rss}")
+        cpu = _seconds(bench.get("cpu_time", ""))
+        if cpu:
+            parts.append(f"cpu={_hms(cpu)}")
+        parts.append(self._counter())
+        self._write("  ".join(parts))
+        self._event(
+            "job_finished",
+            jobid=job.jobid,
+            rule=job.rule,
+            wildcards=job.wildcards,
+            duration=round(elapsed, 1),
+            benchmark=bench,
+        )
+
+    def _job_error(self, record: LogRecord) -> None:
+        jobid = getattr(record, "jobid", None)
+        # Snakemake reports each failure twice — once when it happens, once in the exit
+        # summary (which no longer carries the wildcards). Keep the first, richer report.
+        if jobid in self.failed_ids:
+            return
+        self.failed_ids.add(jobid)
+        job = self.running.pop(jobid, None)
+        rule = getattr(record, "rule_name", job.rule if job else "?")
+        wildcards = format_wildcards(getattr(record, "wildcards", None)) or (
+            job.wildcards if job else ""
+        )
+        logs = list(getattr(record, "log", None) or (job.log if job else []))
+        label = f"{rule} {wildcards}".strip()
+        self.failures.append(label)
+        self._write(f"✗ {label}  jobid={jobid}" + (f"  log={logs[0]}" if logs else ""))
+        self._event(
+            "job_error",
+            jobid=jobid,
+            rule=rule,
+            wildcards=wildcards,
+            log=logs,
+            shellcmd=getattr(record, "shellcmd", None),
+        )
+
+    def _progress(self, record: LogRecord) -> None:
+        self.done = max(self.done, getattr(record, "done", 0) or 0)
+        self.total = getattr(record, "total", self.total) or self.total
+
+    def _reservation(self, job: Job) -> str:
+        """The two resources that decide admission — the rest of the dict is scheduler noise."""
+        out = []
+        for label, key, per_gb in (("mem", "mem_gb", 1), ("disk", "disk_mb", 1024)):
+            text = _gb(job.resources.get(key), per_gb)
+            if text:
+                out.append(f"{label}={text}")
+        return " ".join(out)
+
+    def _counter(self) -> str:
+        running = len(self.running)
+        pct = f", {self.done * 100 // self.total}%" if self.total else ""
+        return f"[{self.done}/{self.total or '?'}{pct}, {running} running]"
+
+    def _maybe_status(self) -> None:
+        interval = getattr(self.settings, "status_interval", STATUS_INTERVAL) or 0
+        if not interval or time.monotonic() - self.last_status < interval:
+            return
+        self.last_status = time.monotonic()
+        self._write(self.status_line())
+
+    def status_line(self) -> str:
+        by_rule: dict[str, int] = {}
+        for job in self.running.values():
+            by_rule[job.rule] = by_rule.get(job.rule, 0) + 1
+        ranked = sorted(by_rule.items(), key=lambda kv: -kv[1])
+        shown = " ".join(f"{rule}×{n}" for rule, n in ranked[:STATUS_RULE_LIMIT])
+        if len(ranked) > STATUS_RULE_LIMIT:
+            shown += f" +{len(ranked) - STATUS_RULE_LIMIT} more"
+        parts = [
+            f"{_hms(time.monotonic() - self.started)} elapsed",
+            self._counter().strip("[]"),
+        ]
+        if shown:
+            parts.append(shown)
+        if self.running:
+            oldest = max(self.running.values(), key=lambda j: j.elapsed)
+            parts.append(f"oldest {oldest.rule} {oldest.wildcards} {_hms(oldest.elapsed)}")
+        if self.failures:
+            parts.append(f"{len(self.failures)} failed")
+        return "── " + " · ".join(parts) + " ──"
+
+    def rollup(self) -> list[str]:
+        """Per-rule timing summary, printed once at close.
+
+        GitHub truncates the middle of a long log but reliably serves the end, so this
+        is the part of a planet build that always survives.
+        """
+        if not self.stats:
+            return []
+        lines = [f"── build summary · {_hms(time.monotonic() - self.started)} elapsed ──"]
+        for rule, (count, total, worst) in sorted(self.stats.items(), key=lambda kv: -kv[1][1]):
+            lines.append(
+                f"   {rule:<{RULE_WIDTH}} n={count:<6} "
+                f"total={_hms(total):>7}  mean={_hms(total / count):>7}  max={_hms(worst):>7}"
+            )
+        if self.failures:
+            lines.append(f"   failed: {', '.join(self.failures)}")
+        return lines
+
+    def _write(self, text: str) -> None:
+        self.stream.write(f"{time.strftime('%H:%M:%S')} {text}\n")
+        self.stream.flush()
+
+    def _event(self, kind: str, **fields: Any) -> None:
+        if self.events is None:
+            return
+        record = {"t": round(time.time(), 3), "event": kind, **fields}
+        self.events.write(json.dumps(record, default=str) + "\n")
+
+    def close(self) -> None:
+        # Snakemake closes its handlers, then logging.shutdown() closes them again — the
+        # rollup must print once.
+        with self.lock:
+            if not self.closed:
+                self.closed = True
+                for line in self.rollup():
+                    self.stream.write(line + "\n")
+                self.stream.flush()
+                if self.events is not None:
+                    self.events.close()
+                    self.events = None
+        super().close()

--- a/snakemake_logger_plugin_seascape/__init__.py
+++ b/snakemake_logger_plugin_seascape/__init__.py
@@ -108,13 +108,17 @@ def read_benchmark(path: str) -> dict[str, str]:
 
     The job process flushes this before exiting, and JOB_FINISHED fires after the
     scheduler has handled success, so it is on disk by the time this is called.
-    Anything unreadable (no benchmark: directive, a killed job) yields {}.
+    Anything short of one complete row yields {} — an OOM-killed job leaves the header
+    with no row behind it, and a half-row would report fabricated measurements for
+    exactly the job whose numbers matter most.
     """
     try:
         with open(path) as f:
-            header = f.readline().strip().split("\t")
-            values = f.readline().strip().split("\t")
+            header = f.readline().rstrip("\n").split("\t")
+            values = f.readline().rstrip("\n").split("\t")
     except OSError:
+        return {}
+    if len(values) != len(header) or not any(values):
         return {}
     return dict(zip(header, values))
 

--- a/snakemake_logger_plugin_seascape/__main__.py
+++ b/snakemake_logger_plugin_seascape/__main__.py
@@ -1,0 +1,133 @@
+"""Self-check: uv run python -m snakemake_logger_plugin_seascape --check
+
+Drives the handler with the exact record shapes snakemake emits (snakemake/jobs.py
+log_info, scheduling/job_scheduler.py) and asserts the console stays one line per job,
+the JSONL carries the structure, and the noise is gone.
+"""
+
+import io
+import json
+import logging
+import os
+import sys
+import tempfile
+
+from snakemake_interface_logger_plugins.common import LogEvent
+
+from snakemake_logger_plugin_seascape import LogHandler, LogHandlerSettings, read_benchmark
+
+BENCHMARK = (
+    "s\th:m:s\tmax_rss\tmax_vms\tmax_uss\tmax_pss\tio_in\tio_out\tmean_load\tcpu_time\n"
+    "1508.2\t0:25:08\t7372.80\t9000.0\t7000.0\t7100.0\t120.0\t80.0\t95.0\t1080.0\n"
+)
+
+
+def record(event=None, msg="", level=logging.INFO, **extra):
+    rec = logging.LogRecord("snakemake", level, __file__, 0, msg, None, None)
+    if event is not None:
+        rec.event = event
+    for key, value in extra.items():
+        setattr(rec, key, value)
+    return rec
+
+
+def check():
+    tmp = tempfile.mkdtemp()
+    bench = os.path.join(tmp, "mosaic.tsv")
+    with open(bench, "w") as f:
+        f.write(BENCHMARK)
+    events = os.path.join(tmp, "events.jsonl")
+
+    handler = LogHandler(
+        common_settings=None,
+        settings=LogHandlerSettings(events=events, starts=True, status_interval=0),
+    )
+    handler.stream = io.StringIO()
+
+    # RUN_INFO's job-stats table is where the DAG size comes from; PROGRESS only lands
+    # after the first job finishes.
+    handler.emit(record(LogEvent.RUN_INFO, msg="Job stats:\njob    count\nmosaic_tile  113\ntotal  113\n"))
+    assert handler.total == 113, handler.total
+
+    handler.emit(
+        record(
+            LogEvent.JOB_INFO,
+            jobid=3603,
+            rule_name="mosaic_tile",
+            wildcards={"stem": "8-70-105-15"},
+            resources={"mem_gb": 9, "disk_mb": 26624, "tmpdir": "/tmp"},
+            benchmark=bench,
+            log=["/app/tmp/logs/mosaic/8-70-105-15.log"],
+            reason="Updated input files: store/source/cudem/catalog.json",
+            input=["a.csv", "b.json"],
+            output=["store/mosaic/tiles/8-70-105-15.tif"],
+        )
+    )
+    # Noise snakemake emits between JOB_INFO and JOB_FINISHED — none of it may print.
+    handler.emit(record(msg="Select jobs to execute..."))
+    handler.emit(record(LogEvent.JOB_STARTED, msg="Execute 16 jobs...", jobs=[3603]))
+    # Snakemake's order: JOB_FINISHED, then PROGRESS. The finish line must already count
+    # itself rather than lag a job behind.
+    handler.emit(record(LogEvent.JOB_FINISHED, msg="", job_id=3603))
+    handler.emit(record(LogEvent.PROGRESS, done=1, total=113))
+
+    out = handler.stream.getvalue()
+    lines = [line for line in out.splitlines() if line.strip()]
+    # The job-stats table passes through; everything between the two job lines is dropped.
+    assert "Select jobs" not in out and "Execute 16 jobs" not in out, out
+    start, finish = lines[-2:]
+    assert "▸ mosaic_tile" in start and "8-70-105-15" in start, start
+    assert "mem=9G" in start and "disk=26G" in start, start
+    for want in ("✓ mosaic_tile", "8-70-105-15", "rss=7.2G", "cpu=18m00s", "[1/113, 0%, 0 running]"):
+        assert want in finish, f"missing {want!r} in {finish!r}"
+
+    # A failure names its rule, its wildcards, and where to look.
+    handler.emit(
+        record(
+            LogEvent.JOB_ERROR,
+            level=logging.ERROR,
+            jobid=42,
+            rule_name="depare_tile",
+            wildcards={"stem": "9-1-2-12"},
+            log=["/app/tmp/logs/depare/9-1-2-12.log"],
+            shellcmd="depare_run.py tile 9-1-2-12",
+        )
+    )
+    failure = handler.stream.getvalue().splitlines()[-1]
+    assert "✗ depare_tile 9-1-2-12" in failure and "depare/9-1-2-12.log" in failure, failure
+
+    # Snakemake re-reports every failure in its exit summary, without the wildcards.
+    before = len(handler.stream.getvalue().splitlines())
+    handler.emit(record(LogEvent.JOB_ERROR, level=logging.ERROR, jobid=42, rule_name="depare_tile"))
+    assert len(handler.stream.getvalue().splitlines()) == before, "failure reported twice"
+
+    # Warnings survive; plain info chatter does not.
+    handler.emit(record(msg="WARNING: only 12G free", level=logging.WARNING))
+    assert "only 12G free" in handler.stream.getvalue()
+
+    status = handler.status_line()
+    assert "1/113" in status and "1 failed" in status, status
+
+    # Snakemake closes its handlers and logging.shutdown() closes them again.
+    handler.close()
+    handler.close()
+    assert handler.stream.getvalue().count("build summary") == 1, "rollup printed twice"
+    assert "mosaic_tile" in handler.stream.getvalue()
+
+    rows = [json.loads(line) for line in open(events)]
+    kinds = [row["event"] for row in rows]
+    assert kinds == ["job_started", "job_finished", "job_error", "message"], kinds
+    assert rows[0]["reason"].startswith("Updated input files"), rows[0]
+    assert rows[1]["benchmark"]["max_rss"] == "7372.80", rows[1]
+    assert rows[1]["duration"] >= 0, rows[1]
+
+    # A job with no benchmark file finishes cleanly rather than raising.
+    assert read_benchmark(os.path.join(tmp, "nope.tsv")) == {}
+
+    print("snakemake_logger_plugin_seascape: ok")
+
+
+if __name__ == "__main__":
+    if "--check" not in sys.argv:
+        sys.exit("usage: python -m snakemake_logger_plugin_seascape --check")
+    check()

--- a/snakemake_logger_plugin_seascape/__main__.py
+++ b/snakemake_logger_plugin_seascape/__main__.py
@@ -101,9 +101,11 @@ def check():
     handler.emit(record(LogEvent.JOB_ERROR, level=logging.ERROR, jobid=42, rule_name="depare_tile"))
     assert len(handler.stream.getvalue().splitlines()) == before, "failure reported twice"
 
-    # Warnings survive; plain info chatter does not.
+    # Warnings reach the console and the JSONL both; a plain info line only the console.
     handler.emit(record(msg="WARNING: only 12G free", level=logging.WARNING))
     assert "only 12G free" in handler.stream.getvalue()
+    handler.emit(record(msg="Nothing to be done (all requested files are present)."))
+    assert "Nothing to be done" in handler.stream.getvalue()
 
     status = handler.status_line()
     assert "1/113" in status and "1 failed" in status, status
@@ -114,15 +116,22 @@ def check():
     assert handler.stream.getvalue().count("build summary") == 1, "rollup printed twice"
     assert "mosaic_tile" in handler.stream.getvalue()
 
-    rows = [json.loads(line) for line in open(events)]
+    with open(events) as f:
+        rows = [json.loads(line) for line in f]
     kinds = [row["event"] for row in rows]
     assert kinds == ["job_started", "job_finished", "job_error", "message"], kinds
     assert rows[0]["reason"].startswith("Updated input files"), rows[0]
     assert rows[1]["benchmark"]["max_rss"] == "7372.80", rows[1]
     assert rows[1]["duration"] >= 0, rows[1]
 
-    # A job with no benchmark file finishes cleanly rather than raising.
+    # No measurement is better than a fabricated one: a missing file, an empty file, and
+    # the header-with-no-row a killed job leaves behind all read as "nothing recorded".
     assert read_benchmark(os.path.join(tmp, "nope.tsv")) == {}
+    for content in ("", BENCHMARK.splitlines()[0] + "\n", "s\th:m:s\n0.5\n"):
+        partial = os.path.join(tmp, "partial.tsv")
+        with open(partial, "w") as f:
+            f.write(content)
+        assert read_benchmark(partial) == {}, content
 
     print("snakemake_logger_plugin_seascape: ok")
 


### PR DESCRIPTION
A build's log is how you tell whether it's healthy, and ours is mostly Snakemake talking about itself. On the last bbox build, 1,852 of 2,103 lines were scaffolding: a field block per job, a bare timestamp on its own line per event, and `Select jobs to execute...` / `Execute 16 jobs...` every scheduling round. That's 88%. A planet build at ~12,000 jobs works out near 200,000 lines, past what the GitHub UI will serve, which is why `scripts/watch-build` exists to grep the box directly.

For all that volume it never prints a job's runtime or its peak memory. Getting a runtime means pairing a `localrule` header with a `Finished jobid:` line 200 lines later, interleaved with fifteen other concurrent jobs. Peak RSS is already measured, by the `benchmark:` directive on every rule, but only reaches you as a post-run artifact after the box is gone.

`--quiet` can't fix it. `rules` also suppresses job errors, `progress` also suppresses the counter the CI heartbeat reads, and neither level touches the two scheduler lines: one is a plain info with no event attached, the other carries an event that isn't in Snakemake's quietness map at all. Snakemake 9 does let a logger plugin replace the console handler outright, and the plugin interface is already a transitive dependency, so this adds one.

## What the log looks like now

```
snakemake 9.23.1 · run 85c80daf-… · /opt/venv/bin/snakemake bundles publish_mosaic …
Job stats:
job            count
-----------  -------
mosaic_tile      113
total            113

05:06:13 ✓ mosaic_tile      8-70-105-15    25m08s  rss=7.2G  cpu=18m00s  [2/113, 2%, 15 running]
05:28:50 ✓ soundings_tile   8-70-105-15     3m12s  rss=2.1G  cpu=3m01s   [3/113, 2%, 14 running]
05:34:35 ✗ depare_tile      9-1-2-12  jobid=42  log=/app/tmp/logs/depare/9-1-2-12.log
05:39:00 ── 58m elapsed · 3/113, 2% · mosaic_tile×12 terrain_render×2 · oldest mosaic_tile 8-70-104-15 22m ──
── build summary · 1h17m elapsed ──
   mosaic_tile      n=112   total= 4h02m  mean=  2m10s  max= 25m08s
   failed: depare_tile 9-1-2-12
```

Runtime is measured by the handler, since the finish event carries only a jobid. RSS and CPU come from the job's own benchmark TSV, which the job process flushes before the scheduler handles success. The status line every five minutes is the one that answers "is this progressing or wedged on one stem". The rollup is at the end on purpose: GitHub truncates the middle of a long log but serves the tail.

Alongside the console stream, `--logger-seascape-events` writes JSONL into `$TMP/logs/`, which the existing benchmark artifact already collects. Every event carries its full record, so digging through a finished build is `jq`, not log scraping, and the enormous `input:` / `reason:` lists live there instead of on screen.

## Fallout

The heartbeat used to grep step counts and subtract two sets of jobids to guess how many jobs were running. Every job line now ends with the whole counter, so that's one grep and no arithmetic, and the running count is exact rather than inferred. `watch-build` filters on the job and status lines. Benchmarks gain `--benchmark-extended`, so each TSV names its own jobid, rule and wildcards rather than relying on the filename.

## On not using an existing plugin

The catalog has ten logger plugins, and I went through all of them. `rich` renders TTY progress bars, which are useless piped into Actions. `snkmt` has the right data model but delivers it to a SQLite file read by a separate TUI, and our box gets destroyed at the end of the run. `prometheus` wants a scrape target or a pushgateway. `github-status` overlaps the heartbeat but reports less than it already does. The rest push to websocket or message-broker dashboards and are unmaintained by the Snakemake org. They all assume something is watching live, so none of them emits the plain-text stream an ephemeral box piping into Actions actually needs.

## Testing

`python -m snakemake_logger_plugin_seascape --check` runs in `just test-engine` and drives the handler with the record shapes Snakemake actually emits. Past that I ran real Snakemake against a synthetic workflow and against this repo's Snakefile: success, failure under `--keep-going`, `-n`, `-p`, a no-op run, and `--benchmark-extended`. `actionlint` is clean.

Four bugs showed up only in those real runs. The handler's own lock shadowed `logging.Handler.lock` and deadlocked at interpreter shutdown. `from __future__ import annotations` broke the CLI outright, because the plugin registry hands each settings field's type straight to argparse. Snakemake reports every failure twice, the second time without wildcards. And dropping unrecognized info-level output silenced both `Nothing to be done` and the entire dry-run plan, so the filter is inverted now: pass info through, drop the two known-empty scheduler lines, and turn the per-job plan lines on automatically under `-n`.

Two things I couldn't prove locally. `max_rss` reads 0 on macOS because psutil's sampler doesn't populate it there, so the RSS formatting is covered against a synthetic TSV but the real number is unproven until this runs on Linux. And the scope-gate dry run keeps the default logger, since it parses `^Job stats` out of that output; the plugin writes passthrough blocks untimestamped so it would survive the switch, but there was no reason to widen the blast radius.

One thing deliberately left alone: rules still redirect `2> {log}`, not `&> {log}`. What reaches stdout isn't leakage, it's `run_command(..., silent=False)` and `run_monitored` deliberately surfacing things like `soundings tile 8-70-105-15: 1160608 points`. Redirecting all of it would bury about a hundred useful lines per build to kill twenty of rclone and tippecanoe noise, and with the scaffolding gone those lines read fine against the job lines instead of drowning in them.
