### PR TITLE
Move the Overture pin off the release about to be pruned

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -292,7 +292,7 @@ rule watermask:
     output:
         "store/landmask/water.fgb"
     params:
-        version=2, # increment to force a rebuild
+        version=3, # increment to force a rebuild
     priority: 10_000_000  # see landmask
     # No retries: the planet read is ~9 h, and every failure seen here has been deterministic
     retries: 0

--- a/pipelines/landmask.py
+++ b/pipelines/landmask.py
@@ -85,7 +85,7 @@ LAND_POLYGONS_URL = "https://osmdata.openstreetmap.de/download/land-polygons-spl
 # snapshot; bump it to the current Overture release when re-preparing (listing:
 # https://docs.overturemaps.org/release/). GDAL opens the partition directory as one
 # dataset (~65M features); the bucket is anonymous, so no credentials in the read path.
-OVERTURE_RELEASE = "2026-06-17.0"
+OVERTURE_RELEASE = "2026-07-22.0"
 OVERTURE_BUCKET_URL = "https://overturemaps-us-west-2.s3.us-west-2.amazonaws.com"
 OVERTURE_PREFIX = f"release/{OVERTURE_RELEASE}/theme=base/type=water/"
 # Where the release's parquet parts are staged (26 GB / 32 files). Kept per release so a


### PR DESCRIPTION
Overture publishes to its public bucket on a roughly monthly cadence and keeps only the last two releases, deleting the rest. The pin sat on the older of the two, so the day the next release lands, `2026-06-17.0` disappears and every inland-water-mask build fails in `_check_release` with nothing to fall back to. Moving to the newer release buys a full cycle of headroom.

This is a pin refresh, not a data change. The schema the window read depends on is unchanged: `subtype`, `class`, `is_salt`, `is_intermittent` and the `source_tags` `$.tidal` passthrough all still exist and are still populated (Thames estuary window: 109 `tidal=yes`, 37 `tidal=no`, so the undocumented passthrough survives another release). The partition is the same shape, 32 parquet parts and 26.2 GiB, and the two releases return identical ids over the probed windows.

`watermask`'s `version=` moves with it. The profile's rerun-triggers deliberately exclude code, so editing `landmask.py` invalidates nothing on its own; without the param bump the box would keep serving the mask built from the old release and the pin would only take effect the next time something else forced a rebuild.

## Rollout

Merging this makes the next sources run rebuild the mask from `2026-07-22.0`. That run stages the new partition (26 GB, into `store/landmask/overture-2026-07-22.0/` beside the existing cache rather than over it) and rebuilds `water.fgb` and `land-z8.tif`, so it is a longer sources run than usual. The mask's own gates decide whether it publishes: the conservation count and the 494 required lakes both have to pass, which is what makes a release bump safe to take without hand-inspecting the result.

Worth doing deliberately rather than letting it ride: the current mask is the one the v2026.08.10 tiles were built against, and `water-pre-huron-fix.fgb` on R2 is the rollback if the new release's water differs more than expected.
