### PR TITLE
Fix blocky deep-water contours near steep coasts

### DIFF
--- a/pipelines/build.smk
+++ b/pipelines/build.smk
@@ -312,16 +312,13 @@ rule publish_mosaic:
 # ── mosaic, as a separate job rather than riding inside the merge                    ──
 
 # The one shared f(depth, zoom) — a knob change reruns stage 3 only, never a merge. Every dial
-# prepare_window applies must appear here, coarsening included: a dial missing from this hash
+# prepare_window applies must appear here: a dial missing from this hash
 # leaves the window artifact fresh, so a sweep silently re-measures the previous surface.
 SMOOTH_CFG = json.dumps({} if os.environ.get("SKIP_SMOOTH") else {
     "sigma": smooth.DEM_SIGMA, "sigma_deep": smooth.DEM_SIGMA_DEEP,
     "mask_sigma": smooth.MASK_SIGMA, "slope_low": smooth.SLOPE_LOW,
     "slope_high": smooth.SLOPE_HIGH, "depth_full": smooth.DEPTH_FULL,
     "depth_smooth": smooth.DEPTH_SMOOTH, "block": smooth.BLOCK,
-    "deep_coarsen_threshold_m": smooth.DEEP_COARSEN_THRESHOLD_M,
-    "deep_coarsen_factor": smooth.DEEP_COARSEN_FACTOR,
-    "deep_coarsen_min_child_z": smooth.DEEP_COARSEN_MIN_CHILD_Z,
     "pond_fill_mm2": smooth.POND_FILL_MM2,
     "pond_fill_extent_m": smooth.POND_FILL_EXTENT_M,
     "pond_fill_max_depth_m": smooth.POND_FILL_MAX_DEPTH_M,
@@ -377,7 +374,7 @@ def fork_inputs(wc):
 
 
 # The forks' shared read surface, built once per stem instead of three times: the buffered
-# window materialized, smoothed, and deep-coarsened. temp() — a z15 window is 4.3 GB and
+# window materialized, smoothed, and pond-filled. temp() — a z15 window is 4.3 GB and
 # only in-flight stems need theirs on disk. Consumers treat it as read-only.
 rule fork_window:
     input:

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -219,7 +219,7 @@ def _run_bounded(cmd, what, timeout):
 
 
 def _uniform_coarsen(dem, factor, out):
-    """Whole-window shoal-biased downsample — the retry rescue when even the deep-coarsened window
+    """Whole-window shoal-biased downsample — the retry rescue when even the smoothed window
     times out (shallow-complexity stems the depth gate can't help). gdal_contour reads the small
     raster directly; _depare_dem re-reads res per file, so the sliver gate adapts.
 

--- a/pipelines/smooth.py
+++ b/pipelines/smooth.py
@@ -44,18 +44,7 @@ DEPTH_SMOOTH = float(os.environ.get("SMOOTH_DEPTH_SMOOTH", "200")) # ≥ this de
 BLOCK = int(os.environ.get("SMOOTH_BLOCK", "2048"))          # window side (px); caps peak memory
 TRUNCATE = 4.0                                               # gaussian_filter default kernel cutoff (σ)
 
-# Deep-water DEM coarsening: below the threshold, band edges carry no navigational detail, but
-# source noise at fine child_z resolution makes gdal_contour's rings astronomically complex (the
-# deep-basin z14 stems burned 8.5 h+ of pure CPU; docs/plans/2026-07-21-depare-perf.md). Pixels
-# whose 8x-block mean is deeper than the threshold take that mean, so the deep interior contours at
-# ~8x resolution while everything shoaler keeps full detail. -250 m sits between ladder levels (m:
-# -200/-300; ft: -182.88/-365.76), so no level rides the transition. Both the depth-area bands and
-# the contour lines coarsen off this one surface so deep isobaths track the band edges. Only fine
-# windows (child_z >= 12) coarsen — coarse windows are already at or past 8x.
-DEEP_COARSEN_THRESHOLD_M = -250.0
-DEEP_COARSEN_FACTOR = 8
-DEEP_COARSEN_MIN_CHILD_Z = 12
-MERC_ORIGIN = 20037508.342789244  # EPSG:3857 half-extent; block grid anchors here (seam alignment)
+MERC_ORIGIN = 20037508.342789244  # EPSG:3857 half-extent
 
 # Enclosed sub-legible water is filled to the shoalest elevation around it. A marsh pond the chart
 # cannot draw at compilation scale holds an outline and no depth (interior Barataria water: 14
@@ -162,51 +151,6 @@ def smooth_merged(tmp_folder):
     """Smooth the merged DEM of one aggregation tile in place."""
     n = len(glob.glob(f"{tmp_folder}/*.tiff"))
     smooth_tiff(f"{tmp_folder}/{n - 1}-3857.tiff")
-
-
-def deep_coarsen(dem, threshold=DEEP_COARSEN_THRESHOLD_M, factor=DEEP_COARSEN_FACTOR):
-    """Rewrite `dem` in place with deep pixels replaced by their block mean. The block grid is
-    anchored to the EPSG:3857 origin, NOT the window, so overlapping windows (neighbor stems'
-    buffers) average identical blocks and band edges still match at macrotile seams. A pixel is
-    replaced only when it AND its block mean are below the threshold: shelf-edge blocks whose
-    mean dips deep keep their shallow pixels, and a deep canyon inside a shallow block stays
-    fine rather than taking a shallow mean. Nodata pixels are never touched (the nodata pass
-    reads this same raster), and nodata is excluded from block means."""
-    with rasterio.open(dem, "r+") as d:
-        nd = d.nodata
-        res = abs(d.transform.a)
-        h, w = d.height, d.width
-        # Global block alignment: pad to the origin-anchored grid (pads land in the buffer).
-        col0 = round((d.transform.c + MERC_ORIGIN) / res)
-        row0 = round((MERC_ORIGIN - d.transform.f) / res)
-        padt, padl = row0 % factor, col0 % factor
-        padr = (-(w + padl)) % factor
-        # Strip-streamed on block-row boundaries: a z15 window is 17 GB as one array, and
-        # blocks never straddle an aligned strip, so per-strip means equal the whole-array
-        # ones. Vertical edge pads repeat the strip's own edge row — the same rows the
-        # full-array pad used.
-        step = max(factor, (2048 // factor) * factor)
-        y = -padt
-        while y < h:
-            y0, y1 = max(0, y), min(h, y + step)
-            arr = d.read(1, window=Window(0, y0, w, y1 - y0))
-            spt = y0 - y                    # top pad only on the first (origin-cut) strip
-            spb = (-(arr.shape[0] + spt)) % factor
-            p = np.pad(arr, ((spt, spb), (padl, padr)), mode="edge")
-            valid = p != nd
-            ph, pw = p.shape
-            vals = np.where(valid, p, 0.0)
-            bsum = vals.reshape(ph // factor, factor, pw // factor, factor).sum(axis=(1, 3))
-            bcnt = valid.reshape(ph // factor, factor, pw // factor, factor).sum(axis=(1, 3))
-            del p, vals, valid
-            bmean = (bsum / np.maximum(bcnt, 1)).astype(np.float32)
-            bmean[bcnt == 0] = nd
-            up = np.repeat(np.repeat(bmean, factor, 0), factor, 1)[spt:spt + arr.shape[0],
-                                                                   padl:padl + w]
-            mask = (arr != nd) & (arr <= threshold) & (up != nd) & (up <= threshold)
-            arr[mask] = up[mask]
-            d.write(arr, 1, window=Window(0, y0, w, y1 - y0))
-            y += step
 
 
 def _pond_fill_array(arr, nd, max_area_px, max_diag_px, max_depth_m=POND_FILL_MAX_DEPTH_M):
@@ -339,40 +283,24 @@ def _check():
     with rasterio.open(i16) as src:
         assert src.read(1).std() < arr16.std(), "Int16 smoothing should denoise"
 
-    # deep_coarsen: shallow and nodata pixels preserved; deep pixels take their block mean;
-    # and the block grid is origin-anchored, so two windows offset against the block grid
-    # produce identical values where they overlap (the macrotile-seam contract).
     def _write_dem(path, arr, left, top, res_m):
         with rasterio.open(path, "w", driver="GTiff", width=arr.shape[1], height=arr.shape[0],
                            count=1, dtype="float32", nodata=-9999.0,
                            transform=from_origin(left, top, res_m, res_m)) as dst:
             dst.write(arr.astype(np.float32), 1)
 
-    f = DEEP_COARSEN_FACTOR
-    big = (-400.0 + rng.uniform(-40, 40, (8 * f, 8 * f))).astype(np.float32)  # noisy deep field
-    big[:f, :] = -10.0            # one shallow block-row: must stay untouched
-    big[f, 0] = -9999.0           # a nodata pixel inside a deep block: preserved + excluded
-    left0, top0 = -MERC_ORIGIN, MERC_ORIGIN  # window A: block-aligned at the origin
-    _write_dem(f"{d}/a.tiff", big, left0, top0, 10.0)
-    deep_coarsen(f"{d}/a.tiff", factor=f)
-    with rasterio.open(f"{d}/a.tiff") as src:
-        a = src.read(1)
-    assert np.array_equal(a[:f, :], big[:f, :]), "shallow pixels must be untouched"
-    assert a[f, 0] == -9999.0, "nodata must be preserved"
-    blk = big[f:2 * f, :f]
-    want = blk[blk != -9999.0].mean()
-    got = a[2 * f - 1, f - 1]  # a deep pixel of that block (away from the nodata cell)
-    assert abs(got - want) < 1e-3, f"deep block mean: {got} != {want}"
-    # Window B: the same field cropped at a NON-block-aligned offset (3 px right/down). Values
-    # in the overlap must match window A exactly — the origin-anchored grid, not the window,
-    # defines the blocks. Interior only: A's edge blocks average pad-replicated pixels.
-    off = 3
-    _write_dem(f"{d}/b.tiff", big[off:, off:], left0 + off * 10.0, top0 - off * 10.0, 10.0)
-    deep_coarsen(f"{d}/b.tiff", factor=f)
-    with rasterio.open(f"{d}/b.tiff") as src:
-        b = src.read(1)
-    assert np.array_equal(a[f:7 * f, f:7 * f], b[f - off:7 * f - off, f - off:7 * f - off]), \
-        "overlapping windows must coarsen identically (seam alignment)"
+    # Deep water carries the heavy blur and nothing else: it comes back smoothed but NOT
+    # quantized onto any lattice, so a deep field keeps a value per pixel rather than a value
+    # per block. Distinct neighbours in the deep are what a piecewise-constant surface loses.
+    deep = (-400.0 + rng.uniform(-40, 40, (128, 128))).astype(np.float32)
+    _write_dem(f"{d}/deep.tiff", deep, -MERC_ORIGIN, MERC_ORIGIN, 10.0)
+    smooth_tiff(f"{d}/deep.tiff", block=64)
+    with rasterio.open(f"{d}/deep.tiff") as src:
+        sm = src.read(1)
+    assert sm.std() < deep.std(), "the deep blur must denoise"
+    interior = sm[8:-8, 8:-8]
+    assert (interior[:, :-1] != interior[:, 1:]).mean() > 0.9, \
+        "deep pixels must stay per-pixel, not collapse onto blocks of equal value"
 
     # pond fill: an enclosed sub-legible pond takes its shoalest surrounding value, while the
     # channel, a thin long fragment, an over-area pond, a diagonal thread and a pond against
@@ -420,7 +348,7 @@ def _check():
 
 def prepare_window(stem, out_tif):
     """The forks' shared read surface: the stem's buffered window materialized once,
-    smoothed, deep-coarsened, and pond-filled. Consumers must treat it as read-only — contour and
+    smoothed and pond-filled. Consumers must treat it as read-only — contour and
     soundings clamp a private copy; depare reads it directly. Every generalization lives here so
     bands, contour lines and soundings stay coincident."""
     import mosaic
@@ -433,8 +361,6 @@ def prepare_window(stem, out_tif):
     with rasterio.env.Env(GDAL_CACHEMAX=256):
         if not os.environ.get("SKIP_SMOOTH"):
             smooth_tiff(tmp)
-        if child_z >= DEEP_COARSEN_MIN_CHILD_Z:
-            deep_coarsen(tmp)
         ponds = pond_fill(tmp, child_z)
     with open(tmp, "rb") as f:
         os.fsync(f.fileno())  # teardown is a power cut; a rename must not outlive its data

--- a/pipelines/test_consistency.py
+++ b/pipelines/test_consistency.py
@@ -17,7 +17,7 @@ plans above it (where the raster reads the pyramid and the vectors do not re-der
 
 What is asserted, and the bound each rests on:
 
-  1. ONE SURFACE. Over the navigable band the served raster and the forks' window are the same
+  1. ONE SURFACE. Over the water domain the served raster and the forks' window are the same
      array, up to the encode's quantization step: the raster never charts more than one step
      shallower than the vector surface, and never charts deeper than it at all — EXCEPT where
      smooth.pond_fill licensed the vectors to shoal (the enclosed pond), which is asserted to
@@ -271,7 +271,7 @@ def _klass(v):
 # ── the checks ─────────────────────────────────────────────────────────────────────────────────
 
 def check_one_surface(stem, native):
-    """1. The served raster and the forks' window are one surface over the navigable band.
+    """1. The served raster and the forks' window are one surface over the water domain.
 
     The fork window's interior is the anchor tile at res(child_z), the same grid the native render
     tiles it into, so this is a pixel-for-pixel comparison of the shipped product against the
@@ -297,7 +297,7 @@ def check_one_surface(stem, native):
 
     # Compare where both call it charted depth; the non-negative codes are property 2's job.
     band = (fork < 0) & (raster < 0)
-    assert band.sum() > CORE * CORE // 4, f"the navigable band must dominate the fixture: {band.sum()} px"
+    assert band.sum() > CORE * CORE // 4, f"the water domain must dominate the fixture: {band.sum()} px"
     step = np.minimum(encode.quantization_factor(CHILD_Z),
                       2.0 ** np.ceil(np.log2(np.maximum(np.abs(raster) * encode.SHALLOW_REL,
                                                         encode.SHALLOW_MIN_STEP))))

--- a/pipelines/test_consistency.py
+++ b/pipelines/test_consistency.py
@@ -5,7 +5,7 @@ asserts they still describe the same seabed:
 
   * raster shading   mosaic -> class-aware shoal pyramid (utils._block_reduce) -> read at the
                      target zoom -> smooth -> classify (terrain._encode_tile) -> Terrarium
-  * isobaths         mosaic -> fork window (smooth + deep_coarsen + pond_fill) -> land clamp ->
+  * isobaths         mosaic -> fork window (smooth + pond_fill) -> land clamp ->
                      gdal_contour -> Chaikin/simplify -> clip
   * depth areas      the same fork window -> gdal_contour -p -> coverage simplify -> land cut
 
@@ -79,8 +79,8 @@ import utils  # noqa: E402
 
 # ── the fixture ────────────────────────────────────────────────────────────────────────────────
 # One aggregation tile at child_z 14: 1024 px of core at res(14), which is small enough to run in
-# the test suite and deep enough that BOTH extra fork generalizations are live (deep_coarsen from
-# child_z 12, pond_fill from 14) — the divergences property 1 has to bound.
+# the test suite and deep enough that the extra fork generalization is live (pond_fill from
+# child_z 14) — the divergence property 1 has to bound.
 ANCHOR = mercantile.Tile(x=4100, y=4100, z=13)
 CHILD_Z = 14
 CORE = 1024
@@ -148,8 +148,7 @@ def _xy(row, col):
 def _dem():
     rng = np.random.default_rng(7)
     arr = np.full((CORE, CORE), BASIN, dtype="float32")
-    # Noise on the deep basin so deep_coarsen has something to average — without it the pass is a
-    # no-op and property 1's licensed-divergence branch never runs.
+    # Noise on the deep basin, so the deep blur has a gradient to work on rather than a flat field.
     arr[DEEP_BOX] = DEEP + rng.normal(0, 30, arr[DEEP_BOX].shape)
     row, col = np.indices(arr.shape)
     dr, dc = row - SHOAL_CENTRE[0], col - SHOAL_CENTRE[1]
@@ -297,7 +296,7 @@ def check_one_surface(stem, native):
                 native[(CHILD_Z, ANCHOR.x * span + i, ANCHOR.y * span + j)]
 
     # Compare where both call it charted depth; the non-negative codes are property 2's job.
-    band = (fork < 0) & (raster < 0) & (fork > smooth.DEEP_COARSEN_THRESHOLD_M)
+    band = (fork < 0) & (raster < 0)
     assert band.sum() > CORE * CORE // 4, f"the navigable band must dominate the fixture: {band.sum()} px"
     step = np.minimum(encode.quantization_factor(CHILD_Z),
                       2.0 ** np.ceil(np.log2(np.maximum(np.abs(raster) * encode.SHALLOW_REL,
@@ -322,14 +321,8 @@ def check_one_surface(stem, native):
         ("the fork surface leaves the water domain outside the pond fill: rows "
          f"{rows.min()}..{rows.max()}, cols {cols.min()}..{cols.max()}")
 
-    # deep_coarsen is the other licensed divergence; the two inequalities above already confine it
-    # to below the threshold, since `band` holds every pixel it is not allowed to touch.
-    deep_moved = (fork <= smooth.DEEP_COARSEN_THRESHOLD_M) & (fork < 0) & (raster < 0) & \
-                 (np.abs(raster - fork) > step + 1e-6)
-    assert deep_moved.any(), "the deep basin must actually exercise deep_coarsen"
-    print(f"  one-surface ok — {int(band.sum())} navigable px agree within one quantization step; "
-          f"{int(filled.sum())} px of pond fill and {int(deep_moved.sum())} px of deep coarsening "
-          "are the only divergences")
+    print(f"  one-surface ok — {int(band.sum())} water px agree within one quantization step; "
+          f"{int(filled.sum())} px of pond fill are the only divergence")
 
 
 def _sweep():
@@ -401,10 +394,6 @@ def check_bracketing(tiles, z, bands):
     Per LADDER: the metre and fathom sets are two independent partitions of the same water, so
     pooling them would widen every bracket to the union of two unrelated buckets.
 
-    Restricted to the navigable band. Below smooth.DEEP_COARSEN_THRESHOLD_M the vectors are cut
-    from 8x block means, which move in BOTH directions against the raster's un-coarsened value, so
-    no bracket exists there by design (measured 116 m on this fixture's noisy deep basin).
-
     The deeper-than-the-band bound is exact at every zoom — a coarse tile is clamped against the
     shoal reduction of the zoom below (property 3), and the native zoom brackets exactly, so the
     coarse value can be no deeper than a band under its own footprint. Only the shallower-than-
@@ -422,8 +411,8 @@ def check_bracketing(tiles, z, bands):
         for row, col in _sweep():
             x, y = _xy(row, col)
             v, footprint = _at(tiles, z, x, y)
-            if v >= 0 or v <= smooth.DEEP_COARSEN_THRESHOLD_M:
-                continue  # flat codes are property 2's job; the deep is coarsened out of scope
+            if v >= 0:
+                continue  # flat codes are property 2's job
             under = tree.query(box(*footprint))
             assert len(under), \
                 f"z{z} {sys_tag} row {row} col {col}: charted {v} m with no depare band beneath it"


### PR DESCRIPTION
Deep contours (below 250 m) render as pixelated staircases wherever they come close to shore — most visibly the Pacific islands, where the 300 m curve sits within 100 m of the beach (reported at Ta'ū, Manu'a). Measured on the published build: 7-pixel treads with 1-pixel risers locked to an absolute 8-pixel block lattice, at both 9.55 m and 4.78 m grids.

The cause is the deep-water block coarsening in `smooth.py`: depths below −250 m are replaced by 8×8 block means, making the surface piecewise-constant so contours can only trace block edges. It earned its place when `gdal_contour`'s polygon mode made deep noise rings ruinously expensive. Under the contour-p patch, an A/B benchmark on the defect stem (Samoa, cz13) and the covering's only majority-abyssal high-res stem (Gulf of Alaska, cz14) shows every justification inverted:

| | Samoa | Gulf of Alaska |
|---|---|---|
| wall with coarsening removed | **−5.4 s** | **−21.9 s** |
| coarsening pass cost vs contour saving | 5.8 s vs 0.4 s | 31.3 s vs 3.9 s |
| deep ring suppression | −46% parts | **zero** |
| shipped contour tile bytes with coarsening | **+6.1%** | **+13.3%** |

The tile-byte inversion is the decisive one: the lattice's right angles survive tippecanoe's simplification better than smooth curves, so the mechanism inflates the payload it existed to shrink. It also deepened pixels through the block mean — a bounded (below −250 m) violation of the charted-no-deeper-than-true rule. `SMOOTH_DEM_SIGMA_DEEP` remains as the deep denoiser.

Deletion is proven behavior-preserving against the benchmark: the branch's smooth output for the Samoa stem is byte-identical to the measured no-coarsening arm. The consistency self-check comes out stronger — the fork/raster comparison now covers all water instead of excluding the deep basin, and agrees within one quantization step.

> [!IMPORTANT]
> Removing the `SMOOTH_CFG` keys invalidates every fork window — stage 3 re-runs planet-wide. Merge alongside the next scheduled re-render, not on its own.