### PR TITLE
Keep dependencies up to date automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        update-types: [minor, patch]
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        update-types: [minor, patch]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directories: ["/", "/.github/actions/*"]
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types: [minor, patch]


### PR DESCRIPTION
Dependabot now watches the four things in this repo that have a manifest: the npm workspace root (which covers `style/` and `worker/`), `pyproject.toml` + `uv.lock`, the GDAL toolchain image in the Dockerfile, and the workflows plus the `ghcr-login` composite action. Everything checks weekly.

Minor and patch updates group into a single PR per ecosystem. Majors come through one at a time.

## Why grouping

CI cost, mostly. `ghcr-login` keys the toolchain image on `hashFiles('Dockerfile', 'pyproject.toml', 'uv.lock')`, and `ci.yml` runs on every push with no path filter. So every Python dependency bump changes `uv.lock`, misses the GHCR tag, and rebuilds `gdal:ubuntu-full` from scratch. Merge one of ten open bumps and the other nine rebase and rebuild again.

Majors stay individual because those are the ones that break things — a `rasterio` or `shapely` major can shift geospatial output quietly, and a lone PR keeps the attribution when `just test` goes red.

Docker is ungrouped either way. One image, and a GDAL bump is a toolchain change worth reading by itself.

## What to expect first

Action versions have drifted, so the opening actions PR will be a large one. `actions/checkout` is on both v6 and v7, `upload-artifact` on v4 and v7, `setup-buildx-action` on v3 and v4.

- [ ] Merge and confirm the first batch of PRs looks sane
- [ ] Revisit grouping if the weekly PRs turn out noisier or quieter than expected