### PR TITLE
Release @openwaters/seascape 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4134,7 +4134,7 @@
     },
     "style": {
       "name": "@openwaters/seascape",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^25.0.0"

--- a/style/package.json
+++ b/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openwaters/seascape",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "MapLibre GL style for Open Waters bathymetry tiles — depth shading, contours, soundings, depth areas",
   "license": "BSD-3-Clause",
   "type": "module",


### PR DESCRIPTION
Version bump for the npm style package: safety-contour color and emphasis, hillshade option, relief band alignment, style.json schema guard, and the applyState contour-paint fix since 0.2.1. Publish to npm from this commit once merged.