### PR TITLE
Replace stale footprint files instead of refusing them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,6 +279,19 @@ jobs:
             nsenter -t 1 -m mountpoint -q "$f" || { echo "bind failed for $f" >&2; exit 1; }
             echo "serving $(basename "$f") from NVMe"
           done
+      - name: Heal legacy depare schemas
+        # A depare tile whose rows are ALL nodata carries no drval, and OGR used to type those
+        # columns String from the staged values — which makes contour_tile's numeric filter
+        # invalid SQL and fails the tile a stage later. depare_run pins the schema on write now,
+        # but that cannot reach artifacts already on the volume: no depare input or param
+        # changed, so Snakemake holds them up to date. Repairing the schema in place is seconds
+        # and keeps the geometry, where a rebuild would recompute the partition for nothing.
+        # A no-op (one metadata read per file) once the fleet is clean.
+        env:
+          STATE: /mnt/seascape-store
+        run: |
+          ./docker.sh run uv run --project /app python \
+            /app/pipelines/heal_depare_schema.py /app/state/store/depare
       - name: Build the mosaic (Snakemake)
         env:
           # Dispatch inputs reach the shell as env vars, never interpolated into a shell line.

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,7 @@ test-engine:
     uv run python bundle.py --check
     uv run python test_build.py
     uv run python terrain.py --check
+    uv run python heal_depare_schema.py --check
     uv run python test_consistency.py
     # Repo root: the logger plugin has to sit on sys.path under its discoverable name.
     cd "{{justfile_directory()}}" && uv run python -m snakemake_logger_plugin_seascape --check

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -531,6 +531,14 @@ class _RowSink:
     # Decimal degrees kept on write: 1e-9 deg is 0.11 mm, four orders below the S-58 vertex floor
     # and below anything the pipeline's own geometry means.
     COORD_DECIMALS = 9
+    # The written field schema, cast at the conversion rather than left to inference. OGR types a
+    # GeoJSONSeq field from the VALUES it sees, and a column null in every row types as String — an
+    # all-nodata tile carries no drval at all, so its drval1/drval2 land as String and every
+    # numeric read of the layer ("drval1 < 0") is then invalid SQL. Casting fixes the type without
+    # touching the values, so absence survives as NULL. None passes the field through: String is
+    # what sys/kind infer to anyway, and casting a string needs a width that could truncate.
+    FIELDS = (("drval1", "float"), ("drval2", "float"), ("sys", None),
+              ("kind", None), ("rank", "integer"))
     # Every repaired row must keep its own polygonal area, measured against itself at each stage of
     # the write: a band or drying part that loses area leaves a hole in the chart, which is the
     # unsafe direction, so the tile fails instead. A repair may GROW a row (an invalid ring's
@@ -631,11 +639,21 @@ class _RowSink:
         # MultiPolygon of 40k+ parts and exceeds it: 8-63-105-15 and 8-63-106-15 both died here,
         # after the full partition pass had already run. Keep the band ONE feature — splitting it
         # would change feature counts and ids, i.e. the partition contract.
+        layer = os.path.splitext(os.path.basename(self.seq))[0]
         contour_run._run(f"ogr2ogr --config OGR_GEOJSON_MAX_OBJ_SIZE 0 "
-                         f"-f FlatGeobuf -overwrite {final_fgb} {self.seq}",
+                         f"-f FlatGeobuf -overwrite "
+                         f"""-sql '{row_select(layer)}' """
+                         f"{final_fgb} {self.seq}",
                          "ogr2ogr depare")
         os.remove(self.seq)
         return self.count
+
+
+def row_select(layer):
+    """The SELECT that pins a depare layer to _RowSink.FIELDS. Shared with heal_depare_schema, so
+    the written schema has ONE definition — the heal has to cast exactly what the writer casts."""
+    cols = ", ".join(f"CAST({n} AS {t}) AS {n}" if t else n for n, t in _RowSink.FIELDS)
+    return f'SELECT {cols} FROM "{layer}"'
 
 
 def _depare_dem(dem, tile_obj, child_z, tmp, label, timeout=0):
