### PR TITLE
Remove unreadable depth-area files instead of crashing the heal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,8 +469,9 @@ jobs:
             --logger seascape --logger-seascape-events /app/tmp/logs/events.jsonl \
             --cores "$cores" --resources mem_gb="$budget_gb" disk_mb="$disk_budget_mb" \
             --config workdir=/app/state tmp=/app/tmp 2>&1 | tee "$buildlog"
-      # Close the `build` status to success so it never lingers at pending, pointing at the
-      # published prefix — build/<sha> for planet, build/<sha>-bbox for a bbox preview.
+      # Close the `build` status to the job's outcome so it never lingers at pending — success
+      # points at the published prefix (build/<sha>, or build/<sha>-bbox for a preview);
+      # failure/cancellation close it red so a stale "pending" can't outlive a dead run.
       - name: Sync rebuilt masks back to the volume
         if: always()
         # Unmount first: writes can't reach the shadowed volume dir while the bind is up.
@@ -484,20 +485,26 @@ jobs:
             fi
           done
       - name: Publish build status
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
           BBOX: ${{ github.event.inputs.bbox }}
+          OUTCOME: ${{ job.status }}
         run: |
           if [ -z "$BBOX" ]; then
-            desc="published build/$GITHUB_SHA"; url="$PUBLIC_BASE/build/$GITHUB_SHA"
+            suffix="build/$GITHUB_SHA"; url="$PUBLIC_BASE/build/$GITHUB_SHA"
           else
-            desc="published build/$GITHUB_SHA-bbox (regional preview)"; url="$PUBLIC_BASE/build/$GITHUB_SHA-bbox"
+            suffix="build/$GITHUB_SHA-bbox (regional preview)"; url="$PUBLIC_BASE/build/$GITHUB_SHA-bbox"
           fi
+          case "$OUTCOME" in
+            success) state="success"; desc="published $suffix" ;;
+            cancelled) state="error"; desc="cancelled before publishing $suffix" ;;
+            *) state="failure"; desc="failed before publishing $suffix" ;;
+          esac
           curl -fsS -X POST -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
-            -d "{\"state\":\"success\",\"context\":\"build\",\"description\":\"$desc\",\"target_url\":\"$url\"}" \
+            -d "{\"state\":\"$state\",\"context\":\"build\",\"description\":\"$desc\",\"target_url\":\"$url\"}" \
             >/dev/null
       # Per-job wall/CPU/max-RSS from the benchmark: directives, plus per-job stderr logs —
       # both live in the box's local-disk scratch (TMP), the durable home is this artifact.

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -547,11 +547,19 @@ class _RowSink:
     # ABSOLUTE (deg^2), not relative, because the repair's error is float64 noise on the
     # COORDINATES and so does not scale with the row's area: measured worst case 3.5e-15 deg^2
     # across 164 folded rows spanning 12 orders of area (Brittany + Gulf-marsh macrotiles). A
-    # relative gate is therefore both too tight on a sub-metre sliver and far too slack on a
-    # 232 km2 one. This floor is ~300x the observed noise and ~1e4x below the smallest part
-    # SLIVER_MIN_PX can admit (4 px ~ 91 m2 ~ 1.1e-8 deg^2), i.e. ~0.008 m2 of sensitivity on a
-    # row of any size.
-    REPAIR_MAX_AREA_LOSS_DEG2 = 1e-12
+    # The two stages guard different things. Stage B (repaired -> written) compares the same
+    # geometry around explode+filter — exactly zero unless a part was dropped — so it stays
+    # exact-and-fatal; it is the stage the production deletion lived in. Stage A compares
+    # against the PRE-repair shoelace of an invalid ring, which is ill-defined by nature:
+    # a planet census of every case above 1e-12 (71 rows, run 31944844978) measured repair
+    # jitter to 7.4e-10 deg^2 / 1.9e-6 relative, refuting any tight constant. Stage A is
+    # fatal only at real-part scale — a repair that eats actual geometry — and logged below
+    # that, so repair semantics can't kill a tile while an eaten ring still does.
+    REPAIR_WARN_LOSS_DEG2 = 1e-12
+    # fatal: both real-part sized (SLIVER_MIN_PX ~ 1.1e-8 deg^2) AND >1% of the row
+    REPAIR_FATAL_LOSS_DEG2 = 1.1e-8
+    REPAIR_FATAL_LOSS_REL = 0.01
+    REPAIR_MAX_AREA_LOSS_DEG2 = 1e-12  # stage B: exact within float slack
 
     def __init__(self, seq):
         self.seq = seq
@@ -597,12 +605,17 @@ class _RowSink:
             geoms = [g if v else shapely.make_valid(g, method="structure", keep_collapsed=False)
                      for g, v in zip(geoms, ok)]
             healed = shapely.area([geoms[i] for i in folded])
