### PR TITLE
Fix green foreshore appearing along tideless coasts

### DIFF
--- a/pipelines/aggregation_reproject.py
+++ b/pipelines/aggregation_reproject.py
@@ -525,7 +525,12 @@ def reproject(filepath):
             # reads this unclamped mosaic in (0, DRYING_CAP]. Clamp positive ocean to 0 so it can't.
             # Deliberately discards coarse "drying": these flagged sources can't resolve the
             # foreshore, and trusted topobathy sources are unflagged, so genuine drying survives.
-            landmask.clamp_positive_ocean(out_tiff, mask_tif, water_tif)
+            # Eroded by the group's own cell (same measure the feather uses), because rasterize
+            # samples centres: a straddling cell that centres on land keeps its positive value here
+            # and re-cuts as drying against the render's finer mask. At least one pixel — a flagged
+            # source is coarse by definition, and a cell finer than the grid still straddles.
+            landmask.clamp_positive_ocean(out_tiff, mask_tif, water_tif,
+                                          erode_px=max(1.0, min(cell_px, FEATHER_MAX_FACTOR)))
         out_i += 1
         if len(grouped) > 1 and not contains_nodata_pixels(out_tiff):
             break

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -107,7 +107,14 @@ def _may_dry(w):
     if "is_salt" in w.columns:
         may |= w["is_salt"].fillna(False).astype(bool)
     if "tidal" in w.columns:
-        may |= w["tidal"] == "yes"
+        tidal = w["tidal"] == "yes"
+        if "is_salt" in w.columns:
+            # An explicit salt=no outranks tidal=yes: the pair is self-contradictory, and OSM
+            # misapplies tidal=yes to inland lakes (105 worldwide, Ladoga/Ohrid/Chiemsee among
+            # them), where it paints drying across the lakebed. Missing salt still rescues, so
+            # the coastal lagoons that carry neither tag are untouched.
+            tidal &= w["is_salt"].fillna(True).astype(bool)
+        may |= tidal
     return may
 
 # Sliver filter: the vector edges (OSM water outline, effective-land cut) and the raster
@@ -1146,6 +1153,13 @@ def _check():
         "class=lagoon must rescue a kind=lake polygon (most lagoons carry no other signal)"
     assert dry.intersects(tidal_lake).any(), \
         "an OSM tidal=yes must rescue a kind=lake polygon"
+    # The three is_salt states against tidal=yes, asserted on the predicate rather than a fifth
+    # fixture box, which would narrow every polygon toward the legibility filters.
+    salt_probe = gpd.GeoDataFrame({"kind": ["lake"] * 3, "class": [None] * 3,
+                                   "is_salt": [False, None, True], "tidal": ["yes"] * 3},
+                                  geometry=[_box(0, 0, 1, 1)] * 3, crs="EPSG:3857")
+    assert list(_may_dry(salt_probe)) == [False, True, True], \
+        "salt=no must veto tidal=yes; unknown or salt water must still rescue"
     nodata_rows = rows[rows["drval1"].isna()]
     assert nodata_rows.covers(lake.intersection(cell_box(0, 20, 60, 40)).centroid).any(), \
         "the lake's [0, cap] shore ribbon stays part of its nodata polygon"