@@ -1119,6 +1137,32 @@ def _check():
     assert "changed polygonal area" in _raised and "lost polygonal area" not in _raised, \
         ("a dropped row whose shoelace had cancelled must fail the write at the explode stage, "
          f"got {_raised!r}")
+
+    # The written schema is a CONTRACT, not an inference. contour_run reads these rows back with a
+    # numeric filter, and a tile whose rows are ALL nodata carries no drval at all — typed by
+    # inference those columns land String and the filter is invalid SQL, which fails the tile far
+    # downstream of the write that caused it. Both flush shapes must land numeric and answer the
+    # real filter. The layer name carries a hyphen in production, so the SQL must quote it.
+    import pyogrio
+    _where = "sys = 'm' OR drval1 < 0"  # contour_run's metre-pass filter, verbatim
+    _nodata = [{"geometry": _box(0, 0, 1, 1), "drval1": None, "drval2": None, "sys": None,
+                "kind": "lake", "rank": NODATA_RANK}]
+    _band = [{"geometry": _box(2, 0, 3, 1), "drval1": -10.0, "drval2": -5.0, "sys": "m",
+              "kind": None, "rank": BAND_RANK}]
+    for _name, _rows, _hits in (("all-nodata", _nodata, 0), ("mixed", _nodata + _band, 1)):
+        _d = tempfile.mkdtemp()
+        _sink = _RowSink(f"{_d}/depare-rows.geojsons")
+        _sink.write(_rows)
+        _sink.finish(f"{_d}/out.fgb")
+        _types = dict(zip(*(pyogrio.read_info(f"{_d}/out.fgb")[k]
+                            for k in ("fields", "dtypes"))))
+        assert _types.get("drval1") == "float64" and _types.get("drval2") == "float64", \
+            f"{_name} flush must write numeric drval columns, got {_types}"
+        _read = gpd.read_file(f"{_d}/out.fgb", where=_where)
+        assert len(_read) == _hits, \
+            f"{_name} flush must answer contour_run's filter with {_hits} row(s), got {len(_read)}"
+        assert gpd.read_file(f"{_d}/out.fgb")["drval1"].isna().sum() == len(_nodata), \
+            f"{_name} flush must keep an absent drval NULL, not fill it"
 
     # ContourTimeout mapping: a bounded command that exceeds its budget must surface as
     # ContourTimeout (the tile's retry trigger), not a generic failure.

