### PR TITLE
Fix the three depth-area stems the planet build lost

### DIFF
--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -665,19 +665,28 @@ class _RowSink:
             # Everything reaching here is valid in 4326, so a throw is GEOS declining an
             # arrangement outright — run 31984351438: "unable to assign free hole to a shell" on
             # one Cornwall row. The vectorized call names no row, so re-run one at a time and
-            # take the declined rows through a pointwise snap + linework repair. The validity
-            # assert and the per-row snap budget below still gate the result, so the fallback can
-            # only ship what the contract allows; its one concession is that repair noding can
-            # add off-grid vertices for the driver to round — the pre-snap-era residual, bounded
-            # to these rows.
+            # take the declined rows through a pointwise snap + linework repair, iterated to a
+            # fixed point ON the write grid: repair noding adds off-grid vertices, and shipping
+            # those would leave the driver's rounding as the last, unvalidated operation. The
+            # validity assert and the per-row snap budget below still gate the result; a row
+            # that will not close still kills the tile, named.
             snapped = raw.copy()
             rescued = 0
             for i, g in enumerate(raw):
                 try:
                     snapped[i] = shapely.set_precision(g, self.GRID, mode="valid_output")
                 except shapely.errors.GEOSException:
-                    snapped[i] = _polygonal(shapely.make_valid(
-                        shapely.set_precision(g, self.GRID, mode="pointwise")))
+                    cur = shapely.set_precision(g, self.GRID, mode="pointwise")
+                    for _ in range(4):
+                        cur = shapely.set_precision(_polygonal(shapely.make_valid(cur)),
+                                                    self.GRID, mode="pointwise")
+                        if shapely.is_valid(cur):
+                            break
+                    else:
+                        raise AssertionError(
+                            f"snapping row {i} of {len(raw)} to the write grid failed to "
+                            f"converge; specimen: {shapely.to_wkt(g, rounding_precision=9)}")
+                    snapped[i] = cur
                     rescued += 1
             print(f"depare: pointwise-snapped {rescued} row(s) valid_output declined", flush=True)
         gdf = gdf.set_geometry(gpd.GeoSeries(snapped, index=gdf.index, crs="EPSG:4326"))
@@ -687,14 +696,15 @@ class _RowSink:
         # measured at 3e-6 m2 — which the previous repair also dropped.
         gdf = gdf.explode(index_parts=False)
         gdf = gdf[(gdf.geom_type == "Polygon") & ~gdf.is_empty]
-        # The two things the write owes: valid geometry, and no real part deleted. A row narrower
-        # than a cell may vanish — its whole area is under its own budget, which is the crumb case
-        # — while a row wide enough to draw cannot.
+        # The two things the write owes: valid geometry, and no real area moved — in EITHER
+        # direction, since a fallback repair that conjured area into a neighbouring band would
+        # pass a loss-only gate. A row narrower than a cell may vanish — its whole area is under
+        # its own budget, which is the crumb case — while a row wide enough to draw cannot.
         assert bool(shapely.is_valid(gdf.geometry.to_numpy()).all()), \
             "set_precision must return valid geometry (mode=valid_output)"
         after = (pd.Series(shapely.area(gdf.geometry.to_numpy()), index=gdf.index)
                  .groupby(level=0).sum().reindex(range(len(raw)), fill_value=0.0).to_numpy())