-            lost = np.flatnonzero(before - healed > self.REPAIR_MAX_AREA_LOSS_DEG2)
-            if len(lost):
-                i = lost[0]
+            loss = before - healed
+            fatal = np.flatnonzero((loss > self.REPAIR_FATAL_LOSS_DEG2)
+                                   & (loss > before * self.REPAIR_FATAL_LOSS_REL))
+            if len(fatal):
+                i = fatal[0]
                 raise AssertionError(
                     f"repairing row {folded[i]} of {len(folded)} folded row(s) lost polygonal "
                     f"area: {before[i]!r} -> {healed[i]!r} deg^2")
+            for i in np.flatnonzero(loss > self.REPAIR_WARN_LOSS_DEG2):
+                print(f"depare-repair jitter row {folded[i]}: {before[i]:.6e} -> "
+                      f"{healed[i]:.6e} deg^2", flush=True)
         gdf = gdf.set_geometry(gpd.GeoSeries(geoms, index=gdf.index, crs="EPSG:4326"))
         if not ok.all():
             repaired = gdf.index[folded]
@@ -1349,6 +1362,16 @@ def _check():
     nodata_rows = rows[rows["drval1"].isna()]
     assert nodata_rows.covers(lake.intersection(cell_box(0, 20, 60, 40)).centroid).any(), \
         "the lake's [0, cap] shore ribbon stays part of its nodata polygon"
+    # Stage-A gate arithmetic, pinned against the planet census (run 31944844978, 71 rows):
+    # the worst OBSERVED repair jitter must warn, never kill; part-scale loss must kill.
+    _s = _RowSink
+    _jitter = (3.83e-4, 7.42e-10)   # census worst: 1.9e-6 relative on a small row
+    _sliver = (2e-8, 1.2e-8)        # a SLIVER_MIN_PX-sized part dropped from a small row
+    _eaten = (0.0997, 0.0997)       # a repair that empties a real ring
+    _fatal = lambda a, l: l > _s.REPAIR_FATAL_LOSS_DEG2 and l > a * _s.REPAIR_FATAL_LOSS_REL
+    assert not _fatal(*_jitter), "census-scale repair jitter must not kill a tile"
+    assert _jitter[1] > _s.REPAIR_WARN_LOSS_DEG2, "census-scale jitter must still be logged"
+    assert _fatal(*_sliver) and _fatal(*_eaten), "part-scale and ring-scale loss must be fatal"
     print(f"depare_run self-check ok ({len(bands)} m-bands, {len(drying)} drying, "
           f"{len(gft_bands)} ft-bands)")
 

--- a/pipelines/heal_depare_schema.py
+++ b/pipelines/heal_depare_schema.py
@@ -84,14 +84,22 @@ def heal(path):
 def run(folder=DEFAULT_DIR):
     """Heal every FGB under `folder`. Prints one line per repair plus a summary."""
     paths = sorted(glob.glob(os.path.join(folder, "*.fgb")))
-    healed = []
+    healed, removed = [], []
     for p in paths:
-        fixed = heal(p)
+        try:
+            fixed = heal(p)
+        except pyogrio.errors.DataSourceError:
+            # Not an FGB at all — a write truncated by a cancelled run. The artifact is
+            # unrecoverable; removing it makes snakemake rebuild the tile.
+            os.remove(p)
+            removed.append(os.path.basename(p))
+            print(f"removed unreadable {os.path.basename(p)} (rebuilt next run)", flush=True)
+            continue
         if fixed:
             healed.append(os.path.basename(p))
             print(f"healed {os.path.basename(p)}: {', '.join(fixed)} -> numeric", flush=True)
-    print(f"depare schema: {len(paths)} scanned, {len(healed)} healed"
-          + (f" ({', '.join(healed)})" if healed else ""), flush=True)
+    print(f"depare schema: {len(paths)} scanned, {len(healed)} healed, {len(removed)} removed"
+          + (f" ({', '.join(healed + removed)})" if healed or removed else ""), flush=True)
     return healed
 
 
@@ -151,6 +159,14 @@ def _check():
                       "sys": "m", "kind": None, "rank": depare_run.BAND_RANK}])
     assert needs_heal(good) == [], "a numeric tile must not be rewritten"
     assert run(d) == [], "a clean folder must heal nothing"
+
+    # A truncated write from a cancelled run is not an FGB at all: removed, others untouched
+    junk = f"{d}/4-0-14-8.fgb"
+    with open(junk, "wb") as f:
+        f.write(b"\x66\x67\x62\x00partial")
+    assert run(d) == [], "garbage must not report as healed"
+    assert not os.path.exists(junk), "an unreadable artifact must be removed"
+    assert os.path.exists(good), "readable neighbours must survive a removal pass"
     print("heal_depare_schema self-check ok")
 
 


### PR DESCRIPTION
Build 31943912836 failed in the new heal step itself: `store/depare/4-0-14-8.fgb` is a write truncated by the previous run's cancellation, and `pyogrio.read_info` raises on it — the heal handled poisoned schemas but not garbage bytes, so one unrecoverable file killed the run before Snakemake started.

An artifact that can't be opened has nothing to preserve: the heal now removes it (making Snakemake rebuild that tile) and keeps scanning, reporting removals separately from repairs. Self-check covers the truncated-file case alongside the schema cases: garbage is removed, readable neighbours survive, nothing reports as healed that wasn't.