--- a/pipelines/heal_depare_schema.py
+++ b/pipelines/heal_depare_schema.py
@@ -1,0 +1,162 @@
+"""Repair depare FGBs whose drval columns are typed String instead of numeric.
+
+OGR types a GeoJSONSeq field from the VALUES it sees, so a tile whose rows are ALL nodata — inland
+water the DEM holds no bathymetry for, which carries no drval at all — used to land drval1/drval2
+as String. contour_run reads those rows back with a numeric filter ("drval1 < 0"), which is then
+invalid SQL, and the tile fails a whole stage downstream of the write that caused it.
+
+depare_run pins the schema on write now. This repairs the artifacts already on the store volume,
+which the writer fix cannot reach: nothing about a depare rule's inputs or params changed, so
+Snakemake considers them up to date. The geometry in them is CORRECT — only the field type is
+wrong — so this rewrites the schema in place rather than re-running the partition, which would
+recompute contours for no geometric gain.
+
+Idempotent and cheap: a clean store costs one read_info per file and rewrites nothing.
+
+    heal_depare_schema.py [<dir>]   heal every .fgb under <dir> (default store/depare)
+    heal_depare_schema.py --check   self-check (synthetic poisoned file, no network)
+"""
+
+import glob
+import os
+import subprocess
+import sys
+
+import pyogrio
+
+import depare_run
+
+# The fields the writer casts to a numeric type; pyogrio reports an OGR String field as "object".
+NUMERIC_FIELDS = tuple(n for n, t in depare_run._RowSink.FIELDS if t in ("float", "integer"))
+NUMERIC_DTYPES = ("float64", "float32", "int64", "int32")
+
+DEFAULT_DIR = "store/depare"
+
+
+def _schema(path):
+    """{field: dtype} as pyogrio reports it — metadata only, the features are never read."""
+    info = pyogrio.read_info(path)
+    return dict(zip(info["fields"], info["dtypes"])), int(info["features"])
+
+
+def needs_heal(path):
+    """The numeric fields this file types as something else. Empty means it is already correct.
+
+    A field that is ABSENT is not reported: casting one would fail, and a depare layer without
+    drval1 is a different defect than a mistyped one."""
+    types, _ = _schema(path)
+    return [n for n in NUMERIC_FIELDS
+            if n in types and types[n] not in NUMERIC_DTYPES]
+
+
+def heal(path):
+    """Rewrite `path` with the numeric schema, atomically. Returns the fields that were fixed.
+
+    The rewrite is a straight copy through the writer's own SELECT, so NULLs stay NULL (absence is
+    what tippecanoe encodes as a missing property) and the geometry is untouched. Written beside
+    the original and renamed, so an interrupted heal cannot leave a truncated artifact in place."""
+    bad = needs_heal(path)
+    if not bad:
+        return []
+    layer = pyogrio.list_layers(path)[0][0]
+    before_types, before_n = _schema(path)
+    tmp = f"{path}.heal.tmp.fgb"
+    try:
+        subprocess.run(["ogr2ogr", "-f", "FlatGeobuf", "-overwrite",
+                        "-sql", depare_run.row_select(layer), tmp, path],
+                       check=True, capture_output=True, text=True)
+        after_types, after_n = _schema(tmp)
+        # Never replace a good artifact with a short one: a partial rewrite would silently delete
+        # depth areas, which is the failure this whole pass exists to undo.
+        if after_n != before_n:
+            raise AssertionError(f"{path}: heal wrote {after_n} of {before_n} features")
+        still = [n for n in NUMERIC_FIELDS
+                 if n in after_types and after_types[n] not in NUMERIC_DTYPES]
+        if still:
+            raise AssertionError(f"{path}: still non-numeric after heal: {still}")
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+    return bad
+
+
+def run(folder=DEFAULT_DIR):
+    """Heal every FGB under `folder`. Prints one line per repair plus a summary."""
+    paths = sorted(glob.glob(os.path.join(folder, "*.fgb")))
+    healed = []
+    for p in paths:
+        fixed = heal(p)
+        if fixed:
+            healed.append(os.path.basename(p))
+            print(f"healed {os.path.basename(p)}: {', '.join(fixed)} -> numeric", flush=True)
+    print(f"depare schema: {len(paths)} scanned, {len(healed)} healed"
+          + (f" ({', '.join(healed)})" if healed else ""), flush=True)
+    return healed
+
+
+def _poisoned(path, rows):
+    """Write an FGB the way the pre-fix writer did — GeoJSONSeq staged, types left to inference."""
+    import geopandas as gpd
+    seq = f"{path}.geojsons"
+    gpd.GeoDataFrame(rows, crs="EPSG:4326").to_file(seq, driver="GeoJSONSeq")
+    # No -sql: this is exactly the conversion that typed an all-null column String.
+    subprocess.run(["ogr2ogr", "-f", "FlatGeobuf", "-overwrite", "-nln", "depare-rows", path, seq],
+                   check=True, capture_output=True, text=True)
+    os.remove(seq)
+
+
+def _check():
+    """A synthetic all-nodata tile is typed String, heals to numeric, answers the reader's filter,
+    keeps its geometry/NULLs/feature count, and heals to a no-op the second time."""
+    import tempfile
+
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    d = tempfile.mkdtemp()
+    path = f"{d}/8-69-88-8.fgb"
+    rows = [{"geometry": box(i, 0, i + 1, 1), "drval1": None, "drval2": None,
+             "sys": None, "kind": "lake", "rank": depare_run.NODATA_RANK} for i in range(8)]
+    _poisoned(path, rows)
+    assert needs_heal(path) == ["drval1", "drval2"], \
+        f"the fixture must reproduce the String schema, got {_schema(path)[0]}"
+    where = "sys = 'm' OR drval1 < 0"  # contour_run's metre-pass filter, verbatim
+    try:
+        gpd.read_file(path, where=where)
+        raise AssertionError("the poisoned fixture must fail the reader's numeric filter")
+    except ValueError:
+        pass
+
+    original = gpd.read_file(path)
+    assert heal(path) == ["drval1", "drval2"], "heal must report the fields it fixed"
+    types, n = _schema(path)
+    assert all(types[f] in NUMERIC_DTYPES for f in NUMERIC_FIELDS), \
+        f"healed schema must be numeric, got {types}"
+    assert n == len(rows), f"heal must keep every feature, got {n} of {len(rows)}"
+    after = gpd.read_file(path)
+    assert bool(original.geometry.equals(after.geometry)), "heal must not touch the geometry"
+    assert bool(after["drval1"].isna().all()), "an absent drval must stay NULL, not become 0"
+    assert bool((original["kind"] == after["kind"]).all()), "heal must carry the other fields"
+    assert len(gpd.read_file(path, where=where)) == 0, \
+        "the healed layer must answer the reader's numeric filter"
+    assert pyogrio.list_layers(path)[0][0] == "depare-rows", "heal must keep the layer name"
+
+    assert heal(path) == [], "a healed file must heal to a no-op"
+    assert not glob.glob(f"{d}/*.tmp.fgb"), "heal must leave no temp artifact behind"
+
+    # A tile that always had numeric drvals is left alone, and run() reports it scanned-not-healed
+    good = f"{d}/8-1-1-8.fgb"
+    _poisoned(good, [{"geometry": box(0, 0, 1, 1), "drval1": -10.0, "drval2": -5.0,
+                      "sys": "m", "kind": None, "rank": depare_run.BAND_RANK}])
+    assert needs_heal(good) == [], "a numeric tile must not be rewritten"
+    assert run(d) == [], "a clean folder must heal nothing"
+    print("heal_depare_schema self-check ok")
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if args[:1] == ["--check"]:
+        _check()
+    else:
+        run(args[0] if args else DEFAULT_DIR)