--- a/style/index.ts
+++ b/style/index.ts
@@ -81,9 +81,10 @@ export const day: Flavor = {
   // Land above datum: translucent buff wash (paper-chart figure-ground — white
   // stays unambiguously "deep water"); a raster base reads through it.
   land: "rgba(247,240,221,0.66)",
-  // Drying areas (INT-1 foreshore green): seabed above chart datum that covers
-  // and uncovers with the tide.
-  drying: "#a8d5ba",
+  // Drying areas (S-52 DEPIT day green): seabed above chart datum that covers
+  // and uncovers with the tide. Darker than the shoalest band — charts weight
+  // the foreshore as the heaviest tint in the shoaling sequence.
+  drying: "#58af9c",
   // Unknown-depth water (ENC DEPARE nodata): mapped water we hold no depth for. Painted
   // the hazard tint — unsurveyed water warrants the same caution as known-unsafe water
   // (ECDIS treats it as unsafe for the safety check; S-52 hatching is the eventual upgrade).


### PR DESCRIPTION
@tkurki reported drying areas showing in the Baltic, where the tide is about 5 cm and no foreshore can exist.

It turned out not to be a Baltic problem. Over 25 tiles of the Stockholm archipelago the published tiles carry 413 drying polygons covering 103 km², about the density the Wadden Sea shows, and the Wadden has a 2.5 m tide. But the two look nothing alike up close. Wadden drying is one coherent flat, its pixels a median of 62 px from the nearest land. The Baltic's are hundreds of separate crumbs sitting 1 px from shore. The same crumbs turn up in the Mediterranean, the Aegean, the Danish belts, and along Lofoten.

## What was happening

Drying is classified as elevation in (0, `DRYING_CAP`] on the water side of the OSM coastline. The ocean clamp is supposed to remove the coarse-source junk before it ever gets there, and it keys on a land mask rasterized at the aggregation resolution. But the terrain render and the depare cut key on a mask rasterized at the render zoom, which is 4 to 32 times finer.

Rasterizing samples pixel centres, so a source cell straddling the coast lands wholly on whichever side its centre falls. A cell that centres on land keeps its positive elevation through the clamp. Then it meets the finer mask, which puts its seaward half on the water side, and that half lands in (0, `DRYING_CAP`] and tints green. The result is a fringe one source cell wide along every coast. The whole Baltic is EMODnet-only, whose cell is 223 m there, and the fringe measured about that wide.

## The fix

Erode the land side by the group's own source cell before clamping, so a cell that merely touches water clamps rather than only one centred on water. It reuses `group_cell_px`, the measure the coverage feather already takes.

This costs no genuine drying. OSM draws the coastline at high water, so real foreshore is already seaward of the line and the clamp was already taking it. The erosion only reaches land-side pixels, which resolve to land downstream where the render nudges a land-side `<= 0` to the land sentinel.

## Evidence

Run against the real Stockholm coastline, using the published OSM mask and a synthetic source at EMODnet's cell size, aggregated at z10 and classified at z13 exactly as the render does:

```
agg z10 (76 m/px), render z13 (9.6 m/px), source cell 223 m = 2.9 agg px
  erode_px=0     drying  0.51%   2.54 km2   1799 parts   median 1.4 px from land
  erode_px=2.9   drying  0.01%   0.06 km2    305 parts   median 1.0 px from land
  removed: 97.5% of the fringe
```

The `erode_px=0` row reproduces the published tiles' signature, which is what confirms the diagnosis rather than just the patch. The remaining 0.06 km² is sub-render-pixel jitter.

Before and after:
<img width="3096" height="1576" alt="baltic-drying-before-after" src="https://github.com/user-attachments/assets/d8f2ae8f-0103-45d7-801f-a086bc75a42b" />

## Also here

The drying green deepens to the S-52 day tint, weighting the foreshore as the heaviest tint in the shoaling sequence the way charts order it.

## Rollout

This changes the recipe for every `land_clamp` source (GEBCO, EMODnet, `great_lakes`, `bodensee`, `lac_neuchatel`), so they re-aggregate on the next build. It is a code-only change, which marks nothing dirty, so it needs forced re-registration. I have not touched any state.

A spatially-varying `DRYING_CAP` driven by local tidal range is still the real answer for telling foreshore from land, and `config.py` already names it as the upgrade path. Nothing measured in the Baltic survives this fix to need it yet.

## Testing

`landmask.py --check` gains two assertions: a positive pixel within `erode_px` of water must clamp, and the erosion must give the same result at any scan-block size. The second caught a real bug in the first draft of the halo. `aggregation_reproject`, `aggregation_covering`, `mosaic`, `terrain`, `bundle` `--check`, `test_build.py`, `test_consistency.py`, and the style suite all pass.

`test_engine.py` fails locally on a `vector_cell` soundings count. It fails identically at HEAD on a clean worktree, so it is local toolchain skew rather than anything here.

Based on #117, since the fix calls `group_cell_px`, which lands there.