-        gone = np.flatnonzero(before - after > budget)
+        gone = np.flatnonzero(np.abs(before - after) > budget)
         if len(gone):
             i = gone[0]
             raise AssertionError(
@@ -1297,6 +1307,11 @@ def _check():
         "the pointwise fallback must write valid rows"
     assert abs(shapely.area(_got.geometry.values).sum() - _want) <= _snap_budget, \
         "the pointwise fallback must conserve the row's area"
+    # ...and land every vertex ON the write grid: the gates validate pre-driver geometry, so an
+    # off-grid repair vertex would make the driver's rounding the last, unvalidated operation.
+    _coords = shapely.get_coordinates(_got.geometry.values)
+    assert (_coords == np.round(_coords, _RowSink.COORD_DECIMALS)).all(), \
+        "the pointwise fallback must land every vertex on the write grid"
 
     # The repair gate's arithmetic, pinned against the planet census (run 31944844978, 71 rows)
     # that the same two-term shape passed at 719739e: the worst OBSERVED repair jitter must not
@@ -1351,6 +1366,29 @@ def _check():
     # real distinction rather than one any budget would catch.
     _lost = gpd.GeoSeries([_doomed], crs=3857).to_crs(4326).area[0]
     assert _lost < 1e-9, f"the doomed row must fit inside a batch-scale budget, got {_lost!r}"
+
+    # The budget is TWO-sided: a snap (or fallback repair) that conjures area past the budget is
+    # a band inflated into its neighbour, and a loss-only gate would wave it through.
+    def _grow_the_second(geoms, grid, **kw):
+        out = list(_real_set_precision(geoms, grid, **kw))
+        _b = shapely.bounds(out[1])
+        out[1] = shapely.box(_b[0] - 1e-3, _b[1] - 1e-3, _b[2] + 1e-3, _b[3] + 1e-3)
+        return np.array(out, dtype=object)
+
+    shapely.set_precision = _grow_the_second
+    _raised = ""
+    try:
+        _d = tempfile.mkdtemp()
+        _sink = _RowSink(f"{_d}/rows.geojsons")
+        _sink.write([{"geometry": g, "drval1": -config.DRYING_CAP, "drval2": 0.0,
+                      "sys": None, "kind": None, "rank": DRYING_RANK}
+                     for g in (_keep, _doomed)])
+    except AssertionError as e:
+        _raised = str(e)
+    finally:
+        shapely.set_precision = _real_set_precision
+    assert "snapped row 1" in _raised and "snap budget" in _raised, \
+        f"a row the write grows past its budget must fail, got {_raised!r}"
 
     # The snap must not break the partition. Snap-rounding is topological, not pointwise, so it
     # MAY node a chain it shares with a neighbour — and two bands that stop sharing their boundary

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -534,9 +534,10 @@ def read_bucket(raw_fgb, where):
 
 
 def _polygonal(geom):
-    """The polygonal content of a linework make_valid result: the repaired area can arrive as a
-    GeometryCollection carrying line fragments, whose MultiPolygon member one explode leaves
-    nested for the Polygon-type filter to delete — merge the areal parts instead."""
+    """The polygonal content of a linework make_valid result. The repair can return a
+    GeometryCollection mixing polygons with line fragments; downstream, explode() unwraps only
+    one level, so a MultiPolygon nested inside the collection would survive as a MultiPolygon
+    row and be deleted by the Polygon-type filter. Merging the areal parts here keeps them."""
     import shapely
     if geom.geom_type != "GeometryCollection":
         return geom
@@ -1280,8 +1281,12 @@ def _check():
     finally:
         shapely.make_valid = _real_mv
     _got = gpd.read_file(f"{_d}/out.fgb")
-    _want_l = shapely.area(_polygonal(_real_mv(_folded4326)))
-    assert len(_got) and abs(shapely.area(_got.geometry.values).sum() - _want_l) <= _snap_budget, \
+    # This path's pre-snap geometry is the LINEWORK repair, so its budget comes from that
+    # ring's own perimeter, not the structure repair's.
+    _repaired_l = _polygonal(_real_mv(_folded4326))
+    _budget_l = shapely.length(_repaired_l) * _RowSink.SNAP_MAX_SHIFT
+    assert len(_got) and abs(shapely.area(_got.geometry.values).sum()
+                             - shapely.area(_repaired_l)) <= _budget_l, \
         "the linework fallback must conserve the area the structure repair ate"
 
     # A row valid_output declines outright (GEOS's free-hole-to-shell refusal, run 31984351438)

--- a/pipelines/depare_run.py
+++ b/pipelines/depare_run.py
@@ -533,6 +533,17 @@ def read_bucket(raw_fgb, where):
     return g
 
 
+def _polygonal(geom):
+    """The polygonal content of a linework make_valid result: the repaired area can arrive as a
+    GeometryCollection carrying line fragments, whose MultiPolygon member one explode leaves
+    nested for the Polygon-type filter to delete — merge the areal parts instead."""
+    import shapely
+    if geom.geom_type != "GeometryCollection":
+        return geom
+    parts = [g for g in geom.geoms if g.geom_type in ("Polygon", "MultiPolygon")]
+    return shapely.union_all(parts) if parts else shapely.Polygon()
+
+
 class _RowSink:
     """Incremental depare-row writer: batches of {geometry (3857), drval1, drval2, sys, kind,
     rank} append to a GeoJSONSeq in 4326; finish() converts to the final FGB. Absent values are
@@ -616,13 +627,29 @@ class _RowSink:
             # What it may not do is eat the ring. Both terms must trip, because either alone is
             # wrong at some scale — see the constants.
             loss = pre - post
-            eaten = np.flatnonzero((loss > self.REPAIR_FATAL_LOSS_DEG2)
-                                   & (loss > pre * self.REPAIR_FATAL_LOSS_REL))
-            if len(eaten):
-                i = eaten[0]
-                raise AssertionError(
-                    f"repairing row {folded[i]} of {len(folded)} folded row(s) lost polygonal "
-                    f"area: {pre[i]!r} -> {post[i]!r} deg^2")
+            eaten = (loss > self.REPAIR_FATAL_LOSS_DEG2) & (loss > pre * self.REPAIR_FATAL_LOSS_REL)
+            if eaten.any():
+                # The structure repair reads some planet-scale folds as (near) nothing — run
+                # 31984351438 lost three stems to ~1e-7 deg^2 rows repaired to 0. linework builds
+                # area from every enclosed region instead of from ring winding, so retry just the
+                # eaten rows with it, under the same gate: the fallback ships only when it
+                # conserves the area, and a row both repairs lose still kills the tile — now
+                # naming its specimen so the failure is diagnosable from the log alone.
+                redo = folded[eaten]
+                raw[redo] = np.array([_polygonal(g) for g in
+                                      shapely.make_valid(gdf.geometry.values[redo])], dtype=object)
+                post2 = shapely.area(raw[redo])
+                loss2 = pre[eaten] - post2
+                still = np.flatnonzero((loss2 > self.REPAIR_FATAL_LOSS_DEG2)
+                                       & (loss2 > pre[eaten] * self.REPAIR_FATAL_LOSS_REL))
+                if len(still):
+                    i = still[0]
+                    raise AssertionError(
+                        f"repairing row {redo[i]} of {len(folded)} folded row(s) lost polygonal "
+                        f"area: {pre[eaten][i]!r} -> {post2[i]!r} deg^2; specimen: "
+                        f"{shapely.to_wkt(gdf.geometry.values[redo[i]], rounding_precision=9)}")
+                print(f"depare: linework repaired {len(redo)} row(s) the structure repair ate",
+                      flush=True)
         # Areas and budgets come off the POST-repair geometry: it is what gets snapped, so it is
         # what the snap bound has to describe.
         before = shapely.area(raw)
@@ -634,19 +661,25 @@ class _RowSink:
         budget = shapely.length(raw) * self.SNAP_MAX_SHIFT
         try:
             snapped = shapely.set_precision(raw, self.GRID, mode="valid_output")
-        except shapely.errors.GEOSException as e:
-            # Everything reaching here is valid in 4326, so a throw is GEOS declining a case the
-            # repair above did not cover — not something the caller can be told to fix upstream.
-            # The vectorized call names no row, so re-run one at a time to point at the offender:
-            # a batch-level message on a 50k-row flush is not a lead to follow.
+        except shapely.errors.GEOSException:
+            # Everything reaching here is valid in 4326, so a throw is GEOS declining an
+            # arrangement outright — run 31984351438: "unable to assign free hole to a shell" on
+            # one Cornwall row. The vectorized call names no row, so re-run one at a time and
+            # take the declined rows through a pointwise snap + linework repair. The validity
+            # assert and the per-row snap budget below still gate the result, so the fallback can
+            # only ship what the contract allows; its one concession is that repair noding can
+            # add off-grid vertices for the driver to round — the pre-snap-era residual, bounded
+            # to these rows.
+            snapped = raw.copy()
+            rescued = 0
             for i, g in enumerate(raw):
                 try:
-                    shapely.set_precision(g, self.GRID, mode="valid_output")
-                except shapely.errors.GEOSException as row_e:
-                    raise AssertionError(
-                        f"snapping row {i} of {len(raw)} to the write grid failed, bounds "
-                        f"{[round(float(v), 6) for v in shapely.bounds(g)]}: {row_e}") from row_e
-            raise AssertionError(f"snapping to the write grid failed: {e}") from e
+                    snapped[i] = shapely.set_precision(g, self.GRID, mode="valid_output")
+                except shapely.errors.GEOSException:
+                    snapped[i] = _polygonal(shapely.make_valid(
+                        shapely.set_precision(g, self.GRID, mode="pointwise")))
+                    rescued += 1
+            print(f"depare: pointwise-snapped {rescued} row(s) valid_output declined", flush=True)
         gdf = gdf.set_geometry(gpd.GeoSeries(snapped, index=gdf.index, crs="EPSG:4326"))
         # Snapping a fold apart splits it into lobes, so a row can come back MultiPolygon; explode
         # keeps the layer uniformly polygon (FlatGeobuf rejects a mixed one). A row thinner than
@@ -1215,6 +1248,55 @@ def _check():
         shapely.make_valid = _real_mv
     assert "lost polygonal area" in _raised, \
         f"a repair that eats a folded ring must fail the write, got {_raised!r}"
+    assert "specimen: " in _raised and "POLYGON" in _raised, \
+        f"a row both repairs lose must name its specimen WKT, got {_raised[:120]!r}"
+
+    # ...but a fold only the STRUCTURE repair eats must fall back to linework rather than kill
+    # the tile (run 31984351438: three stems, ~1e-7 deg^2 rows repaired to 0). Same fixture, with
+    # only the structure-mode repair stubbed; the gate stays the arbiter, so the fallback ships
+    # because it conserves the area.
+    def _structure_eats(geoms, method=None, **kw):
+        if method == "structure":
+            return np.array([Polygon() for _ in np.atleast_1d(geoms)], dtype=object)
+        return _real_mv(geoms, **kw)
+
+    shapely.make_valid = _structure_eats
+    try:
+        _d = tempfile.mkdtemp()
+        _sink = _RowSink(f"{_d}/rows.geojsons")
+        _sink.write([{"geometry": _folder, "drval1": -config.DRYING_CAP, "drval2": 0.0,
+                      "sys": None, "kind": None, "rank": DRYING_RANK}])
+        _sink.finish(f"{_d}/out.fgb")
+    finally:
+        shapely.make_valid = _real_mv
+    _got = gpd.read_file(f"{_d}/out.fgb")
+    _want_l = shapely.area(_polygonal(_real_mv(_folded4326)))
+    assert len(_got) and abs(shapely.area(_got.geometry.values).sum() - _want_l) <= _snap_budget, \
+        "the linework fallback must conserve the area the structure repair ate"
+
+    # A row valid_output declines outright (GEOS's free-hole-to-shell refusal, run 31984351438)
+    # must take the pointwise-snap + repair fallback and still land valid, whole, and on budget —
+    # every valid_output call refused, so the whole batch rides the fallback.
+    def _refuse_valid_output(geoms, grid, mode="valid_output", **kw):
+        if mode == "valid_output":
+            raise shapely.errors.GEOSException("unable to assign free hole to a shell")
+        return _real_set_precision(geoms, grid, mode=mode, **kw)
+
+    _real_set_precision = shapely.set_precision
+    shapely.set_precision = _refuse_valid_output
+    try:
+        _d = tempfile.mkdtemp()
+        _sink = _RowSink(f"{_d}/rows.geojsons")
+        _sink.write([{"geometry": _folder, "drval1": -config.DRYING_CAP, "drval2": 0.0,
+                      "sys": None, "kind": None, "rank": DRYING_RANK}])
+        _sink.finish(f"{_d}/out.fgb")
+    finally:
+        shapely.set_precision = _real_set_precision
+    _got = gpd.read_file(f"{_d}/out.fgb")
+    assert len(_got) and bool(shapely.is_valid(_got.geometry.values).all()), \
+        "the pointwise fallback must write valid rows"
+    assert abs(shapely.area(_got.geometry.values).sum() - _want) <= _snap_budget, \
+        "the pointwise fallback must conserve the row's area"
 
     # The repair gate's arithmetic, pinned against the planet census (run 31944844978, 71 rows)
     # that the same two-term shape passed at 719739e: the worst OBSERVED repair jitter must not


### PR DESCRIPTION
[Run 31984351438](https://github.com/openwatersio/seascape/actions/runs/31984351438) failed on three depare stems, all inside the write's own guards and all on geometry the measured corpus never held:

- `8-73-98-14` and `8-73-97-14` (Chesapeake marsh): the repair-loss gate. `make_valid(method="structure")` repaired a reprojection-folded row to (near) nothing, 1.1e-7 deg^2 to 0 on one stem and 1.7e-7 to 5e-29 on the other. Structure mode assigns area by ring winding, and that residue is the tell: the fold left the major lobe wound backwards, so the repair kept only the microscopic opposite lobe.
- `8-124-86-15` (Cornwall): `set_precision(mode="valid_output")` threw "unable to assign free hole to a shell" on a row that is valid in 4326. GEOS declines the arrangement outright, so the guard raised.

The fix widens the repair repertoire without weakening the contract:

- Rows the structure repair eats retry with linework `make_valid`, which builds area from every enclosed region regardless of winding. The retry runs under the same two-term conservation gate, so it ships only when it conserves the row.
- Rows `valid_output` declines snap pointwise and repair, iterated to a fixed point on the write grid so the driver's rounding stays a no-op. The batch validity assert and the per-row snap budget (now two-sided: conjured area fails like lost area) still gate the result, and a row that will not converge kills the tile, named.
- A row every path loses still kills the tile, and the failure message now carries the row's specimen WKT so the next such failure is diagnosable from the log alone instead of needing the box.

Both fallbacks are pinned by fixtures in `depare_run.py check` in the same monkeypatch style as the existing sink tests: structure-mode repair stubbed to eat the ring must recover through linework with area conserved; every `valid_output` call stubbed to refuse must land the row valid, whole, and on budget; and a row both repairs lose must fail naming its specimen.

No version bump. Stems the failed run wrote are byte-identical under this change (rows that never folded or threw take unchanged paths), and the three failed stems have no output, so they rerun on their own on the next dispatch.

_Updated after an adversarial review in commit aadeb21: the snap budget gate is now two-sided (a fallback repair that conjured area past the budget previously passed a loss-only check), and the pointwise fallback iterates to a fixed point on the write grid so the driver's rounding is never the last unvalidated operation. Both are pinned by fixtures._