--- a/pipelines/source_polygonize.py
+++ b/pipelines/source_polygonize.py
@@ -80,9 +80,14 @@ def polygonize_tif(source, filename):
     utils.run_command(
         f'GDAL_CACHEMAX=1024 gdal_calc.py -A {calc_src} '
         f'--outfile={mask} --calc="A*0+1" --type=Byte --overwrite', silent=SILENT)
+    out = f"store/polygon/{source}/{filename}.gpkg"
+    # A stale per-file gpkg from an interrupted run must not survive: trailing -overwrite is
+    # misparsed as the layer name by current gdal_polygonize, so remove + lead with the flag.
+    if os.path.isfile(out):
+        os.remove(out)
     utils.run_command(
-        f'GDAL_CACHEMAX=1024 gdal_polygonize.py {mask} -b 1 -f "GPKG" '
-        f'store/polygon/{source}/{filename}.gpkg -overwrite', silent=SILENT)
+        f'GDAL_CACHEMAX=1024 gdal_polygonize.py -overwrite {mask} -b 1 -f "GPKG" '
+        f'{out}', silent=SILENT)
     os.remove(mask)
     if calc_src != src:
         os.remove(calc_src)
@@ -165,6 +170,9 @@ def _check():
         info = json.loads(subprocess.run(["ogrinfo", "-json", out],
                                          capture_output=True, text=True, check=True).stdout)
         assert info["layers"][0]["featureCount"] >= 1, info["layers"][0]["featureCount"]
+        # A stale gpkg from an interrupted run must be replaced, not refused.
+        polygonize_tif(sid, name)
+        assert os.path.isfile(out), "a pre-existing footprint must be rewritten"
     finally:
         os.chdir(cwd)
         shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
The sources run from main (31908081953) failed uk_cco's polygon step on a leftover from the previous interrupted run: `gdal_polygonize` misparses a trailing `-overwrite` as the layer name, so a per-file footprint gpkg that already exists makes the rerun fail with "already exists" instead of being replaced. The flag now leads the arguments and the stale file is removed first, mirroring how `merge_source` already handles `merged.gpkg`. Self-check covers the rerun-over-existing-footprint case.

The same run's other failure needs no code: uk_multibeam's stage-time quarantine fired correctly on the truncated EA member and deleted the bad raw — it just fired in the run's final invocation, so the refetch belongs to the next dispatch.