### PR TITLE
Abort fast when the build box's disk can't hold the run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,6 +476,11 @@ jobs:
           # device: /actions-runner/_diag"), so the step never even reports a conclusion. A ccx63
           # ships a 960 G root, a ccx33 240 G — a wide plan on the small box exhausted it in 52
           # minutes (run 32024721698, ~8.8k of 22,181 jobs left). Abort in seconds instead.
+          # Re-measure first: the scope gate's dry run executes inside the container and can
+          # leave overlay writes behind, so the floor — and the main run's disk budget — must
+          # describe what is free NOW, not before the gate ran.
+          avail_mb=$(df -BM --output=avail / | tail -1 | tr -dc '0-9')
+          disk_budget_mb=$(( (avail_mb - 20480) * 8 / 10 ))
           # Width from the scope gate when the dispatcher stated one; an unstated scope is
           # treated as wide, because that is what a planet dispatch looks like. A bbox run is
           # narrow by construction (a window, not the planet), so it keeps the loose floor —

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,8 +358,13 @@ jobs:
           # not headroom: the mem_gb budget stays sized to physical RAM, and reservations sit
           # ~10% over measured max, so this only turns a rare over-peak from an arbitrary
           # OOM kill into a brief spill. swappiness=10 keeps the working set in RAM.
+          # Sized to the box — an eighth of the root disk, capped at 64 G: the same root disk
+          # holds the docker image, TMP scratch and the logs, so a flat big-box swapfile spends
+          # a small box's scratch space on spill it will never use (ccx63 -> 64 G, ccx33 -> 30 G).
           if [ ! -e /swapfile ]; then
-            fallocate -l 64G /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=65536
+            root_mb=$(df -BM --output=size / | tail -1 | tr -dc '0-9')
+            swap_mb=$(( root_mb / 8 )); [ "$swap_mb" -le 65536 ] || swap_mb=65536
+            fallocate -l "${swap_mb}M" /swapfile || dd if=/dev/zero of=/swapfile bs=1M count="$swap_mb"
             chmod 600 /swapfile
             mkswap /swapfile
             swapon /swapfile
@@ -460,6 +465,24 @@ jobs:
               exit 1
             fi
             echo "scope gate ok: $total planned jobs <= max_jobs=$INPUT_MAX_JOBS"
+          fi
+          # Root-disk floor: disk_mb above admits only DECLARED job tmp — swap, the docker image
+          # and its overlay writes, the run logs and any under-declared scratch sit outside that
+          # budget on the same root disk, and when it fills the RUNNER dies ("No space left on
+          # device: /actions-runner/_diag"), so the step never even reports a conclusion. A ccx63
+          # ships a 960 G root, a ccx33 240 G — a wide plan on the small box exhausted it in 52
+          # minutes (run 32024721698, ~8.8k of 22,181 jobs left). Abort in seconds instead.
+          # Width from the scope gate when the dispatcher stated one; an unstated scope is
+          # treated as wide, because that is what a planet dispatch looks like. A bbox run is
+          # narrow by construction (a window, not the planet), so it keeps the loose floor —
+          # bbox smokes are ccx33's documented use and must not demand the big box.
+          floor_mb=$(( 80 * 1024 ))
+          if [ -z "$BBOX" ] && { [ -z "$INPUT_MAX_JOBS" ] || [ "${total:-0}" -gt 2000 ]; }; then
+            floor_mb=$(( 300 * 1024 ))
+          fi
+          if [ "$avail_mb" -lt "$floor_mb" ]; then
+            echo "only $((avail_mb / 1024)) G free on the root disk, under the $((floor_mb / 1024)) G this plan needs for scratch, logs and image layers — re-dispatch with server_type=ccx63, or state a narrow scope with max_jobs if this really is a small run" >&2
+            exit 1
           fi
           # No --prioritize: it flattens the index's whole merge chain to one priority, which
           # lets the scheduler pack small merges ahead of the heavy ones. build.smk's explicit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -533,7 +533,10 @@ jobs:
             cancelled) state="error"; desc="cancelled before publishing $suffix" ;;
             *) state="failure"; desc="failed before publishing $suffix" ;;
           esac
-          curl -fsS -X POST -H "Authorization: Bearer $GH_TOKEN" \
+          # --retry over transient API errors: this step is pure bookkeeping, and a single 503
+          # here painted an entirely successful 721-job build as a failed run (run 32030835194).
+          curl -fsS --retry 5 --retry-all-errors --max-time 120 -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
             -d "{\"state\":\"$state\",\"context\":\"build\",\"description\":\"$desc\",\"target_url\":\"$url\"}" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,8 +448,12 @@ jobs:
           # dry-run — before any box-scale execution.
           case "$INPUT_MAX_JOBS" in *[!0-9]*) echo "invalid max_jobs" >&2; exit 1 ;; esac
           if [ -n "$INPUT_MAX_JOBS" ]; then
+            # --rerun-incomplete mirrors the main invocation: a hard box death leaves incomplete
+            # marks on the volume, and a dry run WITHOUT the flag refuses to plan at all
+            # (IncompleteFilesException, run 32030051338) — the gate must survive exactly the
+            # crash it is most needed after.
             ./docker.sh snakemake "${targets[@]}" "${extra[@]}" "${force[@]}" \
-              -n \
+              -n --rerun-incomplete \
               --cores "$cores" --resources mem_gb="$budget_gb" disk_mb="$disk_budget_mb" \
               --config workdir=/app/state tmp=/app/tmp > /var/tmp/scope-gate.txt 2>&1 \
               || { tail -50 /var/tmp/scope-gate.txt >&2; echo "scope-gate dry-run failed" >&2; exit 1; }


### PR DESCRIPTION
Two dispatches died this weekend to box-sizing failures the workflow could have caught in seconds:

- [Run 32024721698](https://github.com/openwatersio/seascape/actions/runs/32024721698) went out on the default `server_type: ccx33` (240 GB root disk) with ~8,800 planet jobs remaining. Swap, the docker image, merge scratch, and logs are all sized against the ccx63's 960 GB; the root disk filled in 52 minutes and the runner itself died mid-write (`No space left on device: /actions-runner/_diag/...`), so the build step never even reported a conclusion.
- [Run 32030051338](https://github.com/openwatersio/seascape/actions/runs/32030051338), the ccx63 retry, died in the scope gate: the hard SIGKILL above left `vector-shallow.pmtiles` marked incomplete, the main invocation reruns incomplete outputs, but the dry run carried no `--rerun-incomplete` and refused to plan at all (`IncompleteFilesException`).

Four changes: one per observed failure mode, plus the shared sizing root, plus a bookkeeping fix from the successful rerun ([run 32030835194](https://github.com/openwatersio/seascape/actions/runs/32030835194)) whose one-shot status curl let a GitHub 503 paint a fully successful 721-job build as a failed run.

## Swapfile scaled to the box

An eighth of the root disk, capped at 64 G. The ccx63 keeps its proven 64 G; a ccx33 gets 30 G instead of spending a quarter of its disk on spill its 32 GB of RAM will rarely reach.

## Root-disk floor

The `disk_mb` budget admits only declared job tmp; swap, image layers, run logs, and under-declared scratch sit outside it on the same disk. After the scope gate and before the main invocation, the step now requires 300 G free for wide plans (>2000 planned jobs, or an unstated scope, which is what a planet dispatch looks like) and 80 G for narrow ones. Bbox runs are narrow by construction and keep the loose floor, so ccx33's documented uses (bbox smokes, stated-scope incremental builds) stay open. The abort message names both remedies: `server_type=ccx63`, or stating a narrow scope with `max_jobs`.

On the incident's numbers: ccx33 had ~190 G usable after swap and image, and the wide run consumed all of it, so the 300 G floor rejects that dispatch in seconds. The ccx63 clears it roughly 3x over.

## Scope gate plans across incomplete marks

`--rerun-incomplete` mirrored into the dry run, so a crash-recovery dispatch is planned (with the incomplete outputs as jobs) instead of dying in the gate that exists to protect it.

## Status POST retries

The "Publish build status" close is pure bookkeeping; its curl now retries transient API errors (`--retry 5 --retry-all-errors`) instead of failing the job over a blip.

Validated with actionlint (shellcheck-backed) and the two new shell blocks simulated standalone across ccx63/ccx33 with wide, gated-narrow, and bbox plans.
