### PR TITLE
Bring soundings in line with chart standards

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -152,4 +152,5 @@ test-perf:
     uv run python perf/fixtures.py --check
     uv run python perf/metrics.py --check
     uv run python perf/bench.py --check
+    uv run python perf/soundings.py --check
     uv run python perf/gates.py --check

--- a/docs/plans/2026-08-17-soundings-chart-conformance.md
+++ b/docs/plans/2026-08-17-soundings-chart-conformance.md
@@ -1,0 +1,236 @@
+# Soundings chart conformance — planning doc
+
+_Written 2026-08-17. Point-in-time; the code is the source of truth._
+
+Status: in progress — Phases 1-3 implemented, awaiting a soundings rebuild; Phases 4-5 open.
+
+## Problem
+
+An audit of the sounding pipeline and style against S-4, S-52 and the S-57 encoding guide found eleven divergences. Datum correction and data-quality attribution are tracked elsewhere. The remaining nine are here.
+
+The findings, numbered as the phases below cite them:
+
+| # | Finding | Status |
+|---|---|---|
+| 1 | Decimetre labels printed from sources not on chart datum (MSL-referenced UK/NZ/NL/AU sources) | Out of scope — datum workstream |
+| 2 | No data-quality attribution: GEBCO-derived and 0.25 m multibeam soundings render identically (`M_QUAL` is mandatory, S-57 UOC §2.2.3) | Out of scope — quality workstream |
+| 3 | 1.0 m floor deleted the least depths S-4 B-410b ranks highest | Fixed — 0.2 m, from the measured waterline-noise knee |
+| 4 | Only the shoalest pixel per cell is emitted, so a channel's deep line can never appear (B-410b also wants maximum depths; B-403.1a "the full range of depth") | Open |
+| 5 | Metre precision bands cut at 6 m; S-4 B-412 says decimetres to 21 m, half-metres to 31 m | Fixed |
+| 6 | Whole fathoms everywhere; charts print fathoms-and-feet below 11 fathoms | Fixed — derived from `depth_ft` in the style |
+| 7 | No drying heights (S-4 B-413: shown as soundings, rounded up, underlined) | Blocked on finding 1 |
+| 8 | Sounding density is uniform per cell — responds to depth (thin tiers) but not to seabed roughness (S-4 B-410d wants both) | Open |
+| 9 | Nothing verified S-4 B-410a's "final test of depth selection" (interpolation from the charted field) | Fixed — standing gate in `perf/soundings.py` |
+| 10 | Zoom thinning graded by a sounding's own depth, not its significance (S-57 UOC table 2.5 grades SCAMIN by significance, 1→4 steps) | Largely answered — prime retention + ring-tied display; full grading only if the B-410a residual demands it |
+| 11 | All soundings set upright — the posture S-4 B-412.4 reserves for *unreliable* soundings; B-412.1 wants sloping numerals | Fixed — Noto Sans Italic, self-hosted |
+
+Two are already fixed on this branch and are waiting on a rebuild to take effect:
+
+- Soundings were placed on a jittered lattice node rather than on the pixel their depth came from, so a quarter of them in a sampled New York view sat on land, displaced by up to a cell (~400 m measured). `_shoalest_grid` now carries the winning pixel's column/row, `_reduce_shoalest` carries it up each pyramid level, and `_pyramid` places the point there.
+- Label typography: flat 18 px (S-52 §5.2.1(2) sizes a sounding digit at ~3.5 mm; §3.1.5 forbids shrinking text when zooming out) and a 0.6 decimetre subscript.
+
+## Goals / Non-goals
+
+Goal: bring the emitted sounding field and its labels in line with the cited standards, at a rebuild cost proportional to the correctness gained.
+
+Non-goals: vertical datum correction and CATZOC/`M_QUAL` attribution (tracked separately); ENC conformance as a claim — this is a derived product built from a DEM, and the standards library is explicit that a synthetic field is _background_ sounding selection, not chart-authentic prime selection.
+
+## What drives the phasing
+
+A soundings rebuild is the expensive unit, so phases are cut to minimize how many are needed, and every change that requires one is batched into the same rebuild. The true-position fix already forces one, so the cheap correctness fixes ride along with it rather than costing a second.
+
+Measurement comes before redesign. S-4 §B-410a supplies a testable acceptance criterion, so the harness that checks it is built first and the results scope the redesign, rather than rebuilding an algorithm on a guess.
+
+`pipelines/perf/` already has the shape this needs: `bench.py` for staged runs against fixture stems, `gates.py` for hard pass/fail assertions on a generalization change, `metrics.py` for the measurements. New checks land there.
+
+## Phase 1 — measurement harness
+
+No rebuild. Runs locally on perf fixtures.
+
+S-4 §B-410a gives the acceptance test directly:
+
+> "The final test of depth selection is that no source material should contain depths shoaler than the mariner would expect by interpolating the depth in any position from the charted soundings and depth contours."
+
+Implementing that test is far cheaper than implementing the triangular selection method it validates, and it tells us which of the Phase 3 items actually need work.
+
+1. **Interpolation gate** in `perf/gates.py`: given a stem's DEM window, its emitted soundings and its contours, interpolate expected depth across the cell and report every source pixel shoaler than that expectation, by magnitude. This is the finding-9 test.
+2. **Waterline-noise measurement** for finding 3: re-run a coastal fixture at candidate `SOUND_MIN_DEPTH_M` values (1.0, 0.5, 0.3, 0.2, 0.0) and record how many new soundings are real shoals versus land-clamp edge artifacts. Picks the floor with evidence instead of keeping 1.0 by default.
+3. **Density and clutter stats** for finding 8: nearest-neighbour spacing distribution per zoom against the widely-quoted NOAA practice (critical ≥6 mm, supporting ≥10 mm, fill 15–30 mm at chart scale — second-hand via Skopeliti 2020, not citable as a standard, so a target not a gate), plus label-collision rate from the style.
+
+Exit criterion: a measured baseline for the current algorithm on at least one shoal-rich and one deep fixture.
+
+### Results so far
+
+Harness is `pipelines/perf/soundings.py`, wired into `just test-perf`. Its self-check proves B-410a fires on a hidden pinnacle (~18 m shortfall), clears when that pinnacle is charted or ringed by an isobath, and that a sounding which does not display at a zoom does not count as charted there.
+
+**Spacing never reaches critical density, and varies only with depth.** Three published stems, nearest-neighbour median in mm at chart scale:
+
+| stem         | z8   | z10  | z12  | z14   |
+| ------------ | ---- | ---- | ---- | ----- |
+| `8-73-99-14` | 15.6 | 14.5 | 14.2 | 14.0  |
+| `8-75-96-14` | 14.4 | 14.1 | 14.0 | 13.9  |
+| `6-35-18-10` | 14.1 | 14.0 | 55.9 | 223.6 |
+
+Flat ~14 mm on the supporting/fill boundary, never at critical (6 mm). The deep control below reads 30–51 mm, so `SOUND_THIN_TIERS` does coarsen the field with depth as designed — the gap in finding 8 is narrower than first stated: spacing responds to _depth_, but not to _roughness_, and S-4 §B-410d asks for both.
+
+**New finding: coarse-source regions starve when you zoom in.** `6-35-18-10` is a `child_z = 10` stem. Its sounding count freezes at 9,438 past z10 (the finest pyramid level rides uncapped, `_tc`), so spacing blows out to 224 mm at z14 — soundings roughly 22 cm apart on screen. Correct per the current design, but it means the areas with the weakest source data present as the emptiest chart exactly when a mariner zooms in for detail. Worth its own decision: either densify from the same data, or say something explicit about coverage.
+
+**B-410a on real bathymetry** — the `terrebonne` z12 marsh fixture, 216 points emitted:
+
+| zoom | charted | soundings only              | with contours               |
+| ---- | ------- | --------------------------- | --------------------------- |
+| z12  | 16      | 75.1%, max 1.64 m, p99 1.11 | 86.5%, max 2.11 m, p99 1.90 |
+| z13  | 30      | 74.9%, max 2.02 m, p99 1.26 | 85.3%, max 2.11 m, p99 1.90 |
+| z14  | 56      | 76.1%, max 2.03 m, p99 1.26 | 83.3%, max 2.11 m, p99 1.90 |
+| z15  | 105     | 76.6%, max 2.03 m, p99 1.32 | 82.9%, max 2.11 m, p99 1.90 |
+
+Two things stand out, and neither is the one expected.
+
+**The violation rate is flat across zoom.** Quadrupling the sounding count from z12 to z15 barely moves it. The misses are therefore not a thinning problem — significance grading (finding 10) would not have fixed them.
+
+**Adding contours makes it worse**, from ~75% to ~85%. That is backwards on its face: contours are more charted information. The mechanism turned out to be specific and is now its own check.
+
+### The ring finding
+
+A closed contour with no sounding on it is a charted shoal with no charted least depth. A mariner interpolating across the ring reads the ring's own level, so the shoal is understated by however much shoaler the ground really is — which is why adding contours raised the violation rate rather than lowering it. S-4 §B-410b puts "least depths over shoals, banks and sills" at the very top of what must survive selection, so this is the clearest conformance failure in the audit, and the most actionable: the fix is a rule, not a tuning parameter.
+
+Two corrections to the first pass at measuring it, both found while implementing the fix:
+
+- **Not every closed isobath is a shoal ring.** In marsh where most ground is shallower than 2 m, a closed 2 m contour usually encloses a _deep pocket_. Only a ring whose interior rises above its own level owes a least depth. Of the fixture's 15 closed rings, **4** are shoal rings.
+- **The first gate sampled each ring's bounding box, not the ring.** For a small ring in shoal ground the box is mostly water outside it, which read as an understated shoal that was not there. That inflated the original "14 of 15 understating by up to 2.38 m". The gate now rasterizes the polygon, and carries a regression test built on a deep pocket whose bounding box would trip the old code.
+
+Corrected baseline: **4 of 4 shoal rings bare at z12**, worst understatement 1.30 m.
+
+This lands as `soundings.py rings`, with the self-check proving it fires on a bare shoal ring, stays quiet once a sounding is inside, ignores a ring sitting exactly on its own level, and ignores a deep pocket.
+
+### What this does to Phase 3
+
+The ordering changes. Emitting the least depth inside every closed isobath is now the first piece of work, ahead of density tuning — it is a bounded, rule-shaped change with a direct citation, and it addresses the largest measured gap. Finding 10 (significance grading) drops down the list, since the flat-across-zoom result says thinning is not what is hurting.
+
+### The deep control
+
+`iberian-abyssal` is a new fixture site (`8-110-91-10`, −24.61/45.58, GEBCO-only, cz10 built at z8) added because every other site is Gulf marsh or Delmarva lagoon. Ground: 1358–3937 m, median 3098 m, standard deviation 215 m — flat, deep, no land at all.
+
+| zoom | charted | violating | max shortfall | p99    | spacing |
+| ---- | ------- | --------- | ------------- | ------ | ------- |
+| z8   | 9       | 0.00%     | −0.62 m       | −365 m | 51.0 mm |
+| z9   | 25      | 0.02%     | 54 m          | −98 m  | 29.5 mm |
+| z10  | 81      | 1.11%     | 271 m         | 3.9 m  | 31.4 mm |
+
+**The algorithm passes where it should.** Negative shortfall means the charted field reads shoaler than the ground — conservative, the safe direction — and at z8 the p99 is −365 m, i.e. strongly shoal-biased throughout. This is the control that makes the marsh numbers interpretable: ~75–85% violation is a property of that terrain, not a systemic defect in the selection.
+
+Two secondary observations. Violations _rise_ with zoom here (0% → 1.11%), the opposite of intuition: coarse levels are thinned to the shoalest by `SOUND_THIN_TIERS`, so they are heavily shoal-biased, while the finest level charts deeper points too and can overshoot locally. And the 271 m worst case at z10 is ~9% of a 3000 m seabed — proportionally small, and in water where it carries no navigational consequence.
+
+With both ends measured, Phase 3's scope is settled: the work is in shoal, structured terrain, and the ring rule is the first piece.
+
+## Phase 2 — the batched rebuild
+
+Status: **implemented, awaiting a rebuild to take effect.** One rebuild carries all of it.
+
+- **True position.**
+- **Finding 5 — metre bands.** S-4 §B-412 has three: decimetres to 21 m, half-metres 21–31 m, whole metres above; `_depths` cut at 6 m. The half-metre band renders for free — a `.5` residual prints as `23₅`.
+- **Finding 6 — fathoms and feet.** Charts print fathoms _and feet_ up to 11 fathoms, fathoms only beyond (Canada CHS Chart 1 2022; US Chart No. 1 §I), so at 3 fathoms we printed `3` where a chart prints `3₄`. A fathom is exactly six feet, so the viewer derives both digits from `depth_ft` (`floor(ft / 6)` and `ft % 6`). **No schema change and no new field.** The first attempt put feet in `depth_fm`'s tenths slot, which changed the meaning of a published field — forcing a schema bump and a package major — and left a mixed-radix number where `3.4` did not mean 3.4 fathoms. Deriving it in the style is free and unambiguous.
+- **Finding 3 — shoal floor at 0.2 m.** Measured across the four Gulf marsh fixtures: admitted cells grow smoothly from 1.0 m down to 0.1 m, then jump 2–5× at the 0.1 → 0.0 step, which is the waterline-noise regime. 0.2 m clears it with headroom. The old floor's justification ("cells just read 0") no longer holds now that decimetres print — those read `0₂`.
+
+No separator goes between the number and its sub-unit digit. S-4 §B-412.1 offers two forms, not a combination: decimetres set subscript, _or_ on the same baseline where "they must be separated by a comma, full stop or decimal point". A point under the subscript form is neither, and on the fathom ladder it would misread 3 fathoms 4 feet as 3.4 fathoms.
+
+A latent bug surfaced here: `floor(0.3 * 10)` evaluates to 2, so 0.3 m charted as 0.2 m — shoal-safe, but wrong by a decimetre, and the same class of error made 3 fathoms 4 feet compute as 3 feet. Every unit conversion now floors through one epsilon helper.
+
+## Phase 3 — selection redesign
+
+Scoped by Phase 1's results: only the parts measured to fail get built.
+
+### The ring rule — implemented
+
+`_enclosed_shoals` emits the least depth inside every closed isobath as a **prime** sounding.
+
+A closed isobath at level L is exactly the boundary of a connected component of `{depth < L}` that does not reach the window edge, so this reads off the DEM at the same `config.CONTOUR_LEVELS` the contours are cut at. No contour file is involved, which keeps soundings a sibling of the contour stage rather than making it a child and serialising the DAG. Levels are bounded to the navigational band (200 m): past it an enclosed rise is a seabed feature, not a least depth a vessel can touch, and each level costs a labelling pass.
+
+Prime soundings are never zoom-capped. B-410b's "must always be shown" does not stop applying when the mariner zooms out, and the graduated SCAMIN policy puts the most significant soundings at the top of the ladder (S-57 App B.1 Annex A UOC, Ed 4.4.0, table 2.5) — so finding 10's significance grading is now answered for the class where it matters most, without a general redesign.
+
+Measured on the `terrebonne` marsh fixture, with the corrected gate:
+
+**Prime gets no ink of its own.** Emphasis-by-prime was tried and reverted: `prime` means "this feature's isobath closes inside the build window", which is right for retention and collision priority but is not a hazard ranking — a coastal shelf whose contour closes beyond the window edge is never prime, while a 0.5 m wrinkle at 29 m is, so black type on prime read exactly backwards (a black 19.8 m bank beside a grey 9 m shelf). Soundings render in one colour, paper-chart style (S-4 sets one style for all soundings; type distinctions mean reliability, B-412.4); hazard stays in the tint and the isobaths. A hazard-shaped emphasis needs scale-appropriate selection (finding 8), not a new paint rule.
+
+**Prime displays exactly where its enclosing isobath displays.** A prime's minzoom is its deepest enclosing ring's display zoom, read off `CONTOUR_TIERS` (the table that already thins isobath levels by zoom). B-410b's "must always be shown" is a claim about the charted feature: once generalization drops the ring at a scale, the chart makes no claim there for the sounding to complete — and promoting primes past their rings is what put decimetre least depths over the generalized coastline of coarse views. This replaces both the unbounded promotion and a pixel-buffer land-clearance filter that was prototyped and measured (flooring the whole lattice cost half the marsh fixture's field, B-410a 35% → 78%): the standards' mechanism for labels-too-close-to-land is scale selection, not a mask, and the ring tie is scale selection.
+
+## Follow-ups (out of scope)
+
+- **Feature-semantic generalization at low zoom.** The pipeline generalizes surfaces (per-zoom quantization, depth-gated smoothing, zoom-tiered contour levels, simplification) but never deletes, merges or exaggerates whole features by significance at scale — the islet/pit/peak tests, sub-legible ring deletion under the shoal-bias constraint (a deep pocket may be dropped; a shoal must merge into surrounding shallow water or be exaggerated, never vanish). The deferred ring-drop item from the contour-noise work belongs here, and `perf/gates.py`'s shoal-bias and displacement gates already exist to police it. Contour/depare scope, not soundings.
+
+|        | points | shoal rings bare | worst understatement | B-410a z12         | B-410a z15         |
+| ------ | ------ | ---------------- | -------------------- | ------------------ | ------------------ |
+| before | 207    | 4 / 4            | 1.30 m               | 86.5% (p99 1.90 m) | 82.9% (p99 1.90 m) |
+| after  | 1245   | 1 / 4            | 0.07 m               | 34.8% (p99 1.75 m) | 24.3% (p99 1.33 m) |
+
+The remaining bare ring understates by 0.07 m — the contour polygon is generalized, so its interior and the DEM component disagree slightly at the margin. Not worth chasing.
+
+The deep control is byte-identical (115 points, same violation rates): nothing in the abyss is enclosed shoaler than 200 m, so no prime soundings are minted there. Cost is ~2.6 s added on a 4226 px window, ~0.3 s on 2178 px.
+
+### Still open
+
+- **Finding 4 — deep soundings.** Every cell contributes its shoalest pixel and nothing else, so a channel's deep line can never appear. S-4 §B-410b requires maximum depths too, and §B-403.1a wants "sufficient numbers of deeper soundings retained to show the full range of depth" for echo-sounder fixing and anchorage choice.
+- **Finding 8 — density by seabed character.** S-4 §B-410d: flat ground wants a minimum of evenly spaced soundings, "irregular bottom topography should be represented by a denser, and probably irregular, pattern". One global `SOUND_CELL_PX` cannot do that; modulate acceptance by local depth variance. The true-position fix already gets the "irregular" half.
+- **Finding 9** is a standing gate rather than a work item: the B-410a test runs on every generalization change, like the existing shoal-bias gates.
+- **Finding 10** is largely answered by prime soundings; a full prime/supporting/fill classification is only worth building if the remaining B-410a residual demands it.
+
+The residual after the ring rule is ~25–35% of sampled marsh pixels, still shoaler than interpolation implies by up to ~2 m. Findings 4 and 8 are what remain to attack it, and both rewrite the same selection pass, so they are one design change rather than two.
+
+## Phase 4 — typography and a hosted font stack
+
+No rebuild; independent of everything above and can run in parallel.
+
+**Finding 11 — sloping numerals.** S-4 §B-412.1 wants sloping sans-serif; upright is reserved for unreliable soundings (§B-412.4), so we currently render every sounding in the "do not trust this" posture. Getting an italic face means self-hosting glyphs.
+
+The style currently defaults to `demotiles.maplibre.org`, which is a demo subset — it ships only ₂ ₃ ₄ of the Unicode subscript block, which is why the decimetre digit is a scaled `format` section rather than a subscript character. It is also a third-party host in the serving path of a navigation product.
+
+### Where it lives
+
+A separate repo, not `seascape/`:
+
+- The output is shared. Every Open Waters map on `tiles.openwaters.io` wants the same stack; baking it into the bathymetry repo makes one product the owner of a common asset.
+- Release cadence is opposite. The seascape Worker keys everything to `RELEASE_PREFIX` (a per-build R2 prefix). Fonts must be release-independent and effectively immutable — coupling them to bathymetry builds is exactly wrong.
+- No toolchain overlap. Glyph prep is a Rust/Node job with nothing in common with the Python/GDAL/Snakemake pipeline, and seascape's CI is already heavy.
+- Licensing is self-contained: the OFL text ships beside the artifacts.
+- Should include GitHub Actions to auto deploy
+
+`openwaters/tile-fonts`, scoped to fonts and glyphs. Sprites are a separate problem with a separate toolchain; when Phase 5's drying underline or the seamark symbol set needs one, that gets its own home rather than being pre-empted here.
+
+### Shape — built
+
+`openwaters/tile-fonts`, following the [protomaps/basemaps-assets](https://github.com/protomaps/basemaps-assets) precedent. Built and verified locally; not yet pushed to a remote.
+
+- Glyphs are cut by Stadia's [`build_pbf_glyphs`](https://github.com/stadiamaps/sdf_font_tools) rather than MapLibre's `font-maker`: both wrap the same `sdf-glyph-foundry`, but `build_pbf_glyphs` ships prebuilt binaries and a `cargo install`, where `font-maker` needs a cmake build from source. Its macOS release asset is named `x86_64` but is a native arm64 binary.
+- A fontstack is composed from many per-script Noto TTFs, so worldwide coverage is a font list rather than a code problem. Sourced from the `notofonts.github.io` monthly release tags (`noto-monthly-release-YYYY.MM.01`), pinned in `fonts.json`.
+- Faces: **Noto Sans Regular** (keeps the name the style already uses, and becomes the S-4 §B-412.4 upright posture for low-reliability soundings), **Noto Sans Italic** (the §B-412.1 sloping default for soundings), **Noto Sans Medium** (emphasis). All SIL OFL, redistributed with the licence.
+- Output is `fonts/<Fontstack Name>/<start>-<end>.pbf`, published to the existing `tiles` R2 bucket under a `fonts/` prefix.
+
+Built from the 2026.08.01 release: Regular 12,225 glyphs / 50 faces, Medium 6,530 / 20, Italic 3,278 / 4, 256 ranges each. **Subscript digits U+2080–2089 are 10 of 10 present**, against 3 of 10 on the demotiles stack the style currently uses — which is the gap that forced the decimetre digit to be a scaled `format` section instead of a subscript character.
+
+Two things only running it revealed, both now fixed: Tibetan is not in the monolithic Noto repo in any variant (a stack with a silent hole renders as tofu, so a missing source is fatal and every path is resolved before any glyph is cut), and the coverage checker required U+2072/U+2073, which are unassigned in Unicode and produced a false failure on a good stack.
+
+Serving needs no Worker. Glyph PBFs are immutable static files, and an R2 bucket on a custom domain covers all three requirements natively:
+
+- **Caching** — Cloudflare caches from an R2 custom domain off each object's own `Cache-Control`, so `public, max-age=31536000, immutable` set at upload is the whole story.
+- **CORS** — configured on the bucket, or as a response-header rule on the hostname.
+- **TLS and CDN** — come with the custom domain.
+
+So the deliverable is a build script plus an upload, not a service. The one thing to verify against the account's actual DNS is whether `tiles.openwaters.io` can carry an R2 custom domain alongside the existing `tiles.openwaters.io/seascape/*` Worker route — more specific Worker routes take precedence over a custom domain, so the two should coexist, but if that turns out awkward a dedicated hostname is the boring alternative and costs nothing.
+
+Either way, font serving never rides a bathymetry deploy, which is the property that matters.
+
+Then in `style/`: `DEFAULT_GLYPHS` points at the new host, and `Flavor.font` gains the italic face for soundings while `source-labels` stays upright.
+
+Verification: assert the subscript block (U+2080–2089) is present in the built stack, since that absence is what forced the current workaround.
+
+## Phase 5 — drying heights
+
+Gated on the datum workstream; needs Phase 4 first.
+
+**Finding 7.** `_shoalest_grid` selects `block < 0`, so nothing at or above datum becomes a sounding. S-4 §B-413 requires drying soundings shown as drying heights, rounded **up** (the opposite of the truncation everywhere else), with the metre numerals underlined. A drying height on an uncorrected MSL grid is meaningless, hence the datum gate; the underline needs a sprite, since `format` cannot draw one.
+
+## Risks
+
+The Phase 3 redesign changes what a mariner sees at every zoom. The existing `perf/gates.py` shoal-bias assertions plus the new interpolation gate are the guard — a failure there is a defect, not a threshold to widen.
+
+Emitting deep soundings (finding 4) is the one change that can _reduce_ apparent shoal bias in a rendered view by competing for label space with shoal soundings. `symbol-sort-key` already sorts shoalest-first so collisions resolve toward safety, but the collision rate from Phase 1 should be re-measured after.

--- a/docs/plans/2026-08-17-soundings-chart-conformance.md
+++ b/docs/plans/2026-08-17-soundings-chart-conformance.md
@@ -2,7 +2,7 @@
 
 _Written 2026-08-17. Point-in-time; the code is the source of truth._
 
-Status: in progress — Phases 1-3 implemented, awaiting a soundings rebuild; Phases 4-5 open.
+Status: in progress — Phases 1-4 implemented and committed on `soundings-chart-conformance`; Phase 5 (drying) blocked on the datum workstream.
 
 ## Problem
 
@@ -15,11 +15,11 @@ The findings, numbered as the phases below cite them:
 | 1 | Decimetre labels printed from sources not on chart datum (MSL-referenced UK/NZ/NL/AU sources) | Out of scope — datum workstream |
 | 2 | No data-quality attribution: GEBCO-derived and 0.25 m multibeam soundings render identically (`M_QUAL` is mandatory, S-57 UOC §2.2.3) | Out of scope — quality workstream |
 | 3 | 1.0 m floor deleted the least depths S-4 B-410b ranks highest | Fixed — 0.2 m, from the measured waterline-noise knee |
-| 4 | Only the shoalest pixel per cell is emitted, so a channel's deep line can never appear (B-410b also wants maximum depths; B-403.1a "the full range of depth") | Open |
+| 4 | Only the shoalest pixel per cell is emitted, so a channel's deep line can never appear (B-410b also wants maximum depths; B-403.1a "the full range of depth") | Fixed — error-driven deep-side repair; the Ambrose corridor gains its 26–31 m line and axis infill with no channel-specific code |
 | 5 | Metre precision bands cut at 6 m; S-4 B-412 says decimetres to 21 m, half-metres to 31 m | Fixed |
 | 6 | Whole fathoms everywhere; charts print fathoms-and-feet below 11 fathoms | Fixed — derived from `depth_ft` in the style |
 | 7 | No drying heights (S-4 B-413: shown as soundings, rounded up, underlined) | Blocked on finding 1 |
-| 8 | Sounding density is uniform per cell — responds to depth (thin tiers) but not to seabed roughness (S-4 B-410d wants both) | Open |
+| 8 | Sounding density is uniform per cell — responds to depth (thin tiers) but not to seabed roughness (S-4 B-410d wants both) | Largely fixed — repair insertions land where interpolation fails, which is where structure is; the lattice itself stays uniform |
 | 9 | Nothing verified S-4 B-410a's "final test of depth selection" (interpolation from the charted field) | Fixed — standing gate in `perf/soundings.py` |
 | 10 | Zoom thinning graded by a sounding's own depth, not its significance (S-57 UOC table 2.5 grades SCAMIN by significance, 1→4 steps) | Largely answered — prime retention + ring-tied display; full grading only if the B-410a residual demands it |
 | 11 | All soundings set upright — the posture S-4 B-412.4 reserves for *unreliable* soundings; B-412.1 wants sloping numerals | Fixed — Noto Sans Italic, self-hosted |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -52,8 +52,8 @@ Coarse zooms carry fewer levels (deep-ocean contours thin out zoomed out); a lev
 
 | Field | Type | Meaning |
 |---|---|---|
-| `depth_m` | Number | Depth in metres, **positive-down** (unlike `contours.depth_m`), floored toward shallower; carries one decimal shallower than 6 m, whole metres beyond. |
-| `depth_ft` | Number | Integer feet, floored toward shallower. |
+| `depth_m` | Number | Depth in metres, **positive-down** (unlike `contours.depth_m`), floored toward shallower. The tenths digit is decimetres. Precision follows the charted band (S-4 B-412): decimetres shallower than 21 m, half metres from 21 to 31 m, whole metres beyond. |
+| `depth_ft` | Number | Integer feet, floored toward shallower. A chart sets fathoms-and-feet below 11 fathoms; a fathom is exactly six feet, so a renderer derives both from this field (`floor(depth_ft / 6)` and `depth_ft % 6`). |
 | `depth_fm` | Number | Integer fathoms, floored toward shallower. |
 
 ### `depare` — depth-area polygons (ENC DEPARE)

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ fetch(`${tilesBase}/vector.json`)
       `These tiles use schema version ${tj.schema}, but this viewer was built ` +
       `for schema version ${SCHEMA}. Rendering could silently show wrong depths, ` +
       `so the chart is disabled. Update the viewer to match the tiles.`;
-    el.replaceChildren(msg);
+    // el.replaceChildren(msg);
   })
   .catch(() => {}); // unreachable TileJSON already surfaces as a map load error
 
@@ -229,13 +229,15 @@ map.on("click", async (e) => {
 
   const lines = [];
   if (ele != null) {
-    const depth = Math.round(-ele);
+    // Floored toward shallower, like the soundings (soundings_run.py): a reported
+    // depth must never overstate the water, so 16.6 m reads 16, not 17.
+    const depth = -ele;
     // Non-negative values are category codes (0 unknown water, 1 drying, 2 land);
     // overzoom fractions between codes round to the nearest one.
     lines.push(
       `<strong>${
         ele < 0
-          ? `${depth}m (${Math.round(depth * 3.28084)}ft)`
+          ? `${Math.floor(depth)}m (${Math.floor(depth * 3.28084)}ft)`
           : ["unknown depth", "drying", "land"][Math.min(Math.round(ele), 2)]
       }</strong>`,
     );

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ fetch(`${tilesBase}/vector.json`)
       `These tiles use schema version ${tj.schema}, but this viewer was built ` +
       `for schema version ${SCHEMA}. Rendering could silently show wrong depths, ` +
       `so the chart is disabled. Update the viewer to match the tiles.`;
-    // el.replaceChildren(msg);
+    el.replaceChildren(msg);
   })
   .catch(() => {}); // unreachable TileJSON already surfaces as a map load error
 

--- a/pipelines/contour_run.py
+++ b/pipelines/contour_run.py
@@ -409,9 +409,13 @@ def require_stable_complete(layer, stems, files):
 # depth — tippecanoe detects per layer).
 # depare's kind stays in the FGBs but OUT of the tiles: nothing reads it (the style keys on
 # sys/drval1 presence and sorts by rank), and it measured -3.9% on the dominant coarse-stem class.
+# `-y` is an ALLOWLIST: an attribute missing from this list is silently dropped from the tiles,
+# however faithfully the pipeline wrote it. `prime` marks a sounding as the least depth inside a
+# closed isobath (S-4 B-410b), which is what lets the style weight it — it is carried on a small
+# minority of features and absent on the rest.
 VECTOR_ATTRS = ["depth_m", "depth_abs_m", "sys", "depth_ft", "depth_fm",
-                "drval1", "drval2", "rank"]
-VECTOR_TYPES = ["depth_abs_m:int", "depth_ft:int", "depth_fm:int", "rank:int"]
+                "drval1", "drval2", "rank", "prime"]
+VECTOR_TYPES = ["depth_abs_m:int", "depth_ft:int", "depth_fm:int", "rank:int", "prime:int"]
 DEPARE_MINZOOM = 6  # depare's zoom floor, now per-feature (was depare_run's run-level -Z)
 # Geometric self-check thresholds, calibrated on the NY-harbor archive (2026-07-29). Decoded tiles
 # include their buffer ring, and a parent's ring spans 2× its children's in shared-map units, so

--- a/pipelines/perf/fixtures.py
+++ b/pipelines/perf/fixtures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv run --script
-"""Local profiling fixtures: small real windows over the Gulf marsh and the Delmarva lagoons, cut
-from the published mosaic COGs by range read.
+"""Local profiling fixtures: small real windows over the Gulf marsh, the Delmarva lagoons and the
+Iberian abyssal plain, cut from the published mosaic COGs by range read.
 
 A real z15 marsh stem is a z8 macrotile: 65666 px square, 17.2 GB as Float32. That does not run
 on a 17 GB laptop, so the fixtures are synthetic macrotile-z stems over the same ground —
@@ -57,12 +57,19 @@ SITES = {
                     "open bay with real -2/-5 m bathymetry; the level-set control"),
     "delmarva": ("8-74-99-14-3fb472fde1f8.tif", -75.9103, 37.2197,
                  "back-barrier lagoons; the drying fragmentation site, 713 parts at z12"),
+    "iberian-abyssal": ("8-110-91-10-db6827ae146c.tif", -24.61, 45.58,
+                        "deep flat GEBCO-only ocean; the control every other site lacks — every "
+                        "shoal-water measurement needs ground where it should trivially pass"),
 }
 
 # A crop must carry its macrotile's OWN child_z or it is not the surface production contours:
 # the Delmarva macrotile is cz14, and reading it at CHILD_Z would invent detail the mosaic
 # does not hold.
-SITE_CHILD_Z = {"delmarva": 14}
+SITE_CHILD_Z = {"delmarva": 14, "iberian-abyssal": 10}
+
+# Sites whose macrotile is coarse enough that a z12 stem would be a few hundred pixels. Build
+# these at a lower z so the crop is a comparable amount of ground: the core is 2^(cz-z)*512 px.
+SITE_Z = {"iberian-abyssal": 8}
 
 # Published mask sizes, so a stale mask can never silently change a measurement. A stale or
 # absent water.fgb changes the nodata layer AND the drying cut, which is exactly the mechanism
@@ -99,7 +106,7 @@ def build(sites=None, z=12):
     stems = []
     for site in sites:
         tile, lon, lat, _why = SITES[site]
-        stem = stem_for(site, z)
+        stem = stem_for(site, SITE_Z.get(site, z))
         stems.append(stem)
         out = f"{tiles}/{stem}.tif"
         if os.path.exists(out):
@@ -145,7 +152,8 @@ def masks():
 
 def _list():
     for site in SITES:
-        for z in (12, 11, 10, 9):
+        base = SITE_Z.get(site, 12)
+        for z in range(base, base - 4, -1):
             stem = stem_for(site, z)
             (_bounds, res, w, h) = geometry(stem)
             gb = w * h * 4 / 1e9

--- a/pipelines/perf/soundings.py
+++ b/pipelines/perf/soundings.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env -S uv run --script
+"""Conformance measurements for the sounding field. Unlike gates.py these are not before/after
+comparisons — each one is an absolute property of one stem's output, measured so a redesign is
+scoped by evidence instead of a guess.
+
+  1. interpolation  S-4 B-410a's final test of depth selection, per display zoom
+  2. rings          every closed isobath must carry the least depth inside it (S-4 B-410b)
+  3. density        spacing distribution vs the practice figures, per display zoom
+  4. floor          what SOUND_MIN_DEPTH_M actually admits and drops, per candidate value
+
+Gate 1 is the one that matters. S-4, Ed 4.10.0, B-410a:
+
+    "The final test of depth selection is that no source material should contain depths shoaler
+     than the mariner would expect by interpolating the depth in any position from the charted
+     soundings and depth contours."
+
+That is testable directly, and testing it is far cheaper than implementing the triangular
+selection method it validates. The mariner's interpolation is modelled as linear interpolation
+over a Delaunay triangulation of everything charted at that zoom — the soundings that display
+there plus the isobath vertices — which is what the "triangle" language in B-410a describes.
+
+Measuring per zoom is the point: the shoalest pixel of every cell IS emitted at the finest level,
+so violations only appear once the pyramid thins the field. Where that starts is the number that
+scopes any selection change.
+
+    soundings.py interpolation <window.tif> <soundings.geojsons> <contour.fgb> --zoom Z [--tol-m M]
+    soundings.py rings <window.tif> <soundings.geojsons> <contour.fgb> --zoom Z
+    soundings.py density <soundings.geojsons> --zoom Z [--tile-px 512]
+    soundings.py floor <window.tif> [--floors 1.0,0.5,0.3,0.2,0.0]
+    soundings.py --check
+"""
+import json
+import math
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+NODATA = -9999.0
+# Practice figures for label spacing at chart scale, quoted second-hand (Skopeliti et al. 2020
+# via the NOAA Nautical Chart Manual) — a target to report against, never a pass/fail threshold.
+SPACING_MM = {"critical": 6.0, "supporting": 10.0, "fill": 15.0}
+# A CSS pixel is defined as a visual angle at arm's length, the same distance ECDIS displays are
+# engineered for, so screen px convert to millimetres exactly (S-52 Ed 6.1.1 §5.1 sizing basis).
+MM_PER_PX = 0.2646
+
+
+def _displayed(feat, zoom):
+    """Does this sounding render at `zoom`? Per-feature tippecanoe placement: minzoom always,
+    maxzoom only on levels that swap out when a finer field arrives (soundings_run._tc)."""
+    tc = feat.get("tippecanoe", {})
+    lo = tc.get("minzoom", 0)
+    hi = tc.get("maxzoom", math.inf)
+    return lo <= zoom <= hi
+
+
+def _read_soundings(path, zoom):
+    """[(lon, lat, depth_pos)] for the soundings that display at `zoom`."""
+    out = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            ft = json.loads(line)
+            if not _displayed(ft, zoom):
+                continue
+            lon, lat = ft["geometry"]["coordinates"]
+            out.append((lon, lat, float(ft["properties"]["depth_m"])))
+    return out
+
+
+def _read_contours(path):
+    """[(lon, lat, depth_pos)] over every vertex of the metre ladder's isobaths. The fathom-curve
+    duplicates cover the same water, so including them would just double-weight the same lines."""
+    import geopandas as gpd
+    from shapely import get_coordinates
+    gdf = gpd.read_file(path)
+    if gdf.empty:
+        return []
+    if "sys" in gdf.columns:
+        gdf = gdf[gdf["sys"] != "ft"]
+    col = "depth_abs_m" if "depth_abs_m" in gdf.columns else "depth_m"
+    out = []
+    for depth, geom in zip(gdf[col], gdf.geometry):
+        if geom is None or depth is None:
+            continue
+        for x, y in get_coordinates(geom):
+            out.append((float(x), float(y), abs(float(depth))))
+    return out
+
+
+def _to_dem_xy(pts, dem_crs):
+    """[(lon, lat, d)] in 4326 -> (N,2) array in the DEM's CRS, plus the depths."""
+    from pyproj import Transformer
+    if not pts:
+        return np.empty((0, 2)), np.empty(0)
+    lon, lat, d = (np.asarray(c, float) for c in zip(*pts))
+    tf = Transformer.from_crs("EPSG:4326", dem_crs, always_xy=True)
+    x, y = tf.transform(lon, lat)
+    return np.column_stack([x, y]), d
+
+
+def interpolation(window_tif, soundings_path, contour_path, zoom, tol_m=0.0, stride=4):
+    """S-4 B-410a: no source pixel may be shoaler than interpolation from the charted field.
+
+    `stride` subsamples the DEM — a fixture window is millions of pixels and the interpolant is
+    the expensive part. It is a sample, and the reported counts say so.
+    """
+    import rasterio
+    from scipy.interpolate import LinearNDInterpolator
+
+    with rasterio.open(window_tif) as src:
+        arr = src.read(1)
+        transform, crs, nd = src.transform, src.crs, (src.nodata if src.nodata is not None else NODATA)
+
+    snd = _read_soundings(soundings_path, zoom)
+    cnt = _read_contours(contour_path) if contour_path and os.path.exists(contour_path) else []
+    xy_s, d_s = _to_dem_xy(snd, crs)
+    xy_c, d_c = _to_dem_xy(cnt, crs)
+    xy = np.vstack([xy_s, xy_c])
+    dd = np.concatenate([d_s, d_c])
+    if len(xy) < 3:
+        return {"pass": False, "zoom": zoom, "charted_points": int(len(xy)),
+                "failures": ["fewer than 3 charted features — nothing to interpolate from"]}
+
+    sub = arr[::stride, ::stride]
+    rows, cols = np.mgrid[0:arr.shape[0]:stride, 0:arr.shape[1]:stride]
+    wet = (sub != nd) & (sub < 0)
+    if not wet.any():
+        return {"pass": True, "zoom": zoom, "charted_points": int(len(xy)),
+                "sampled_water_px": 0, "failures": []}
+
+    # Pixel centres in DEM CRS; positive-down actual depth.
+    px_x, px_y = rasterio.transform.xy(transform, rows[wet], cols[wet])
+    actual = -sub[wet].astype(float)
+
+    expected = LinearNDInterpolator(xy, dd)(np.column_stack([px_x, px_y]))
+    inside = ~np.isnan(expected)          # outside the convex hull the mariner has nothing to go on
+    shortfall = expected[inside] - actual[inside]   # >0 => real ground shoaler than charted
+    # The interpolant reproduces a control point to ~1e-15, not exactly; a micron of that is not
+    # a charting defect.
+    viol = shortfall > max(tol_m, 1e-6)
+
+    n = int(inside.sum())
+    return {
+        "pass": not bool(viol.any()),
+        "zoom": zoom,
+        "charted_points": int(len(xy)),
+        "displayed_soundings": int(len(xy_s)),
+        "sampled_water_px": n,
+        "violating_px": int(viol.sum()),
+        "violating_fraction": (float(viol.sum()) / n) if n else 0.0,
+        "max_shortfall_m": float(shortfall.max()) if n else 0.0,
+        "p99_shortfall_m": float(np.percentile(shortfall, 99)) if n else 0.0,
+        "stride": stride,
+        "failures": ([] if not viol.any() else
+                     [f"{int(viol.sum())} of {n} sampled water px are shoaler than the charted "
+                      f"field implies (max {float(shortfall.max()):.2f} m) — S-4 B-410a"]),
+    }
+
+
+def rings(window_tif, soundings_path, contour_path, zoom):
+    """Every closed isobath must carry the least depth inside it.
+
+    S-4, Ed 4.10.0, B-410b puts "least depths over shoals, banks and sills in navigable channels"
+    at the top of what must survive selection. A closed contour with no sounding inside it is a
+    charted shoal with no charted least depth: a mariner interpolating across the ring reads the
+    ring's own level, so the shoal is understated by however much shoaler the ground really is.
+
+    This is the sharpest form of the B-410a failure, and unlike the aggregate violation fraction
+    it names the specific features at fault.
+    """
+    import geopandas as gpd
+    import rasterio
+    from rasterio.features import geometry_mask
+    from shapely import get_coordinates
+    from shapely.geometry import Point, Polygon
+
+    gdf = gpd.read_file(contour_path)
+    if "sys" in gdf.columns:
+        gdf = gdf[gdf["sys"] != "ft"]
+    col = "depth_abs_m" if "depth_abs_m" in gdf.columns else "depth_m"
+
+    closed = []
+    for depth, geom in zip(gdf[col], gdf.geometry):
+        if geom is None or depth is None:
+            continue
+        parts = geom.geoms if geom.geom_type.startswith("Multi") else [geom]
+        for part in parts:
+            c = get_coordinates(part)
+            if len(c) > 3 and np.allclose(c[0], c[-1]):
+                closed.append((abs(float(depth)), Polygon(c)))
+
+    pts = [Point(lo, la) for lo, la, _ in _read_soundings(soundings_path, zoom)]
+    shoal_rings, bare, worst = 0, 0, 0.0
+    with rasterio.open(window_tif) as src:
+        arr = src.read(1)
+        nd = src.nodata if src.nodata is not None else NODATA
+        for depth, poly in closed:
+            # Mask by the ring itself. Its bounding box is not the ring: for a small ring in shoal
+            # ground the box is mostly water outside it, which reads as an understated shoal that
+            # is not there.
+            geom = gpd.GeoSeries([poly], crs="EPSG:4326").to_crs(src.crs).iloc[0]
+            try:
+                inside = geometry_mask([geom], arr.shape, src.transform, invert=True)
+            except Exception:
+                continue
+            wet = inside & (arr != nd) & (arr < 0)
+            if not wet.any():
+                continue
+            shoalest = -float(arr[wet].max())
+            # A closed isobath can enclose a shoal or a deep. Only a shoal ring owes a least
+            # depth: the interior has to actually rise above the ring's own level.
+            if shoalest >= depth - 0.05:
+                continue
+            shoal_rings += 1
+            if not any(poly.contains(p) for p in pts):
+                bare += 1
+                worst = max(worst, depth - shoalest)
+
+    return {
+        "pass": bare == 0,
+        "zoom": zoom,
+        "closed_rings": len(closed),
+        "shoal_rings": shoal_rings,
+        "shoal_rings_without_least_depth": bare,
+        "worst_understatement_m": worst,
+        "failures": ([] if bare == 0 else
+                     [f"{bare} of {shoal_rings} closed isobaths enclosing a shoal carry no "
+                      f"sounding (worst {worst:.2f} m understated) — S-4 B-410b"]),
+    }
+
+
+def density(soundings_path, zoom, tile_px=512):
+    """Nearest-neighbour spacing of the displayed field, in mm at chart scale.
+
+    At its native zoom a tile of `tile_px` renders at that many CSS px, so ground distance
+    converts to screen px through the zoom's own resolution and then to mm exactly.
+    """
+    from scipy.spatial import cKDTree
+    snd = _read_soundings(soundings_path, zoom)
+    if len(snd) < 2:
+        return {"zoom": zoom, "displayed": len(snd), "failures": []}
+    lon, lat, _ = (np.asarray(c, float) for c in zip(*snd))
+    # Local equirectangular metres is plenty for a nearest-neighbour statistic within one stem.
+    R = 6378137.0
+    lat0 = math.radians(float(lat.mean()))
+    x = np.radians(lon) * R * math.cos(lat0)
+    y = np.radians(lat) * R
+    d, _i = cKDTree(np.column_stack([x, y])).query(np.column_stack([x, y]), k=2)
+    nn_m = d[:, 1]
+    m_per_px = (2 * math.pi * R * math.cos(lat0)) / (tile_px * 2 ** zoom)
+    nn_mm = nn_m / m_per_px * MM_PER_PX
+    q = lambda t: float(np.percentile(nn_mm, t))
+    median = q(50)
+    band = ("tighter than critical" if median < SPACING_MM["critical"] else
+            "critical" if median < SPACING_MM["supporting"] else
+            "supporting" if median < SPACING_MM["fill"] else "fill")
+    return {"zoom": zoom, "displayed": len(snd), "m_per_px": m_per_px,
+            "nn_mm": {"p10": q(10), "median": median, "p90": q(90)},
+            "band": band, "targets_mm": SPACING_MM, "failures": []}
+
+
+def floor(window_tif, floors):
+    """What each candidate SOUND_MIN_DEPTH_M admits. Finding 3: the 1.0 m default drops exactly
+    the least depths S-4 B-410b puts at the top of what must survive selection, so the question is
+    how much of what it drops is real shoal and how much is waterline artifact."""
+    import rasterio
+    import soundings_run
+    rows = []
+    with rasterio.open(window_tif) as src:
+        nd = src.nodata if src.nodata is not None else NODATA
+        for f in floors:
+            g, _cx, _cy = soundings_run._shoalest_grid(src, nd, f)
+            ok = ~np.isnan(g)
+            rows.append({"floor_m": f, "cells": int(ok.sum()),
+                         "shoalest_m": float(np.nanmin(g)) if ok.any() else None})
+    base = rows[0]["cells"]
+    for r in rows:
+        r["added_vs_first"] = r["cells"] - base
+    return {"floors": rows, "failures": []}
+
+
+def _check():
+    """Each measurement must fire on ground it should reject and stay quiet on ground it should
+    accept. Synthetic stems only — no store, no network."""
+    import tempfile
+    import geopandas as gpd
+    import rasterio
+    from rasterio.transform import from_origin
+    from shapely.geometry import LineString
+
+    tmp = tempfile.mkdtemp()
+
+    # A 20 m flat basin with an undetected 2 m pinnacle in the middle. 100 m px, EPSG:3857.
+    n, px = 128, 100.0
+    arr = np.full((n, n), -20.0, "float32")
+    arr[64, 64] = -2.0
+    tr = from_origin(0, n * px, px, px)
+    dem = f"{tmp}/w.tif"
+    with rasterio.open(dem, "w", driver="GTiff", height=n, width=n, count=1, dtype="float32",
+                       nodata=NODATA, crs="EPSG:3857", transform=tr) as dst:
+        dst.write(arr, 1)
+
+    from pyproj import Transformer
+    inv = Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True)
+
+    def write_snd(path, cells, zoom_lo=8):
+        with open(path, "w") as f:
+            for (row, col, depth) in cells:
+                x, y = tr * (col + 0.5, row + 0.5)
+                lon, lat = inv.transform(x, y)
+                f.write(json.dumps({
+                    "type": "Feature", "tippecanoe": {"minzoom": zoom_lo},
+                    "properties": {"depth_m": depth},
+                    "geometry": {"type": "Point", "coordinates": [lon, lat]}}) + "\n")
+
+    # Charting only the flat 20 m ground hides the pinnacle: the interpolant says 20 m where the
+    # ground is 2 m, so B-410a must fail by ~18 m.
+    corners = [(4, 4, 20.0), (4, 123, 20.0), (123, 4, 20.0), (123, 123, 20.0), (100, 20, 20.0)]
+    miss = f"{tmp}/miss.geojsons"
+    write_snd(miss, corners)
+    r = interpolation(dem, miss, None, zoom=8, stride=2)
+    assert not r["pass"], "B-410a must fail when a pinnacle is left uncharted"
+    assert r["max_shortfall_m"] > 17.0, r["max_shortfall_m"]
+
+    # Charting the pinnacle too clears it.
+    hit = f"{tmp}/hit.geojsons"
+    write_snd(hit, corners + [(64, 64, 2.0)])
+    r = interpolation(dem, hit, None, zoom=8, stride=2)
+    assert r["pass"], f"charted pinnacle must pass: {r['failures']}"
+
+    # Zoom filtering: a sounding that only displays at z12 must not rescue z8.
+    late = f"{tmp}/late.geojsons"
+    with open(late, "w") as f:
+        f.write(open(hit).read().replace('"minzoom": 8}', '"minzoom": 12}', 1))
+    lines = open(late).read().splitlines()
+    with open(late, "w") as f:
+        for i, ln in enumerate(lines):
+            o = json.loads(ln)
+            o["tippecanoe"] = {"minzoom": 12} if o["properties"]["depth_m"] == 2.0 else {"minzoom": 8}
+            f.write(json.dumps(o) + "\n")
+    assert not interpolation(dem, late, None, zoom=8, stride=2)["pass"], \
+        "a sounding that does not display at this zoom must not count as charted"
+    assert interpolation(dem, late, None, zoom=12, stride=2)["pass"], \
+        "…and must count at a zoom where it does display"
+
+    # Contours are charted features too: a 2 m isobath ringing the pinnacle carries the shoal.
+    ring = gpd.GeoDataFrame(
+        [{"sys": "m", "depth_abs_m": 2.0,
+          "geometry": LineString([tr * (60.5, 60.5), tr * (68.5, 60.5),
+                                  tr * (68.5, 68.5), tr * (60.5, 68.5), tr * (60.5, 60.5)])}],
+        crs="EPSG:3857").to_crs("EPSG:4326")
+    cpath = f"{tmp}/c.fgb"
+    ring.to_file(cpath, driver="FlatGeobuf")
+    assert interpolation(dem, miss, cpath, zoom=8, stride=2)["pass"], \
+        "an isobath around the shoal must satisfy B-410a on its own"
+
+    # rings: a closed isobath around the pinnacle with no sounding inside is the B-410b failure;
+    # putting the least depth on it clears the check.
+    # The 2 m isobath exactly on a 2 m pinnacle does not rise above its own level, so it is not a
+    # shoal ring and owes nothing.
+    r = rings(dem, miss, cpath, zoom=8)
+    assert r["closed_rings"] == 1 and r["shoal_rings"] == 0 and r["pass"], r
+
+    # Labelled 5 m over the same 2 m ground it IS a shoal ring, and bare it understates by 3 m.
+    deep_ring = ring.copy()
+    deep_ring["depth_abs_m"] = 5.0
+    dpath = f"{tmp}/c5.fgb"
+    deep_ring.to_file(dpath, driver="FlatGeobuf")
+    r = rings(dem, miss, dpath, zoom=8)
+    assert r["shoal_rings"] == 1 and not r["pass"], r
+    assert abs(r["worst_understatement_m"] - 3.0) < 0.01, r["worst_understatement_m"]
+    r = rings(dem, hit, dpath, zoom=8)
+    assert r["pass"], f"a sounding inside the ring must clear B-410b: {r['failures']}"
+
+    # A ring around a DEEP pocket is not a shoal ring: only the bounding box of a small ring
+    # touches shallower ground, and sampling that box instead of the ring invents a failure.
+    deep_hole = arr.copy()
+    deep_hole[:] = -1.0
+    deep_hole[60:69, 60:69] = -8.0
+    hp = f"{tmp}/hole.tif"
+    with rasterio.open(hp, "w", driver="GTiff", height=n, width=n, count=1, dtype="float32",
+                       nodata=NODATA, crs="EPSG:3857", transform=tr) as dst:
+        dst.write(deep_hole, 1)
+    r = rings(hp, miss, dpath, zoom=8)
+    assert r["closed_rings"] == 1 and r["shoal_rings"] == 0 and r["pass"], r
+
+    # density: spacing scales with zoom, and the band label tracks the practice figures.
+    d8 = density(hit, zoom=8)
+    d14 = density(hit, zoom=14)
+    assert d14["nn_mm"]["median"] > d8["nn_mm"]["median"], "same ground is wider apart when zoomed in"
+    assert d8["displayed"] == len(corners) + 1, d8["displayed"]
+    assert density(hit, zoom=7)["displayed"] == 0, "minzoom 8 must not display at z7"
+
+    # floor: lowering it can only admit cells, never drop them, and finds the shallower ground.
+    shallow = arr.copy()
+    shallow[0:8, 0:8] = -0.4
+    sp = f"{tmp}/shallow.tif"
+    with rasterio.open(sp, "w", driver="GTiff", height=n, width=n, count=1, dtype="float32",
+                       nodata=NODATA, crs="EPSG:3857", transform=tr) as dst:
+        dst.write(shallow, 1)
+    import soundings_run
+    soundings_run.SOUND_CELL_PX = 8
+    f = floor(sp, [1.0, 0.3])
+    assert f["floors"][1]["cells"] > f["floors"][0]["cells"], "a lower floor must admit more cells"
+    assert f["floors"][0]["shoalest_m"] >= 1.0 and f["floors"][1]["shoalest_m"] < 1.0
+
+    print("soundings self-check ok (B-410a fires on a hidden shoal, clears on a charted one)")
+
+
+if __name__ == "__main__":
+    a = sys.argv[1:]
+    opt = lambda k, d: (type(d)(a[a.index(k) + 1]) if k in a else d)
+    if a[:1] == ["--check"]:
+        _check()
+    elif a[:1] == ["interpolation"] and len(a) >= 4:
+        r = interpolation(a[1], a[2], a[3] if a[3] != "-" else None,
+                          opt("--zoom", 12), opt("--tol-m", 0.0), opt("--stride", 4))
+        print(json.dumps(r, indent=2))
+        sys.exit(0 if r["pass"] else 1)
+    elif a[:1] == ["rings"] and len(a) >= 4:
+        r = rings(a[1], a[2], a[3], opt("--zoom", 12))
+        print(json.dumps(r, indent=2))
+        sys.exit(0 if r["pass"] else 1)
+    elif a[:1] == ["density"] and len(a) >= 2:
+        print(json.dumps(density(a[1], opt("--zoom", 12), opt("--tile-px", 512)), indent=2))
+    elif a[:1] == ["floor"] and len(a) >= 2:
+        floors = [float(x) for x in opt("--floors", "1.0,0.5,0.3,0.2,0.0").split(",")]
+        print(json.dumps(floor(a[1], floors), indent=2))
+    else:
+        sys.exit(__doc__.strip().split("\n\n")[-1])

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -12,10 +12,15 @@ A shoalest-wins quadtree tags each point with the coarsest zoom it survives to (
 minzoom), so zoomed-out views carry only the shoalest few per area and low-zoom tiles stay
 small; the viewer's symbol collision (sorted shallow-first) de-conflicts what remains.
 
-Per tile: read merged DEM (3857) in row strips -> a staggered-grid PYRAMID (one jittered quincunx
-grid per zoom level, each point valued by the shoalest wet pixel in its block) -> keep points in
+Each sounding sits on the pixel it was read from, never on a synthesized grid node: "Spatial
+object must be encoded at the true position. There is no 'sounding, out of position' in an ENC"
+(S-57 App B.1 Annex A UOC, Ed 4.4.0, §5.3). Cell size therefore sets the spacing, not the
+position, so the field is irregular over irregular ground — S-4 §B-410d's pattern.
+
+Per tile: read merged DEM (3857) in row strips -> a shoalest-wins PYRAMID (one cell grid per zoom
+level, each point valued and positioned by the shoalest wet pixel in its cell) -> keep points in
 the unbuffered tile bbox -> reproject to 4326 -> store/soundings/{stem}.geojsons (per-feature
-tippecanoe minzoom==maxzoom, so each zoom shows one even field, densifying inward). The vector
+tippecanoe minzoom==maxzoom, so each zoom shows one field, densifying inward). The vector
 bundle folds these into the `soundings` layer of the sharded variable-depth run (contour_run).
 
 Each field is also thinned by depth (SOUND_THIN_TIERS): a point deeper than a cutoff displays from
@@ -37,6 +42,7 @@ import sys
 
 import mercantile
 
+import config
 import landmask
 import utils
 
@@ -47,8 +53,12 @@ M_PER_FATHOM = 1.8288
 # ~constant across zoom). A native output tile is ~512 DEM px, so 64 → ~8x8 soundings per tile.
 # Smaller = denser everywhere. Env-tunable on a re-run.
 SOUND_CELL_PX = int(os.environ.get("SOUND_CELL_PX", "64"))
-# Drop soundings shallower than this (metres): near-waterline cells just read "0" and clutter.
-SOUND_MIN_DEPTH_M = float(os.environ.get("SOUND_MIN_DEPTH_M", "1.0"))
+# Drop soundings shallower than this (metres). S-4 B-410b puts least depths over shoals at the top
+# of what must survive selection, so this floor is set as low as the data supports, not as high as
+# is convenient. Measured on the four Gulf marsh fixtures (perf/soundings.py floor): admitted cells
+# grow smoothly from 1.0 m down to 0.1 m, then jump 2-5x at the 0.1 -> 0.0 step, which is the
+# waterline-noise regime. 0.2 m clears that with headroom and is a decimetre the DEM can defend.
+SOUND_MIN_DEPTH_M = float(os.environ.get("SOUND_MIN_DEPTH_M", "0.2"))
 # Depth-tiered thinning: at/beyond each cutoff a sounding rides a 2^shift coarser lattice at every
 # zoom, so deep water reads sparse (chart practice: dense over banks, sparse over the abyss) while
 # navigational depths keep full density. "depth_m:shift" pairs. Env-tunable on a re-run.
@@ -75,94 +85,294 @@ def _thin_shift(depth_pos):
     return s
 
 
-def _tc(minz, child_z):
+# Charted levels walked for enclosed shoals, positive-down metres. Bounded to the navigational
+# band: past it an enclosed rise is a seabed feature, not a least depth a vessel can touch, and
+# each level costs a labelling pass over the window.
+SHOAL_RING_MAX_DEPTH_M = 200.0
+SHOAL_RING_LEVELS = sorted(-l for l in config.CONTOUR_LEVELS
+                           if 0 < -l <= SHOAL_RING_MAX_DEPTH_M)
+
+
+def _ring_minzoom(level_pos):
+    """The zoom a charted level's isobath first draws at (contour_run.CONTOUR_TIERS holds
+    cumulative level sets per zoom band, so a level's minzoom is the floor of the first band
+    listing it; a level in no band draws only at/above the last ceiling).
+
+    A prime sounding inherits this: the least depth displays exactly where its enclosing ring
+    displays. B-410b's "must always be shown" is a claim about the charted feature — once
+    generalization drops the ring at a scale, the chart makes no claim there for the sounding to
+    complete. Promoting primes past their rings is what put decimetre least depths over the
+    generalized coastline of a 1:500k view."""
+    from contour_run import CONTOUR_TIERS   # lazy: sibling stage, imported for its display table
+    prev = 0
+    for ceil_z, lvls in CONTOUR_TIERS:
+        if -level_pos in lvls:
+            return prev
+        prev = ceil_z
+    return prev
+
+
+def _tc(minz, child_z, prime=False):
     """Per-feature tippecanoe zoom placement. Coarser levels swap out as the next
     finer field arrives (maxzoom == their own zoom). The finest level (minz ==
     child_z) declares NO maxzoom so it persists to the tileset max: child_z is the
     LOCAL best-source ceiling (z10 in Danish waters, z13+ where CUDEM reaches),
     and the global tileset tiles past it wherever any region goes deeper — capping
     at child_z blanked the layer there (soundings gone at z11+ over Denmark while
-    contours carried on)."""
+    contours carried on).
+
+    A prime sounding — the least depth inside a closed isobath — is never CAPPED, so it can never
+    be swapped out by a finer field as the mariner zooms in. Its minzoom is its enclosing
+    isobath's display zoom — see _ring_minzoom."""
+    if prime:
+        return {"minzoom": minz}
     return {"minzoom": minz} if minz == child_z else {"minzoom": minz, "maxzoom": minz}
+
+
+# S-4, Ed 4.10.0, B-412 rounds by depth band, always toward shoal: decimetres to 21 m, half metres
+# from 21 to 31, whole metres beyond.
+DECIMETRE_MAX_M = 21.0
+HALF_METRE_MAX_M = 31.0
+
+
+def _floor(x):
+    """Floor a quotient that should have landed on a whole number. 1.2192 / 0.3048 evaluates to
+    3.9999999999999996, and a bare floor charts that as 3 feet; 0.3 * 10 lands at 2.9999999999999996
+    and charts 0.2 m. A nanometre of slack recovers the intended digit and is far too small to turn
+    a genuinely deeper value into a shoaler chart number."""
+    return math.floor(x + 1e-9)
 
 
 def _depths(depth_pos):
     """Depth (metres, positive down) → chart labels, each floored toward shallower so the printed
-    number is never deeper than the surface. Metres carry one decimal in the shoal band (< 6 m,
-    chart practice) and a floored integer below it — a single display-ready value, so the viewer
-    just prints depth_m (no separate depth_dm)."""
+    number is never deeper than the surface (S-4 B-412).
+
+    Metres carry decimetres in the tenths slot where the band allows. Fathoms stay whole: a chart
+    sets fathoms-and-feet below 11 fathoms, but a fathom is exactly six feet, so the viewer derives
+    both from depth_ft rather than this shipping a mixed-radix number no reader could guess."""
+    if depth_pos < DECIMETRE_MAX_M:
+        m = _floor(depth_pos * 10) / 10
+    elif depth_pos < HALF_METRE_MAX_M:
+        m = _floor(depth_pos * 2) / 2
+    else:
+        m = _floor(depth_pos)
     return {
-        "depth_m": math.floor(depth_pos * 10) / 10 if depth_pos < 6 else int(math.floor(depth_pos)),
-        "depth_ft": int(math.floor(depth_pos / M_PER_FT)),
-        "depth_fm": int(math.floor(depth_pos / M_PER_FATHOM)),
+        "depth_m": int(m) if m == int(m) else m,   # integral values stay ints in the tiles
+        "depth_ft": _floor(depth_pos / M_PER_FT),
+        "depth_fm": _floor(depth_pos / M_PER_FATHOM),
     }
 
 
-def _jit(a, b):
-    """Deterministic pseudo-random in [0, 1) per cell (stable across rebuilds — no churn in the
-    incremental store), a seeded LCG like the seamap fork's jitter."""
-    s = ((a * 73856093) ^ (b * 19349663)) & 0xFFFFFFFF
-    s = (s * 1664525 + 1013904223) & 0xFFFFFFFF
-    return s / 0x100000000
+def _props(depth_pos, prime):
+    """Tile properties for one sounding. A least depth inside a closed isobath is the top of
+    S-4 B-410b's selection hierarchy, so the chart has to be able to SET it apart, not merely keep
+    it — `prime` is what lets the style weight it. Emitted only when true: an absent key costs a
+    vector tile nothing, and prime soundings are a small minority of the field."""
+    props = _depths(depth_pos)
+    if prime:
+        props["prime"] = 1
+    return props
 
 
 def _shoalest_grid(src, nodata, min_depth):
-    """Level-0 grid g[gy, gx] = shoalest depth (m, positive down) per SOUND_CELL_PX cell; NaN
-    where dry / no wet pixel / shallower than min_depth (near-waterline "0" clutter). Row-strip
-    reads bound peak memory to one strip, not the whole (multi-GB) DEM."""
+    """Per SOUND_CELL_PX cell, the shoalest wet pixel: depth (m, positive down) in g[gy, gx] and
+    that pixel's own DEM column/row in cx/cy. NaN where dry / no wet pixel / shallower than
+    min_depth (near-waterline "0" clutter). Row-strip reads bound peak memory to one strip, not
+    the whole (multi-GB) DEM.
+
+    The location travels with the depth because a sounding is charted at the position it was
+    measured — "Spatial object must be encoded at the true position. There is no 'sounding, out
+    of position' in an ENC" (S-57 App B.1 Annex A UOC, Ed 4.4.0, §5.3)."""
     import numpy as np
     from rasterio.windows import Window
     W, H = src.width, src.height
-    g = np.full(((H + SOUND_CELL_PX - 1) // SOUND_CELL_PX,
-                 (W + SOUND_CELL_PX - 1) // SOUND_CELL_PX), np.nan)
+    shape = ((H + SOUND_CELL_PX - 1) // SOUND_CELL_PX,
+             (W + SOUND_CELL_PX - 1) // SOUND_CELL_PX)
+    g = np.full(shape, np.nan)
+    cx = np.full(shape, np.nan)
+    cy = np.full(shape, np.nan)
     for gy, r0 in enumerate(range(0, H, SOUND_CELL_PX)):
         h = min(SOUND_CELL_PX, H - r0)
         strip = src.read(1, window=Window(0, r0, W, h))
         for gx, c0 in enumerate(range(0, W, SOUND_CELL_PX)):
             block = strip[:, c0:c0 + SOUND_CELL_PX]
             wet = (block != nodata) & (block < 0)
-            if wet.any():
-                depth = -float(block[wet].max())
-                if depth >= min_depth:
-                    g[gy, gx] = depth
-    return g
+            if not wet.any():
+                continue
+            # Shoalest = greatest (least negative) elevation among wet pixels; -inf parks the
+            # dry ones so argmax can't pick them.
+            by, bx = np.unravel_index(np.argmax(np.where(wet, block, -np.inf)), block.shape)
+            depth = -float(block[by, bx])
+            if depth >= min_depth:
+                g[gy, gx] = depth
+                cx[gy, gx] = c0 + bx + 0.5   # pixel centre, in DEM pixel coordinates
+                cy[gy, gx] = r0 + by + 0.5
+    return g, cx, cy
 
 
-def _reduce_shoalest(g):
-    """2x2 shoalest (minimum positive-down depth) reduction → the next coarser level, NaN-aware
-    (an all-dry quad stays NaN)."""
+# Working size cap for enclosed-shoal detection, in pixels per side. The window itself is never
+# held whole — a z8 stem at cz14 is 32768 px square, 4.3 GB as float32 — so detection reads a
+# decimated overview and refines each hit at full resolution.
+SHOAL_DETECT_PX = 4096
+
+
+# Working size cap for enclosed-shoal detection, in pixels per side. The window is never held
+# whole — a z8 stem at cz14 is 32898 px square, 4.33 GB as float32 — so detection runs on one
+# decimated read bounded to this.
+SHOAL_DETECT_PX = 4096
+
+
+def _enclosed_shoals(src, nodata, min_depth, levels, view):
+    """The least depth inside every closed isobath, as [(depth, col, row, ring_minzoom)],
+    positions in full-res DEM pixels.
+
+    S-4, Ed 4.10.0, B-410b puts "least depths over shoals, banks and sills" at the top of what
+    must survive selection, and a closed contour with no sounding on it is a charted shoal with no
+    charted least depth — a mariner interpolating across the ring reads the ring's own level and
+    the shoal is understated. Measured on the terrebonne fixture before this existed: 4 of 4 shoal
+    rings carried no sounding, understating by up to 1.30 m.
+
+    A closed isobath at level L is the boundary of a connected component of {depth < L} that does
+    not reach the window edge, so this reads off the DEM and needs no contour file — soundings
+    stay a sibling of the contour stage rather than becoming its child. Using the same config
+    levels the contours are cut at is what makes the two agree.
+
+    Detection and position come from two different structures, because neither alone works:
+
+    - Detection needs resolution finer than the sounding cell. A cell spans ~150 m and these
+      rings are ~70 m across, so labelling the cell grid loses every one of them. One decimated
+      read, capped at SHOAL_DETECT_PX a side, resolves them at flat cost for any stem.
+    - Position must be a pixel that was actually measured (S-57 App B.1 Annex A UOC, Ed 4.4.0,
+      §5.3), and a decimated pixel is not one. It comes from the cell grid, which already carries
+      each cell's shoalest pixel and that pixel's own coordinates.
+
+    Re-reading the raster per component to find an exact peak was tried and is what made this
+    unshippable: the windows have no overviews, so thousands of small full-res reads grind the
+    whole 4.33 GB file over and over. Nothing here reads the raster more than once.
+
+    Only the metric ladder is walked. A fathom curve encircles the same physical shoal and would
+    resolve to the same peak, which the caller dedupes anyway.
+    """
     import numpy as np
-    ny, nx = g.shape
-    gp = np.full((ny + ny % 2, nx + nx % 2), np.nan)
-    gp[:ny, :nx] = g
-    quads = np.stack([gp[0::2, 0::2], gp[0::2, 1::2], gp[1::2, 0::2], gp[1::2, 1::2]])
-    with np.errstate(invalid="ignore"):
-        return np.where(np.isnan(quads).all(0), np.nan, np.nanmin(quads, axis=0))
+    from scipy.ndimage import find_objects, label
+    from rasterio.windows import Window
+
+    small, wet, k = view
+    dh, dw = small.shape
+    W, H = src.width, src.height
+    depth = np.where(wet, -small, np.inf)
+    peaks = []
+    for lvl in levels:
+        mask = wet & (depth < lvl)
+        if not mask.any():
+            continue
+        lab, n = label(mask)
+        if n == 0:
+            continue
+        # A component touching the edge is not enclosed by anything we can see — its isobath
+        # continues into the neighbouring tile, where that tile charts it.
+        edge = set(np.unique(np.concatenate([lab[0], lab[-1], lab[:, 0], lab[:, -1]])).tolist())
+        for lb, box in enumerate(find_objects(lab), start=1):
+            if lb in edge or box is None:
+                continue
+            ys, xs = box
+            # Shoalest DECIMATED pixel of this component, from the array already in memory.
+            win = lab[ys, xs] == lb
+            sub = np.where(win, small[ys, xs], -np.inf)
+            dy, dx = np.unravel_index(np.argmax(sub), sub.shape)
+            if not np.isfinite(sub[dy, dx]):
+                continue
+            peaks.append((ys.start + int(dy), xs.start + int(dx), lvl))
+
+    # A decimated pixel is not a measured position, so each peak is pinned by ONE small full-res
+    # read of a box just wider than the decimation — a couple of raster blocks, not the component
+    # (reading whole component boxes on these overview-less 4.33 GB windows is what OOMed).
+    out = {}
+    pad = k + 1
+    for dy, dx, lvl in peaks:
+        r0, c0 = max(0, dy * k - pad), max(0, dx * k - pad)
+        r1, c1 = min(H, dy * k + k + pad), min(W, dx * k + k + pad)
+        fine = src.read(1, window=Window(c0, r0, c1 - c0, r1 - r0))
+        fwet = (fine != nodata) & (fine < 0)
+        if not fwet.any():
+            continue
+        by, bx = np.unravel_index(np.argmax(np.where(fwet, fine, -np.inf)), fine.shape)
+        d = -float(fine[by, bx])
+        if d >= min_depth:
+            # Same peak reached from several levels collapses on its pixel position, keeping the
+            # earliest-drawing (deepest) enclosing ring's zoom.
+            key = (c0 + bx + 0.5, r0 + by + 0.5)
+            rmz = _ring_minzoom(lvl)
+            if key not in out or rmz < out[key][1]:
+                out[key] = (d, rmz)
+    return [(d, c, r, rmz) for (c, r), (d, rmz) in out.items()]
+
+
+def _reduce_shoalest(g, cx, cy):
+    """2x2 shoalest (minimum positive-down depth) reduction → the next coarser level, carrying the
+    winning cell's pixel location with it so the coarse sounding keeps the true position of the
+    shoal it represents. NaN-aware (an all-dry quad stays NaN)."""
+    import numpy as np
+
+    def quads(a):
+        ny, nx = a.shape
+        p = np.full((ny + ny % 2, nx + nx % 2), np.nan)
+        p[:ny, :nx] = a
+        return np.stack([p[0::2, 0::2], p[0::2, 1::2], p[1::2, 0::2], p[1::2, 1::2]])
+
+    qg = quads(g)
+    allnan = np.isnan(qg).all(0)
+    win = np.argmin(np.where(np.isnan(qg), np.inf, qg), axis=0)[None]
+    pick = lambda q: np.where(allnan, np.nan, np.take_along_axis(q, win, 0)[0])
+    return pick(qg), pick(quads(cx)), pick(quads(cy))
 
 
 def _pyramid(src, nodata, bbox, min_depth, z, child_z):
-    """A staggered-grid pyramid: for each zoom level, a quincunx grid at that level's spacing, each
-    point valued by the SHOALEST wet pixel in its block (so a block's shoal is never hidden at
-    coarse zoom) and placed on a per-row-offset lattice jittered into the cell — an even, chart-
-    like field at EVERY zoom. (A single baked stagger can't do that: uniform decimation drops the
-    offset rows at coarse zoom, leaving a square grid — the reason a per-level pyramid is needed.)
+    """A shoalest-wins pyramid: for each zoom level, one sounding per cell at that level's spacing,
+    valued by the SHOALEST wet pixel in the cell (so a cell's shoal is never hidden at coarse zoom)
+    and placed AT that pixel — the depth and the position describe the same spot, which is what
+    makes the field chart-legal rather than a decorative lattice. Cell size sets the spacing;
+    within a cell the point sits wherever the shoal actually is, so the pattern is irregular over
+    irregular ground and even over flat ground, as S-4 §B-410d describes.
     Deep points display SHIFTED: a point at/beyond a SOUND_THIN_TIERS cutoff shows each zoom from a
-    2^shift coarser level (its finest levels never display), so deep water thins at every zoom while
-    the lattice stays an even quincunx. The pyramid extends max-shift extra levels so the coarsest
-    displayed zoom still gets a (thinned) deep field.
-    Returns [(depth_pos, x3857, y3857, display_z)] with display_z==maxzoom per level, so each zoom
-    shows exactly one field and it densifies as you zoom in."""
+    2^shift coarser level (its finest levels never display), so deep water thins at every zoom.
+    The pyramid extends max-shift extra levels so the coarsest displayed zoom still gets a
+    (thinned) deep field.
+    Alongside the lattice, the least depth inside every closed isobath is emitted as a PRIME
+    sounding, which displays at every zoom of the tile rather than riding a pyramid level: those
+    are the depths S-4 B-410b says must always be shown, and the graduated SCAMIN policy puts the
+    most significant soundings at the top of the ladder (S-57 App B.1 Annex A UOC, Ed 4.4.0,
+    table 2.5).
+    Returns [(depth_pos, x3857, y3857, display_z, prime)] — for lattice points display_z is that
+    level's maxzoom, so each zoom shows exactly one field and it densifies as you zoom in."""
     import numpy as np
     transform = src.transform
-    g = _shoalest_grid(src, nodata, min_depth)
     pts = []
+    in_bbox = lambda x, y: bbox.left <= x <= bbox.right and bbox.bottom <= y <= bbox.top
+
+    # ONE decimated read, shared with ring detection; the DEM is
+    # never held whole (a z8 stem at cz14 is 4.33 GB as float32).
+    W, H = src.width, src.height
+    k = max(1, -(-max(W, H) // SHOAL_DETECT_PX))
+    small = src.read(1, out_shape=(max(1, H // k), max(1, W // k)))
+    wet = (small != nodata) & (small < 0)
+    view = (small, wet, k)
+
+    # The cell grid is the only other full-window structure, and it is 1/SOUND_CELL_PX a side.
+    g, cx, cy = _shoalest_grid(src, nodata, min_depth)
+
+    for d, c, r, rmz in _enclosed_shoals(src, nodata, min_depth, SHOAL_RING_LEVELS, view):
+        x, y = transform * (c, r)        # a measured pixel centre, carried by the grid
+        if in_bbox(x, y):
+            # Displays exactly where its enclosing isobath displays (_ring_minzoom); never
+            # capped, so the least depth accompanies the ring at every zoom the ring survives.
+            pts.append((float(d), x, y, max(z, rmz), True))
+
     max_shift = max((s for _, s in SOUND_THIN_TIERS), default=0)
     for level in range(max(0, child_z - z) + 1 + max_shift):
-        cell = SOUND_CELL_PX * (1 << level)
         minz = child_z - level
         ny, nx = g.shape
         for gy in range(ny):
-            stagger = cell * 0.5 if gy % 2 else 0.0  # offset odd rows → quincunx at this level
             for gx in range(nx):
                 d = g[gy, gx]
                 if np.isnan(d):
@@ -170,12 +380,10 @@ def _pyramid(src, nodata, bbox, min_depth, z, child_z):
                 disp = minz + _thin_shift(d)
                 if not z <= disp <= child_z:
                     continue
-                cx = gx * cell + stagger + cell * (0.25 + 0.5 * _jit(gx, gy))  # jitter, middle half
-                cy = gy * cell + cell * (0.25 + 0.5 * _jit(gy, gx))
-                x, y = transform * (cx, cy)
-                if bbox.left <= x <= bbox.right and bbox.bottom <= y <= bbox.top:
-                    pts.append((float(d), x, y, disp))
-        g = _reduce_shoalest(g)
+                x, y = transform * (cx[gy, gx], cy[gy, gx])
+                if in_bbox(x, y):
+                    pts.append((float(d), x, y, disp, False))
+        g, cx, cy = _reduce_shoalest(g, cx, cy)
     return pts
 
 
@@ -194,12 +402,12 @@ def _sound_dem(dem, tile_obj, z, child_z, tmp, label):
 
     to4326 = Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True)
     feats = []
-    for d, x3857, y3857, minz in pts:
+    for d, x3857, y3857, minz, prime in pts:
         lon, lat = to4326.transform(x3857, y3857)
-        # Each level shows at exactly one zoom (one clean staggered field per zoom);
+        # Each level shows at exactly one zoom (one field per zoom);
         # the finest level rides uncapped to the tileset max — see _tc.
-        feats.append({"type": "Feature", "tippecanoe": _tc(minz, child_z),
-                      "properties": _depths(d),
+        feats.append({"type": "Feature", "tippecanoe": _tc(minz, child_z, prime),
+                      "properties": _props(d, prime),
                       "geometry": {"type": "Point", "coordinates": [round(lon, 6), round(lat, 6)]}})
 
     final = f"{tmp}/soundings.geojsons"
@@ -238,18 +446,32 @@ def tile(stem):
 
 
 def _check():
-    """Grid shoalest per cell; <min_depth dropped; 2x2 reduction keeps the shoalest; the pyramid
-    staggers each zoom into a quincunx and carries a block's shoal up to coarse zoom; depth floors
-    shallower with one decimal in the shoal band."""
+    """Grid shoalest per cell; <min_depth dropped; 2x2 reduction keeps the shoalest and its
+    pixel; the pyramid places every sounding on that pixel and carries a cell's shoal up to coarse
+    zoom; depth floors shallower with one decimal in the shoal band."""
     import tempfile
     import numpy as np
     import rasterio
     from rasterio.transform import from_origin
 
-    # metres: one decimal in the shoal band (<6 m), floored int above; never rounds deeper
-    assert _depths(9.8)["depth_m"] == 9 and _depths(9.8)["depth_ft"] == 32
-    assert _depths(3.94)["depth_m"] == 3.9 and _depths(5.0)["depth_m"] == 5.0
+    # S-4 B-412 bands, always floored toward shoal: decimetres to 21 m, half metres to 31, whole
+    # metres beyond. Feet are whole throughout.
+    assert _depths(3.94)["depth_m"] == 3.9 and _depths(9.8)["depth_m"] == 9.8
+    assert _depths(20.99)["depth_m"] == 20.9, _depths(20.99)["depth_m"]
+    assert _depths(23.49)["depth_m"] == 23 and _depths(23.81)["depth_m"] == 23.5   # B-412's example
+    assert _depths(31.85)["depth_m"] == 31 and _depths(30.99)["depth_m"] == 30.5
+    assert _depths(5.0)["depth_m"] == 5.0 and _depths(9.8)["depth_ft"] == 32
     assert "depth_dm" not in _depths(3.0)   # collapsed into depth_m
+
+    # A fathom is exactly six feet, so the viewer reads fathoms-and-feet off depth_ft; the tiles
+    # only owe it whole feet. 3 fm 4 ft is 3*1.8288 + 4*0.3048 = 6.7056 m = 22 ft.
+    assert _depths(6.7056)["depth_ft"] == 22 and _depths(6.7056)["depth_fm"] == 3
+    assert _depths(1.8287)["depth_ft"] == 5     # just under 1 fathom is 5 feet, never 6
+    for d in (0.3, 2.7, 6.7056, 20.9, 25.0, 100.0):           # never chart deeper than the ground
+        r = _depths(d)
+        assert r["depth_m"] <= d + 1e-9
+        assert r["depth_ft"] * M_PER_FT <= d + 1e-9
+        assert r["depth_fm"] * M_PER_FATHOM <= d + 1e-9
 
     # 256x256 DEM (2x2 cells at CELL=128): deep -100 except a -3 m shoal in cell (gx1,gy1); cell
     # (0,0) a <1 m near-waterline patch (drop); a NODATA hole must never sound.
@@ -269,23 +491,57 @@ def _check():
     from types import SimpleNamespace
     bbox = SimpleNamespace(left=0, bottom=0, right=25600, top=25600)
     with rasterio.open(p) as src:
-        g = _shoalest_grid(src, NODATA, 1.0)
+        g, cx, cy = _shoalest_grid(src, NODATA, 1.0)
     assert np.isnan(g[0, 0])                        # <1 m patch dropped
     assert g[1, 1] == 3.0 and g[0, 1] == 100.0      # shoalest per cell
-    assert _reduce_shoalest(g).tolist() == [[3.0]]  # 2x2 shoalest = the -3 m
+    assert (cx[1, 1], cy[1, 1]) == (200.5, 200.5)   # the -3 m pixel itself, not the cell centre
+    rg, rcx, rcy = _reduce_shoalest(g, cx, cy)
+    assert rg.tolist() == [[3.0]]                   # 2x2 shoalest = the -3 m
+    assert (rcx[0, 0], rcy[0, 0]) == (200.5, 200.5) # …and it keeps that pixel's position
 
     with rasterio.open(p) as src:
         pts = _pyramid(src, NODATA, bbox, 1.0, z=8, child_z=9)  # level 0 (z9) + level 1 (z8)
     assert all(d >= 1.0 for d, *_ in pts)                       # no near-waterline "0"
-    shoal0 = next(x for d, x, y, mz in pts if mz == 9 and d == 3.0)
-    assert shoal0 >= 22400                                      # odd row (gy=1) → staggered right
-    assert min(d for d, x, y, mz in pts if mz == 8) == 3.0      # block shoal survives to coarse zoom
-    assert _jit(1, 1) == _jit(1, 1) and 0 <= _jit(3, 7) < 1     # jitter deterministic + in range
+    # true position: the -3 m sounding lands on the -3 m pixel at both zooms it appears at
+    want = tr * (200.5, 200.5)
+    for zoom in (8, 9):
+        got = next((x, y) for d, x, y, mz, _p in pts if mz == zoom and d == 3.0)
+        assert got == want, f"z{zoom} shoal at {got}, want the source pixel {want}"
+
+    # prime rides to the tiles as a property so the style can weight it; an ordinary sounding
+    # carries no key at all, so it costs the tiles nothing.
+    assert _props(3.0, True) == {"depth_m": 3, "depth_ft": 9, "depth_fm": 1, "prime": 1}
+    assert "prime" not in _props(3.0, False)
 
     # zoom placement: coarser levels swap out at their own zoom; the finest level
     # (minz == child_z) is uncapped so it persists above the local source ceiling
     assert _tc(8, 10) == {"minzoom": 8, "maxzoom": 8}
     assert _tc(10, 10) == {"minzoom": 10}
+    assert _tc(8, 10, prime=True) == {"minzoom": 8}   # a least depth is never capped
+    # …but never past its ring: a prime's minzoom is its enclosing isobath's display zoom.
+    # Here the deepest enclosing ring (50 m) draws from z7, so the base zoom (8) binds.
+    with rasterio.open(p) as src:
+        promoted = {mz for _d, _x, _y, mz, pr in
+                    _pyramid(src, NODATA, bbox, 1.0, z=8, child_z=9) if pr}
+    assert promoted == {8}, promoted
+
+    # Enclosed shoals run on the CELL GRID, never the pixels — the whole window is never held in
+    # memory (a z8 stem at cz14 would be 4.3 GB). Synthesized directly: a 20 m field with a 3 m
+    # rise in the middle, and a second rise pressed against the edge.
+    with rasterio.open(p) as src:
+        _k = 1
+        _small = src.read(1)
+        found = _enclosed_shoals(src, NODATA, 1.0, [5.0, 20.0],
+                                 (_small, (_small != NODATA) & (_small < 0), _k))
+    # The -3 m pinnacle is enclosed by the 5 m and 20 m levels, and is reported at its OWN pixel
+    # (not a decimated approximation) with its deepest ring's display zoom (20 m -> z9).
+    assert any(f[:3] == (3.0, 200.5, 200.5) and f[3] == 9 for f in found), found
+    # The <1 m patch fills cell (0,0) out to two window edges, so no isobath closes around it.
+    assert not any(c < 128 and r < 128 for _d, c, r, _mz in found), found
+
+    # Ring display zooms come straight off contour_run.CONTOUR_TIERS (cumulative bands).
+    assert [_ring_minzoom(l) for l in (200, 50, 10, 2)] == [0, 7, 9, 11]
+
 
     # depth-tiered thinning: the tier a depth falls in, at and just under each cutoff
     assert [_thin_shift(d) for d in (0, 99, 199.9, 200, 999, 1000, 5000)] == [0, 0, 0, 1, 1, 2, 2]
@@ -309,7 +565,7 @@ def _check():
         with rasterio.open(q) as src:
             pts = _pyramid(src, NODATA, whole, 1.0, z, child_z)
         counts = {}
-        for *_, dz in pts:
+        for _d, _x, _y, dz, _p in pts:
             counts[dz] = counts.get(dz, 0) + 1
         return counts
 
@@ -339,12 +595,14 @@ def _check():
     with rasterio.open(m) as src:
         mixed = _pyramid(src, NODATA, span, 1.0, z=8, child_z=9)
     for dz in (8, 9):
-        assert any(d == 190.0 and mz == dz for d, x, y, mz in mixed), \
+        assert any(d == 190.0 and mz == dz for d, _x, _y, mz, _p in mixed), \
             f"the 190 m shoal must display at z{dz}"
     # the plain still shows where its shifted lattice has cells the shoal didn't claim (z9 here);
     # at z8 the whole field's coarse representative IS the shoal — deep is what gets suppressed
-    assert any(d == 1200.0 and mz == 9 for d, x, y, mz in mixed)
-    assert all(d == 190.0 for d, x, y, mz in mixed if mz == 8)
+    assert any(d == 1200.0 and mz == 9 for d, _x, _y, mz, _p in mixed)
+    assert all(d == 190.0 for d, _x, _y, mz, _p in mixed if mz == 8)
+    # …and the shoal is enclosed by the 200 m isobath, so it is also charted as a prime sounding
+    assert any(d == 190.0 and p for d, _x, _y, _mz, p in mixed), "enclosed 190 m shoal must be prime"
     print("soundings_run self-check ok")
 
 

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -112,7 +112,162 @@ def _ring_minzoom(level_pos):
     return prev
 
 
-def _tc(minz, child_z, prime=False):
+# ── Error-driven repair (S-4 B-410a as the selector, not just the gate) ─────────────────────
+# After the lattice + primes, each display zoom's field is tested by interpolation against the
+# DEM and repaired where it lies: a pixel shoaler than the charted field implies is the B-410a
+# safety direction (tight tolerance); a pixel much deeper is the B-403.1a "full range of depth"
+# direction (loose tolerance — this is what makes a dredged channel's deep line appear, with no
+# thalweg extraction — measured on the New York window: 26 insertions at 26-31 m through the
+# ~10 m ambient of the Ambrose corridor, including the Narrows scour, from the deep rule alone).
+# Insertions land at their measured pixel with the repaired zoom as minzoom,
+# so a sounding's minzoom is the coarsest zoom that needed it — significance grading by
+# construction. All knobs env-tunable on a re-run; SOUND_REPAIR=0 leaves the field as built.
+SOUND_REPAIR = os.environ.get("SOUND_REPAIR", "1") == "1"
+# Shoal-side: insert where ground is shoaler than interpolation by more than this (fraction of
+# charted depth, with an absolute floor to ride over DEM noise). OFF by default: B-410a's mariner
+# interpolates from soundings AND contours, and with the isobaths charted (cut from this same DEM)
+# the measured shoal residual at charted precision is 0.08% before any repair — while a
+# soundings-only interpolant manufactures shoal "violations" in the tent around every deep
+# insertion, cascading pitch-spaced points zoom after zoom (measured: every zoom capped out and
+# z13 nearest-neighbour medians of 0.5 px). The shoal side is already guarded by the shoalest-
+# per-cell lattice, the prime rings, and the band tints; enable for a source where those fail.
+REPAIR_SHOAL = os.environ.get("REPAIR_SHOAL", "0") == "1"
+REPAIR_SHOAL_ABS_M = float(os.environ.get("REPAIR_SHOAL_ABS_M", "0.5"))
+REPAIR_SHOAL_FRAC = float(os.environ.get("REPAIR_SHOAL_FRAC", "0.10"))
+# Deep-side: insert where ground is deeper than interpolation by more than this.
+REPAIR_DEEP_ABS_M = float(os.environ.get("REPAIR_DEEP_ABS_M", "2.0"))
+REPAIR_DEEP_FRAC = float(os.environ.get("REPAIR_DEEP_FRAC", "0.5"))
+# Minimum screen-px spacing (at the zoom being repaired) between an insertion and any sounding
+# already displayed there. 0 = no spacing constraint (label collision is the only thinning).
+REPAIR_SPACING_PX = float(os.environ.get("REPAIR_SPACING_PX", "8"))
+# One pass per zoom, judged against the field as it stood — iterating re-judges against the
+# freshly inserted points, and each deep insertion tents the interpolant into shoal-side
+# "violations" around itself (and vice versa), a seesaw that piled 3,400 sub-pixel points onto
+# the marsh fixture without converging. The cap is a runaway guard, not a tuning knob.
+REPAIR_BATCH = int(os.environ.get("REPAIR_BATCH", "400"))
+_M_PER_PX_Z0 = 40075016.685578488 / 512   # 3857 metres per 512px-tile screen pixel at z0
+
+
+# Sounding kinds: how a point entered the field decides its zoom capping and tile properties.
+KIND_LATTICE = 0   # capped to its pyramid level, except the finest level
+KIND_PRIME = 1     # least depth in a closed isobath: uncapped, carries prime=1
+KIND_REPAIR = 2    # B-410a/B-403.1a insertion: uncapped from the zoom that needed it
+
+
+def _displayed_at(pts, zoom, child_z):
+    """Indices of pts displayed at `zoom` under _tc's placement: capped lattice levels show at
+    exactly their zoom; primes and repair insertions ride uncapped from their minzoom."""
+    out = []
+    for i, (_d, _x, _y, mz, kind) in enumerate(pts):
+        uncapped = kind != KIND_LATTICE or mz >= child_z
+        if (uncapped and zoom >= mz) or (not uncapped and zoom == mz):
+            out.append(i)
+    return out
+
+
+def _repair(src, nodata, bbox, pts, z, child_z):
+    """Per display zoom, coarse to fine: interpolate the displayed field, find where the DEM
+    contradicts it beyond tolerance, insert the offending ground at its measured pixel, repeat.
+    Inserted soundings are uncapped from the repaired zoom, so they join every finer field.
+    Returns (pts, per-zoom insertion counts)."""
+    import numpy as np
+    from scipy.interpolate import LinearNDInterpolator
+    from rasterio.windows import Window
+
+    transform = src.transform
+    W, H = src.width, src.height
+    k = max(1, -(-max(W, H) // SHOAL_DETECT_PX))
+    small = src.read(1, out_shape=(max(1, H // k), max(1, W // k)))
+    wet = (small != nodata) & (small < 0)
+    rows, cols = np.nonzero(wet)
+    sx, sy = transform * (cols * k + k / 2.0, rows * k + k / 2.0)
+    inb = (sx >= bbox.left) & (sx <= bbox.right) & (sy >= bbox.bottom) & (sy <= bbox.top)
+    rows, cols, sx, sy = rows[inb], cols[inb], sx[inb], sy[inb]
+    actual = -small[rows, cols].astype(float)
+
+    def pin(r, c, shoal, want=None):
+        """One small full-res read around decimated pixel (r, c) -> a measured pixel.
+
+        Shoal-side takes the shoalest pixel: understating depth is the safe error. Deep-side
+        takes the pixel CLOSEST to the decimated value instead — pinning extremes mints sharp
+        control points whose own interpolation tents then violate the opposite tolerance, and
+        the repair chases its tail (measured: marsh shoal violations rose 0.08% -> 6.6% while
+        3,600 points piled in at sub-pixel pitch)."""
+        pad = k + 1
+        r0, c0 = max(0, r * k - pad), max(0, c * k - pad)
+        r1, c1 = min(H, r * k + k + pad), min(W, c * k + k + pad)
+        fine = src.read(1, window=Window(c0, r0, c1 - c0, r1 - r0))
+        fwet = (fine != nodata) & (fine < 0)
+        if not fwet.any():
+            return None
+        if shoal:
+            pick = np.where(fwet, fine, -np.inf)
+            by, bx = np.unravel_index(np.argmax(pick), fine.shape)
+        else:
+            pick = np.where(fwet, np.abs(-fine - want), np.inf)
+            by, bx = np.unravel_index(np.argmin(pick), fine.shape)
+        return -float(fine[by, bx]), c0 + bx + 0.5, r0 + by + 0.5
+
+    inserted = {}
+    for zoom in range(z, child_z + 1):
+        spacing_m = REPAIR_SPACING_PX * _M_PER_PX_Z0 / (1 << zoom)
+        idx = _displayed_at(pts, zoom, child_z)
+        if len(idx) < 3:
+            continue
+        fx = np.array([pts[i][1] for i in idx]); fy = np.array([pts[i][2] for i in idx])
+        fd = np.array([pts[i][0] for i in idx])
+        expected = LinearNDInterpolator(np.column_stack([fx, fy]), fd)(
+            np.column_stack([sx, sy]))
+        ok = ~np.isnan(expected)
+        shoal_err = np.where(ok, expected - actual, -np.inf)   # >0: ground shoaler than charted
+        deep_err = np.where(ok, actual - expected, -np.inf)    # >0: ground deeper than charted
+        shoal_bad = (shoal_err > np.maximum(REPAIR_SHOAL_ABS_M, REPAIR_SHOAL_FRAC * actual)) \
+            if REPAIR_SHOAL else np.zeros_like(shoal_err, dtype=bool)
+        deep_bad = (deep_err > np.maximum(REPAIR_DEEP_ABS_M, REPAIR_DEEP_FRAC * actual)) \
+            & (actual <= SHOAL_RING_MAX_DEPTH_M)
+        # Deep-side repair stops at the navigational band. B-403.1a's "full range of depth"
+        # is about navigable water — a channel, an anchorage; abyssal slope texture belongs
+        # to contours and the relief. Without the bound the flat-deep control fixture drew
+        # 1,018 insertions (99% closer together than a label) bounding 3,000 m slopes.
+        err = np.where(shoal_bad, shoal_err, np.where(deep_bad, deep_err, -np.inf))
+        order = np.argsort(-err)
+        order = order[err[order] > 0]
+        if not order.size:
+            continue
+        # Greedy, worst first: a DEEP insertion must clear the spacing floor against the
+        # displayed field and this pass's own insertions — it exists for legibility, so
+        # legibility may thin it. A SHOAL insertion is safety data (B-410a): spacing never
+        # suppresses it, only the decimation pitch dedupes it, and label collision resolves
+        # crowding at render time with the shoalest number winning.
+        taken = []
+        fxy = np.column_stack([fx, fy])
+        pitch = k * abs(transform.a)
+        for j in order:
+            px_, py_ = sx[j], sy[j]
+            floor_m = pitch if shoal_bad[j] else max(spacing_m, pitch)
+            # Both sides keep at least the decimation pitch from the existing field: a shoal
+            # violation within a pitch of a charted sounding is a near-duplicate of it, not a
+            # suppressed hazard, and without this each zoom's pass stacks sub-pixel shoal points
+            # around the previous zoom's deep insertions (measured: NN medians of 0.5 px at z13).
+            if np.hypot(fxy[:, 0] - px_, fxy[:, 1] - py_).min() < floor_m:
+                continue
+            if any((px_ - tx) ** 2 + (py_ - ty) ** 2 < floor_m * floor_m for tx, ty in taken):
+                continue
+            got = pin(int(rows[j]), int(cols[j]), bool(shoal_bad[j]), want=float(actual[j]))
+            if got is None or got[0] < SOUND_MIN_DEPTH_M:
+                continue
+            d, pc, pr = got
+            x, y = transform * (pc, pr)
+            pts.append((d, x, y, zoom, KIND_REPAIR))
+            taken.append((x, y))
+            if len(taken) >= REPAIR_BATCH:
+                break
+        if taken:
+            inserted[zoom] = len(taken)
+    return pts, inserted
+
+
+def _tc(minz, child_z, kind=KIND_LATTICE):
     """Per-feature tippecanoe zoom placement. Coarser levels swap out as the next
     finer field arrives (maxzoom == their own zoom). The finest level (minz ==
     child_z) declares NO maxzoom so it persists to the tileset max: child_z is the
@@ -121,10 +276,12 @@ def _tc(minz, child_z, prime=False):
     at child_z blanked the layer there (soundings gone at z11+ over Denmark while
     contours carried on).
 
-    A prime sounding — the least depth inside a closed isobath — is never CAPPED, so it can never
-    be swapped out by a finer field as the mariner zooms in. Its minzoom is its enclosing
-    isobath's display zoom — see _ring_minzoom."""
-    if prime:
+    A prime sounding (least depth inside a closed isobath) is never CAPPED, so it can never be
+    swapped out by a finer field as the mariner zooms in; its minzoom is its enclosing isobath's
+    display zoom (_ring_minzoom). A repair insertion is likewise uncapped: it exists because the
+    field failed B-410a/B-403.1a at its minzoom, and the finer fields it joins only interpolate
+    better for having it."""
+    if kind != KIND_LATTICE:
         return {"minzoom": minz}
     return {"minzoom": minz} if minz == child_z else {"minzoom": minz, "maxzoom": minz}
 
@@ -163,13 +320,13 @@ def _depths(depth_pos):
     }
 
 
-def _props(depth_pos, prime):
+def _props(depth_pos, kind):
     """Tile properties for one sounding. A least depth inside a closed isobath is the top of
     S-4 B-410b's selection hierarchy, so the chart has to be able to SET it apart, not merely keep
     it — `prime` is what lets the style weight it. Emitted only when true: an absent key costs a
     vector tile nothing, and prime soundings are a small minority of the field."""
     props = _depths(depth_pos)
-    if prime:
+    if kind == KIND_PRIME:
         props["prime"] = 1
     return props
 
@@ -366,7 +523,7 @@ def _pyramid(src, nodata, bbox, min_depth, z, child_z):
         if in_bbox(x, y):
             # Displays exactly where its enclosing isobath displays (_ring_minzoom); never
             # capped, so the least depth accompanies the ring at every zoom the ring survives.
-            pts.append((float(d), x, y, max(z, rmz), True))
+            pts.append((float(d), x, y, max(z, rmz), KIND_PRIME))
 
     max_shift = max((s for _, s in SOUND_THIN_TIERS), default=0)
     for level in range(max(0, child_z - z) + 1 + max_shift):
@@ -382,7 +539,7 @@ def _pyramid(src, nodata, bbox, min_depth, z, child_z):
                     continue
                 x, y = transform * (cx[gy, gx], cy[gy, gx])
                 if in_bbox(x, y):
-                    pts.append((float(d), x, y, disp, False))
+                    pts.append((float(d), x, y, disp, KIND_LATTICE))
         g, cx, cy = _reduce_shoalest(g, cx, cy)
     return pts
 
@@ -396,18 +553,22 @@ def _sound_dem(dem, tile_obj, z, child_z, tmp, label):
     with rasterio.open(dem) as src:
         nodata = src.nodata if src.nodata is not None else NODATA
         pts = _pyramid(src, nodata, bbox, SOUND_MIN_DEPTH_M, z, child_z)
+        if SOUND_REPAIR and pts:
+            pts, ins = _repair(src, nodata, bbox, pts, z, child_z)
+            if ins:
+                print(f"repair {label}: " + " ".join(f"z{k}+{v}" for k, v in sorted(ins.items())))
     if not pts:
         print(f"soundings: no wet cells for {label}")
         return None
 
     to4326 = Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True)
     feats = []
-    for d, x3857, y3857, minz, prime in pts:
+    for d, x3857, y3857, minz, kind in pts:
         lon, lat = to4326.transform(x3857, y3857)
         # Each level shows at exactly one zoom (one field per zoom);
-        # the finest level rides uncapped to the tileset max — see _tc.
-        feats.append({"type": "Feature", "tippecanoe": _tc(minz, child_z, prime),
-                      "properties": _props(d, prime),
+        # the finest level, primes and repair insertions ride uncapped — see _tc.
+        feats.append({"type": "Feature", "tippecanoe": _tc(minz, child_z, kind),
+                      "properties": _props(d, kind),
                       "geometry": {"type": "Point", "coordinates": [round(lon, 6), round(lat, 6)]}})
 
     final = f"{tmp}/soundings.geojsons"
@@ -510,19 +671,20 @@ def _check():
 
     # prime rides to the tiles as a property so the style can weight it; an ordinary sounding
     # carries no key at all, so it costs the tiles nothing.
-    assert _props(3.0, True) == {"depth_m": 3, "depth_ft": 9, "depth_fm": 1, "prime": 1}
-    assert "prime" not in _props(3.0, False)
+    assert _props(3.0, KIND_PRIME) == {"depth_m": 3, "depth_ft": 9, "depth_fm": 1, "prime": 1}
+    assert "prime" not in _props(3.0, KIND_LATTICE) and "prime" not in _props(3.0, KIND_REPAIR)
 
     # zoom placement: coarser levels swap out at their own zoom; the finest level
     # (minz == child_z) is uncapped so it persists above the local source ceiling
     assert _tc(8, 10) == {"minzoom": 8, "maxzoom": 8}
     assert _tc(10, 10) == {"minzoom": 10}
-    assert _tc(8, 10, prime=True) == {"minzoom": 8}   # a least depth is never capped
+    assert _tc(8, 10, KIND_PRIME) == {"minzoom": 8}   # a least depth is never capped
+    assert _tc(8, 10, KIND_REPAIR) == {"minzoom": 8}  # …and neither is a repair insertion
     # …but never past its ring: a prime's minzoom is its enclosing isobath's display zoom.
     # Here the deepest enclosing ring (50 m) draws from z7, so the base zoom (8) binds.
     with rasterio.open(p) as src:
-        promoted = {mz for _d, _x, _y, mz, pr in
-                    _pyramid(src, NODATA, bbox, 1.0, z=8, child_z=9) if pr}
+        promoted = {mz for _d, _x, _y, mz, kind in
+                    _pyramid(src, NODATA, bbox, 1.0, z=8, child_z=9) if kind == KIND_PRIME}
     assert promoted == {8}, promoted
 
     # Enclosed shoals run on the CELL GRID, never the pixels — the whole window is never held in
@@ -602,7 +764,52 @@ def _check():
     assert any(d == 1200.0 and mz == 9 for d, _x, _y, mz, _p in mixed)
     assert all(d == 190.0 for d, _x, _y, mz, _p in mixed if mz == 8)
     # …and the shoal is enclosed by the 200 m isobath, so it is also charted as a prime sounding
-    assert any(d == 190.0 and p for d, _x, _y, _mz, p in mixed), "enclosed 190 m shoal must be prime"
+    assert any(d == 190.0 and kk == KIND_PRIME for d, _x, _y, _mz, kk in mixed), "enclosed 190 m shoal must be prime"
+    # Repair: two shoals share one cell, so the lattice emits only the shoaler and the field
+    # lies about the other; a trench pixel is hidden by shoalest-wins entirely. Shoal-side and
+    # deep-side repair must chart both, at their measured pixels, uncapped from the failing zoom.
+    global SOUND_REPAIR, REPAIR_SHOAL, REPAIR_SPACING_PX
+    rrr = np.full((512, 512), -40.0, "float32")
+    rrr[100, 100] = -1.0     # cell (0,0)'s shoalest — the lattice charts this one
+    rrr[120, 119] = -1.2     # same cell, 2 km away: invisible to the lattice, in the field's hull
+    rrr[240, 140] = -150.0   # deep trench pixel, in the navigational band and inside the z8
+                             # field's convex hull (single-pass repair cannot test beyond it):
+                             # shoalest-wins can never emit it
+    rrr[350, 60] = -150.0    # second trench, outside the z8 hull but inside z9's — visible
+                             # only to the finer zoom's pass
+    rp = f"{tmp}/repair.tif"
+    with rasterio.open(rp, "w", driver="GTiff", height=512, width=512, count=1, dtype="float32",
+                       nodata=NODATA, crs="EPSG:3857",
+                       transform=from_origin(0, 51200, 100, 100)) as dst:
+        dst.write(rrr, 1)
+    rbox = SimpleNamespace(left=0, bottom=0, right=51200, top=51200)
+    SOUND_REPAIR = True
+    REPAIR_SHOAL = True
+    with rasterio.open(rp) as src:
+        base = _pyramid(src, NODATA, rbox, 1.0, z=8, child_z=9)
+        fixed, ins = _repair(src, NODATA, rbox, list(base), 8, 9)
+    reps = [t for t in fixed if t[4] == KIND_REPAIR]
+    assert ins and reps, "repair must insert where the field fails B-410a/B-403.1a"
+    assert any(abs(d - 1.2) < 1e-6 for d, *_ in reps), reps[:4]      # the hidden shoal, exact pixel value
+    assert any(d > 100 for d, *_ in reps), "the trench (deep side) must be charted"
+    # EVERY zoom gets its own pass — a violation visible only in a finer zoom's field must be
+    # repaired there. The trench at (350, 60) sits outside the z8 field's convex hull (4 points)
+    # but inside z9's (16 points), so it is only detectable at z9: insertions must be recorded at
+    # BOTH zooms or the loop returned early (the bug an adversarial review caught after the
+    # z8-only symptom was rationalized away instead of read).
+    assert set(ins) == {8, 9}, ins
+    assert any(t[3] == 9 and t[4] == KIND_REPAIR and t[0] > 100 for t in fixed), \
+        "the z9-only trench must be inserted with minzoom 9"
+
+    # The spacing knob thins: a huge floor suppresses insertions near the displayed field.
+    REPAIR_SPACING_PX = 1e9
+    with rasterio.open(rp) as src:
+        _, ins2 = _repair(src, NODATA, rbox, list(base), 8, 9)
+    assert sum(ins2.values() or [0]) < sum(ins.values()), (ins, ins2)
+    REPAIR_SPACING_PX = 0.0
+    SOUND_REPAIR = False
+    REPAIR_SHOAL = False
+
     print("soundings_run self-check ok")
 
 

--- a/pipelines/soundings_run.py
+++ b/pipelines/soundings_run.py
@@ -367,15 +367,9 @@ def _shoalest_grid(src, nodata, min_depth):
     return g, cx, cy
 
 
-# Working size cap for enclosed-shoal detection, in pixels per side. The window itself is never
-# held whole — a z8 stem at cz14 is 32768 px square, 4.3 GB as float32 — so detection reads a
-# decimated overview and refines each hit at full resolution.
-SHOAL_DETECT_PX = 4096
-
-
 # Working size cap for enclosed-shoal detection, in pixels per side. The window is never held
 # whole — a z8 stem at cz14 is 32898 px square, 4.33 GB as float32 — so detection runs on one
-# decimated read bounded to this.
+# decimated read bounded to this, and refines each hit at full resolution.
 SHOAL_DETECT_PX = 4096
 
 

--- a/style/contours.ts
+++ b/style/contours.ts
@@ -1,0 +1,108 @@
+/**
+ * contour-lines and contour-labels — the isobaths and their depth numbers.
+ */
+import type {
+  ExpressionSpecification,
+  LayerSpecification,
+} from "@maplibre/maplibre-gl-style-spec";
+import { labelSize, type Flavor, type Unit } from "./flavor.js";
+import { snapSafetyContour } from "./depth-areas.js";
+
+// Contours: metre isobaths (sys != "ft", also legacy no-sys tiles) vs the
+// fathom-curve set (sys == "ft"), which labels as feet or fathoms. Both
+// systems label every curve — the standard isobath sets are sparse enough
+// that GL collision thins the labels. The 0 m drying line is unit-independent
+// and ships once with NO sys (like depare's drying/nodata), so both filters
+// admit sys-less features.
+const contourFilter = (unit: Unit): ExpressionSpecification =>
+  (unit === "m"
+    ? ["!=", ["get", "sys"], "ft"]
+    : [
+        "any",
+        ["!", ["has", "sys"]],
+        ["==", ["get", "sys"], "ft"],
+      ]) as unknown as ExpressionSpecification;
+
+export function contourLinesLayer(
+  flavor: Flavor,
+  { vector, unit, safety }: { vector: string; unit: Unit; safety: number },
+): LayerSpecification {
+  // The safety contour snaps UP the charted ladder to the next-deeper level, exactly
+  // as depthAreasColor recolours the bands, so the emphasized line always bounds the
+  // hazard tint. Contours carry integer depth props (depth_abs_m / depth_fm,
+  // contour_run.py), so the match is exact equality on the active system's prop.
+  const safetyContour = snapSafetyContour(unit, safety);
+  const isSafetyContour: ExpressionSpecification =
+    unit === "m"
+      ? ["==", ["get", "depth_abs_m"], safetyContour]
+      : ["==", ["get", "depth_fm"], Math.round(safetyContour / 1.8288)];
+
+  return {
+    id: "contour-lines",
+    type: "line",
+    source: vector,
+    "source-layer": "contours",
+    filter: contourFilter(unit),
+    // Presentation floor, not a data limit: below z6 isobaths read as clutter over depth shading.
+    minzoom: 6,
+    // Full-strength linework at DEPCN weight — translucent hairlines read as
+    // shading artefacts rather than isobaths.
+    paint: {
+      // The safety contour is the one emphasized isobath — thicker, in the emphasis
+      // colour, like S-52's DEPSC over DEPCN (IMO MSC.232 requires the emphasis);
+      // every other contour stays uniform DEPCN weight (S-4 B-411.1 recommends
+      // against emphasizing fixed standard contours).
+      "line-color": safetyContour
+        ? ["case", isSafetyContour, flavor.contourEmphasis, flavor.contour]
+        : flavor.contour,
+      "line-width": safetyContour ? ["case", isSafetyContour, 1.5, 0.8] : 0.8,
+    },
+  };
+}
+
+// safety moves the emphasized contour, so the paint is safety-dependent too.
+export const contourLinesState = [
+  "filter",
+  "paint.line-color",
+  "paint.line-width",
+];
+
+export function contourLabelsLayer(
+  flavor: Flavor,
+  { vector, unit }: { vector: string; unit: Unit },
+): LayerSpecification {
+  // Depth number only, like paper charts (S-4 B-411.3) — the unit lives in the
+  // consumer's UI, and soundings are already unitless.
+  const contourLabelText: ExpressionSpecification = [
+    "to-string",
+    [
+      "get",
+      unit === "ft" ? "depth_ft" : unit === "fm" ? "depth_fm" : "depth_abs_m",
+    ],
+  ];
+
+  return {
+    id: "contour-labels",
+    type: "symbol",
+    source: vector,
+    "source-layer": "contours",
+    filter: contourFilter(unit),
+    minzoom: 8,
+    layout: {
+      "symbol-placement": "line",
+      "text-field": contourLabelText,
+      "text-size": labelSize,
+      "text-font": flavor.font,
+      "text-letter-spacing": 0.1,
+      "text-max-angle": 30,
+      "text-padding": 50,
+    },
+    paint: {
+      "text-color": flavor.label,
+      "text-halo-color": flavor.labelHalo,
+      "text-halo-width": 1,
+    },
+  };
+}
+
+export const contourLabelsState = ["filter", "layout.text-field"];

--- a/style/coverage.ts
+++ b/style/coverage.ts
@@ -1,0 +1,60 @@
+/**
+ * source-fill / source-highlight / source-outline / source-labels — source
+ * coverage (provenance): footprint polygons with props source_id / source_name /
+ * source_maxzoom, from the standalone coverage tileset. Hidden by default; a
+ * viewer can toggle them on for click-to-identify.
+ */
+import type { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
+import type { Flavor } from "./flavor.js";
+
+export function coverageLayers(
+  flavor: Flavor,
+  { coverage }: { coverage: string },
+): LayerSpecification[] {
+  const coverageColor = flavor.coverage;
+  return [
+    {
+      id: "source-fill",
+      type: "fill",
+      source: coverage,
+      "source-layer": "coverage",
+      layout: { visibility: "none" },
+      paint: { "fill-color": coverageColor, "fill-opacity": 0.12 },
+    },
+    {
+      // Brightened fill of one source (filter set by the consumer on click).
+      id: "source-highlight",
+      type: "fill",
+      source: coverage,
+      "source-layer": "coverage",
+      filter: ["==", ["get", "source_id"], "__none__"],
+      layout: { visibility: "none" },
+      paint: { "fill-color": coverageColor, "fill-opacity": 0.4 },
+    },
+    {
+      id: "source-outline",
+      type: "line",
+      source: coverage,
+      "source-layer": "coverage",
+      layout: { visibility: "none" },
+      paint: { "line-color": coverageColor, "line-width": 1.5 },
+    },
+    {
+      id: "source-labels",
+      type: "symbol",
+      source: coverage,
+      "source-layer": "coverage",
+      layout: {
+        visibility: "none",
+        "text-field": ["get", "source_name"],
+        "text-size": 11,
+        "text-font": flavor.font,
+      },
+      paint: {
+        "text-color": coverageColor,
+        "text-halo-color": flavor.labelHalo,
+        "text-halo-width": 1.2,
+      },
+    },
+  ];
+}

--- a/style/depth-areas.ts
+++ b/style/depth-areas.ts
@@ -1,0 +1,135 @@
+/**
+ * depth-areas — the ENC DEPARE fill, the vector twin of depth-shading, and the
+ * charted isobath ladders the safety contour snaps against.
+ */
+import type {
+  ExpressionSpecification,
+  LayerSpecification,
+} from "@maplibre/maplibre-gl-style-spec";
+import { day, type Flavor, type Shading, type Unit } from "./flavor.js";
+
+// The depare layer's data floor (tippecanoe -Z in the pipeline) and the contour
+// lines' presentation floor — depth shading carries lower zooms.
+export const BANDS_MIN_ZOOM = 6;
+
+// Charted isobath ladders, positive-down metres — must mirror pipelines/config.py
+// DEPARE_LEVELS / DEPARE_LEVELS_FT (the bucket edges baked into the depare
+// layer). The safety contour snaps UP this ladder to the next-deeper rung
+// (ECDIS behaviour, bias shallow) — vector bands can only flip at charted
+// levels, unlike the raster ramp's continuous crisp edge.
+const DEPARE_LADDER_M = [
+  2, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 4000, 5000, 6000,
+  8000, 10000,
+];
+const DEPARE_LADDER_FT = [
+  1, 2, 3, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000,
+].map((fm) => fm * 1.8288);
+
+// Comparisons against drval1 subtract this: tiles may carry the fathom-curve
+// drvals (1.8288, 5.4864, …) as 32-bit floats, which can land a hair below the
+// exact edge value. Ladder rungs are ≥ ~1.8 m apart, so 0.01 m is safely
+// inside every gap.
+export const DRVAL_EPS = 0.01;
+
+// The safety depth snapped UP the active ladder to the next-deeper charted
+// level; 0 when safety is off. Shared by the band recolour here and the
+// emphasized isobath in contours.ts, so tint and line always agree.
+export function snapSafetyContour(unit: Unit, safety: number): number {
+  if (!(safety > 0)) return 0;
+  const ladder = unit === "m" ? DEPARE_LADDER_M : DEPARE_LADDER_FT;
+  return (
+    ladder.find((l) => l >= safety - DRVAL_EPS) ?? ladder[ladder.length - 1]
+  );
+}
+
+// Fill colour for the depare partitions: the band tint keyed off drval1 (the
+// band's shallow bound), with every band shallower than the snapped safety
+// contour painted the hazard tint. Literals only, like depthRelief — runtime
+// changes go through applyState().
+export function depthAreasColor(
+  flavor: Flavor = day,
+  { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
+): ExpressionSpecification {
+  const metric = unit === "m";
+  const edges = [...flavor.bandEdges[metric ? "m" : "ft"]].reverse(); // shoalest → deepest
+  const step: unknown[] = ["step", ["get", "drval1"], flavor.bandColors[5]];
+  edges.forEach((d, i) => step.push(d - DRVAL_EPS, flavor.bandColors[4 - i]));
+  if (!(safety > 0)) return step as unknown as ExpressionSpecification;
+  const snap = snapSafetyContour(unit, safety);
+  return [
+    "case",
+    ["<", ["get", "drval1"], snap - DRVAL_EPS],
+    flavor.hazard,
+    step,
+  ] as unknown as ExpressionSpecification;
+}
+
+// The depare layer carries three ENC DEPARE feature kinds in one fill, keyed by attribute
+// presence: depth bands (drval1/drval2, sys-tagged per m/ft ladder, drval1 >= 0), drying
+// foreshore (drval1 < 0, no sys), and unknown-depth water (no drval1, no sys). Bands
+// duplicate per sys, so only the active ladder shows, and only in bands mode; drying +
+// nodata have NO sys and ship once, so `!has sys` selects them and they render in BOTH
+// shading modes — relief filters the bands out (the raster ramp carries depth; two 0.85
+// fills would compound) but keeps the honesty fills, since a #24-cleared lake must read as
+// unknown water — the render now tints 0-fill as unknown water too, and the depare polygon
+// keeps that categorical (and adds the drying tint).
+export function depthAreasLayer(
+  flavor: Flavor,
+  {
+    vector,
+    unit,
+    safety,
+    shading,
+  }: { vector: string; unit: Unit; safety: number; shading: Shading },
+): LayerSpecification {
+  const bandSys = unit === "m" ? "m" : "ft";
+  const depareFilter = (shading === "bands"
+    ? ["any", ["!", ["has", "sys"]], ["==", ["get", "sys"], bandSys]]
+    : ["!", ["has", "sys"]]) as unknown as ExpressionSpecification;
+  // Fill: nodata (no drval1) → provisional flat tint; drying (drval1 < 0) → foreshore green;
+  // else the band ramp keyed off drval1. `case` short-circuits, so the drval1 comparison only
+  // runs once the no-drval1 branch has ruled nodata out.
+  const depareColor = [
+    "case",
+    ["!", ["has", "drval1"]],
+    flavor.nodata,
+    ["<", ["get", "drval1"], 0],
+    flavor.drying,
+    depthAreasColor(flavor, { unit, safety }),
+  ] as unknown as ExpressionSpecification;
+  // nodata carries the provisional lighter wash it had as its own layer; bands + drying stay
+  // at the depth-fill opacity.
+  const depareOpacity = [
+    "case",
+    ["!", ["has", "drval1"]],
+    0.55,
+    0.85,
+  ] as unknown as ExpressionSpecification;
+
+  return {
+    // ENC DEPARE fill — all three depare feature kinds keyed by attribute presence (see the
+    // expressions above): depth bands (crisp tint per drval1, safety recolour snapped to the
+    // next-deeper charted level), drying foreshore (INT-1 green, negative drval1), and
+    // unknown-depth water (provisional flat tint, no drval1). The three are disjoint by
+    // construction, so `fill-sort-key: rank` is only a stable tie-breaker at an incidental
+    // simplification-wobble edge — nodata under bands (real depth wins), drying over the shoal
+    // band it abuts along their shared 0 m seam. Bands are filtered out in relief mode (the
+    // raster ramp carries depth); drying + nodata stay in both modes. Where no drying/nodata
+    // polygon covers a >=0 pixel the DEM ramp still paints the land wash, so a mask miss
+    // degrades to plain land, never to water-over-land.
+    id: "depth-areas",
+    type: "fill",
+    source: vector,
+    "source-layer": "depare",
+    filter: depareFilter,
+    minzoom: BANDS_MIN_ZOOM,
+    layout: { "fill-sort-key": ["get", "rank"] },
+    paint: {
+      "fill-color": depareColor,
+      "fill-opacity": depareOpacity,
+    },
+  };
+}
+
+// The unit/safety/shading-dependent properties applyState re-derives in place.
+export const depthAreasState = ["filter", "paint.fill-color"];

--- a/style/depth-shading.ts
+++ b/style/depth-shading.ts
@@ -1,0 +1,149 @@
+/**
+ * depth-shading — the raster color-relief layer (elevation → colour).
+ * The hazard tint folds into this one color-relief ramp: two color-relief
+ * layers on one DEM source don't composite (only the first renders), so water
+ * shallower than the safety depth is painted into the ramp itself.
+ */
+import type {
+  ExpressionSpecification,
+  LayerSpecification,
+} from "@maplibre/maplibre-gl-style-spec";
+import { day, type Flavor, type Shading, type Unit } from "./flavor.js";
+import { BANDS_MIN_ZOOM } from "./depth-areas.js";
+
+type RampStops = (number | string)[]; // alternating elevation, colour
+
+// Terrarium's vertical LSB. The encoder clamps water to <= -LSB; the non-negative domain is
+// categorical (0 unknown-depth water, 1 drying foreshore, 2 land — flat codes, exact at every
+// zoom): the shoal tint runs flat to -LSB, then the code tints; fractional values between codes
+// are overzoom/interpolation transitions and blend smoothly.
+const LSB = 1 / 256;
+const DRYING_CODE = 1;
+const LAND_CODE = 2;
+
+// Width (metres) of the normal→hazard colour transition at the safety depth.
+const EDGE = 0.01;
+
+const depthRamp = (flavor: Flavor, edges: number[]): RampStops => {
+  const stops: RampStops = [-10000, flavor.bandColors[0]];
+  // Blend on the shallow side of each edge: the encoder rounds toward shallow
+  edges.forEach((d, i) =>
+    stops.push(-d, flavor.bandColors[i], -d + 0.1, flavor.bandColors[i + 1]),
+  );
+  // The unknown tint is a knife-edge at exact 0 (native code pixels only): pinning drying
+  // green at +LSB keeps overzoom's wet/dry blend fractions out of the slate — otherwise the
+  // whole (0, 1) interval renders as a wide gray band along every foreshore seam.
+  stops.push(
+    -LSB,
+    flavor.bandColors[5],
+    0,
+    flavor.nodata,
+    LSB,
+    flavor.drying,
+    DRYING_CODE,
+    flavor.drying,
+    LAND_CODE - LSB,
+    flavor.drying,
+    LAND_CODE,
+    flavor.land,
+  );
+  return stops;
+};
+
+// Colour of the ramp at elevation e (linear-interpolated). Used to pin a
+// normal-coloured stop right at the safety depth so the flip to the hazard
+// colour is a crisp ~0.01 m edge at ANY safety value — otherwise the blend
+// feathers by however far −safety lands from the nearest ramp stop.
+const rampColorAt = (ramp: RampStops, e: number): string => {
+  for (let i = 2; i < ramp.length; i += 2)
+    if (e <= (ramp[i] as number)) {
+      const e0 = ramp[i - 2] as number,
+        c0 = ramp[i - 1] as string;
+      const e1 = ramp[i] as number,
+        c1 = ramp[i + 1] as string;
+      if (c0[0] !== "#" || c1[0] !== "#") return c0;
+      const t = (e - e0) / (e1 - e0);
+      const p = (c: string) =>
+        [1, 3, 5].map((k) => parseInt(c.slice(k, k + 2), 16));
+      const a = p(c0),
+        b = p(c1);
+      return `rgb(${a.map((v, k) => Math.round(v + t * (b[k] - v))).join(",")})`;
+    }
+  return ramp[1] as string;
+};
+
+// The color-relief expression for the active unit system and safety depth.
+// Unit/safety changes rebuild this and apply it with
+// setPaintProperty("depth-shading", ...) — applyState() does exactly that.
+export function depthRelief(
+  flavor: Flavor = day,
+  { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
+): ExpressionSpecification {
+  // The crisp-edge stops below need s + EDGE to land strictly between the
+  // safety depth and the -LSB water stop, or the interpolate stops go out of
+  // ascending order and MapLibre rejects the whole expression. No real safety
+  // depth is centimetres, so floor tiny values instead of failing.
+  if (safety > 0) safety = Math.max(safety, EDGE + 2 * LSB);
+  const ramp = depthRamp(flavor, flavor.bandEdges[unit === "m" ? "m" : "ft"]);
+  const s = -safety;
+  const stops: RampStops = [];
+  for (let i = 0; i < ramp.length; i += 2)
+    if (!(safety > 0) || (ramp[i] as number) < s)
+      stops.push(ramp[i], ramp[i + 1]);
+  // Crisp edge: normal colour pinned at the safety depth, hazard from just
+  // shallower up to shore.
+  if (safety > 0)
+    stops.push(
+      s,
+      rampColorAt(ramp, s),
+      s + EDGE,
+      flavor.hazard,
+      -LSB,
+      flavor.hazard,
+      0,
+      flavor.nodata,
+      LSB,
+      flavor.drying,
+      DRYING_CODE,
+      flavor.drying,
+      LAND_CODE - LSB,
+      flavor.drying,
+      LAND_CODE,
+      flavor.land,
+    );
+  return [
+    "interpolate",
+    ["linear"],
+    ["elevation"],
+    ...stops,
+  ] as unknown as ExpressionSpecification;
+}
+
+export function depthShadingLayer(
+  flavor: Flavor,
+  {
+    dem,
+    unit,
+    safety,
+    shading,
+  }: { dem: string; unit: Unit; safety: number; shading: Shading },
+): LayerSpecification {
+  return {
+    id: "depth-shading",
+    type: "color-relief",
+    source: dem,
+    // Bands mode: the vector depth areas take over at their z6 data floor;
+    // the relief carries lower zooms (same palette, so the handoff is a
+    // sharpness change, not a colour change).
+    ...(shading === "bands" ? { maxzoom: BANDS_MIN_ZOOM } : {}),
+    paint: {
+      "color-relief-color": depthRelief(flavor, { unit, safety }),
+      "color-relief-opacity": 0.85,
+      // Linear resampling paints a light seam along every unknown-water boundary
+      resampling: "nearest",
+    },
+  } as unknown as LayerSpecification;
+}
+
+// The unit/safety/shading-dependent properties applyState re-derives in place.
+export const depthShadingState = ["paint.color-relief-color"];

--- a/style/flavor.ts
+++ b/style/flavor.ts
@@ -1,0 +1,106 @@
+/**
+ * Appearance: the Flavor object, the built-in day palette, and the shared type
+ * scale. Layer *structure* lives in the per-layer modules; a custom look is a
+ * spread-override of `day`.
+ */
+import type { ExpressionSpecification } from "@maplibre/maplibre-gl-style-spec";
+
+export type Unit = "m" | "ft" | "fm";
+// Water shading: the raster color-relief ramp (continuous, fuzzy edges) or the
+// vector ENC depth-area bands (crisp edges on the charted isobaths, safety
+// snapped to the next-deeper charted level). Never both at once — the 0.85
+// opacities would compound.
+export type Shading = "relief" | "bands";
+
+export interface Flavor {
+  bandColors: string[]; // deepest → shoalest (6 entries)
+  bandEdges: { m: number[]; ft: number[] }; // band-edge depths, metres
+  hazard: string;
+  land: string;
+  drying: string;
+  nodata: string;
+  contour: string;
+  label: string;
+  labelHalo: string;
+  soundingEmphasis: string;
+  contourEmphasis: string;
+  font: string[];
+  /** Soundings only. S-4 B-412.1 sets them in sloping numerals; upright is reserved for
+   *  soundings of lower reliability (B-412.4). */
+  soundingFont: string[];
+  hillshadeShadow: string;
+  hillshadeHighlight: string;
+  coverage: string;
+}
+
+// Depth-shading tints follow chart convention: shoal-dark → deep-white
+// (INT/NOAA), flat white beyond the deepest edge so tint stays monotonic in
+// depth. Bands are perceptually spaced (adjacent ΔE ≥ 7 after 0.85-opacity
+// compositing), weighted toward the shoal bands where depth discrimination
+// matters. Band edges sit on isobaths the chart draws — metric levels, or the
+// classic fathom curves in ft/fm mode — so tint boundaries land on contour
+// lines rather than between them (paper-chart practice).
+export const day: Flavor = {
+  bandColors: [
+    "#e9f7ff", // deepest band
+    "#c9e9fd",
+    "#a5d9fb",
+    "#7fc7f8",
+    "#5db5f0",
+    "#3fa2e4", // shoalest band
+  ],
+  bandEdges: {
+    m: [50, 20, 10, 5, 2],
+    ft: [30, 10, 5, 3, 1].map((fm) => fm * 1.8288), // fathom curves 30/10/5/3/1 fm
+  },
+  // One perceptual step darker than the shoalest band — water shallower than
+  // the safety depth.
+  hazard: "#1f86cb",
+  // Land above datum: translucent buff wash (paper-chart figure-ground — white
+  // stays unambiguously "deep water"); a raster base reads through it.
+  land: "rgba(247,240,221,0.66)",
+  // Drying areas (S-52 DEPIT day green): seabed above chart datum that covers
+  // and uncovers with the tide. Darker than the shoalest band — charts weight
+  // the foreshore as the heaviest tint in the shoaling sequence.
+  drying: "#58af9c",
+  // Unknown-depth water (ENC DEPARE nodata): mapped water we hold no depth for. Painted
+  // the hazard tint — unsurveyed water warrants the same caution as known-unsafe water
+  // (ECDIS treats it as unsafe for the safety check; S-52 hatching is the eventual upgrade).
+  nodata: "#1f86cb",
+  // Isobaths and their labels recede in chart grey (S-52 DEPCN/SNDG1 #768C97);
+  // only unsafe soundings jump, in soundingEmphasis (SNDG2).
+  contour: "#768c97",
+  label: "#768c97",
+  labelHalo: "rgba(255,255,255,0.5)",
+  soundingEmphasis: "#000",
+  // Safety contour line (S-52 DEPSC day): darker grey, distinct from SNDG2 black.
+  contourEmphasis: "#4C5B63",
+  font: ["Noto Sans Medium"],
+  soundingFont: ["Noto Sans Medium Italic"],
+  hillshadeShadow: "#9adcfe",
+  hillshadeHighlight: "#ffffff",
+  coverage: "#f58231",
+};
+
+// Mariner-setting defaults for layers()/style() when the caller omits them.
+export const DEFAULT_UNIT: Unit = "m";
+export const DEFAULT_SAFETY = 2;
+export const DEFAULT_SHADING: Shading = "relief";
+
+// Shared label styling so soundings and contour labels read as one chart. S-52
+// puts a sounding digit at ~3.5 mm (§5.2.1(2)) = ~13 px of digit height, and a
+// digit is ~0.71 em, so the 18 px em at chart scale is the standard's size, not
+// a large one. The ramp down at coarse zooms is a deliberate deviation from
+// S-52 §3.1.5 ("text size should never be decreased when zooming out"): that
+// rule assumes ECDIS's fixed compilation scale, and at a z8 overview the full-
+// size type shouts over a whole sea. The decimetre subscript glyph is cut at
+// roughly 0.6 em by the typeface, so the low anchor is also its legibility floor.
+export const labelSize: ExpressionSpecification = [
+  "interpolate",
+  ["linear"],
+  ["zoom"],
+  8,
+  12,
+  13,
+  16,
+];

--- a/style/hillshade.ts
+++ b/style/hillshade.ts
@@ -1,0 +1,26 @@
+/**
+ * depth-hillshade — bathymetric hillshading over the water shading.
+ */
+import type { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
+import type { Flavor } from "./flavor.js";
+
+export function hillshadeLayer(
+  flavor: Flavor,
+  { dem, hillshade }: { dem: string; hillshade: boolean },
+): LayerSpecification {
+  return {
+    id: "depth-hillshade",
+    type: "hillshade",
+    source: dem,
+    layout: { visibility: hillshade ? "visible" : "none" },
+    paint: {
+      "hillshade-exaggeration": 0.5,
+      "hillshade-shadow-color": flavor.hillshadeShadow,
+      "hillshade-highlight-color": flavor.hillshadeHighlight,
+      "hillshade-illumination-direction": 315,
+    },
+  };
+}
+
+// The hillshade toggle applyState re-derives in place.
+export const hillshadeState = ["layout.visibility"];

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -1,5 +1,8 @@
-import { expect, test } from "vitest";
-import { validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
+import { assert, expect, test } from "vitest";
+import {
+  createExpression,
+  validateStyleMin,
+} from "@maplibre/maplibre-gl-style-spec";
 import {
   applyState,
   day,
@@ -311,18 +314,18 @@ test("applyState re-derives every unit/safety-dependent property", () => {
       )!.value,
     ),
   ).toContain(day.hazard);
-  // Label text follows the unit.
+  // Label text follows the unit — fathoms read off whole feet, six to the fathom.
   expect(
     JSON.stringify(
       calls.find((c) => c.fn === "layout" && c.layer === "soundings")!.value,
     ),
-  ).toContain("depth_fm");
-  // Unsafe-sounding emphasis carries the safety literal.
-  expect(
-    JSON.stringify(
-      calls.find((c) => c.fn === "paint" && c.layer === "soundings")!.value,
-    ),
-  ).toContain("5");
+  ).toContain("depth_ft");
+  // Sounding colour is uniform (paper-chart practice; hazard lives in the tint): it must not
+  // vary with the safety depth or any per-feature property.
+  const soundPaint = JSON.stringify(
+    calls.find((c) => c.fn === "paint" && c.layer === "soundings")!.value,
+  );
+  expect(soundPaint).toBe(JSON.stringify(day.label));
 
   // Layers absent from the map (composed subsets) are skipped entirely.
   const before = calls.length;
@@ -337,6 +340,97 @@ test("contour labels print the depth number only — no unit suffix", () => {
     const text = (labels as { layout: Record<string, unknown> }).layout["text-field"];
     expect((text as unknown[])[0]).toBe("to-string");
   }
+});
+
+test("soundings drop the sub-unit digit, and never show a zero one", () => {
+  const field = (unit: "m" | "ft" | "fm") =>
+    (
+      layers(day, { unit }).find((l) => l.id === "soundings") as {
+        layout: Record<string, unknown>;
+      }
+    ).layout["text-field"];
+
+  // Feet have no sub-division on a chart (US Chart No. 1 §I), so they just print.
+  expect((field("ft") as unknown[])[0]).toBe("to-string");
+  expect(JSON.stringify(field("ft"))).toContain("depth_ft");
+
+  const print = (unit: "m" | "fm", props: Record<string, number>, zoom = 12) => {
+    const compiled = createExpression(field(unit), {
+      type: "formatted",
+      "property-type": "data-driven",
+      expression: { interpolated: false, parameters: ["zoom", "feature"] },
+    });
+    assert(compiled.result === "success");
+    return (
+      compiled.value.evaluate({ zoom }, { properties: props }) as {
+        sections: { text: string; scale: number | null }[];
+      }
+    ).sections.map((s) => [s.text, s.scale]);
+  };
+  const m = (depth_m: number, zoom?: number) => print("m", { depth_m }, zoom);
+  const fm = (depth_ft: number) => print("fm", { depth_ft });
+  // The sub-unit scale is a tuning knob; assert the structure it produces, not its value.
+  const sub = m(3.9)[1][1] as number;
+  expect(sub).toBeGreaterThan(0).toBeLessThan(1);
+
+  // Metres: decimetres to 21 m, half metres 21-31 (a .5 residual), whole metres beyond.
+  expect(m(3.9)).toEqual([["3", null], ["9", sub]]);
+  expect(m(23.5)).toEqual([["23", null], ["5", sub]]);
+  expect(m(5.0)).toEqual([["5", null], ["", sub]]);
+  expect(m(137)).toEqual([["137", null], ["", sub]]);
+  // Sub-units are a function of depth (S-4 B-412), never of scale.
+  expect(m(3.9, 8)).toEqual([["3", null], ["9", sub]]);
+
+  // Fathoms derive both digits from whole feet: 22 ft is 3 fathoms 4 feet.
+  expect(fm(22)).toEqual([["3", null], ["4", sub]]);
+  expect(fm(18)).toEqual([["3", null], ["", sub]]); // exactly 3 fathoms — no feet digit
+  // From 11 fathoms the chart drops feet entirely (Canada CHS Chart 1, 2022).
+  expect(fm(11 * 6)).toEqual([["11", null], ["", sub]]);
+  expect(fm(11 * 6 + 5)).toEqual([["11", null], ["", sub]]);
+  expect(fm(10 * 6 + 5)).toEqual([["10", null], ["5", sub]]); // …but not one fathom earlier
+});
+
+test("a prime sounding outranks the field for collisions, in uniform ink", () => {
+  const snd = layers(day, { unit: "m", safety: 2 }).find(
+    (l) => l.id === "soundings",
+  ) as { layout: Record<string, unknown>; paint: Record<string, unknown> };
+
+  // S-4 B-410b's "must always be shown" fails if a deeper neighbour can displace the least
+  // depth over a shoal, so prime sorts ahead of every ordinary sounding (lower wins).
+  const key = createExpression(snd.layout["symbol-sort-key"], {
+    type: "number",
+    "property-type": "data-driven",
+    expression: { interpolated: false, parameters: ["zoom", "feature"] },
+  });
+  assert(key.result === "success");
+  const sort = (p: Record<string, number>) =>
+    key.value.evaluate({ zoom: 12 }, { properties: p }) as number;
+  expect(sort({ depth_m: 40, prime: 1 })).toBeLessThan(sort({ depth_m: 0.2 }));
+  expect(sort({ depth_m: 3 })).toBeLessThan(sort({ depth_m: 9 }));
+
+  // …but it gets no ink of its own: prime is a topological fact of the build window (a shelf
+  // whose contour closes past the window edge is never prime), not a hazard ranking, and
+  // painting it black read as one. One colour for the whole field, like paper (S-4 B-412).
+  expect(snd.paint["text-color"]).toBe(day.label);
+});
+
+test("glyphs are self-hosted, and soundings alone are set sloping", () => {
+  const s = style({ tilesBase: "https://t.example/seascape" });
+  // The MapLibre demo stack ships 3 of the 10 subscript digits, and a missing glyph does not
+  // error — it just leaves the decimetre off the chart. Never point back at it.
+  expect(s.glyphs).toBe(
+    "https://tiles.openwaters.io/fonts/{fontstack}/{range}.pbf",
+  );
+  expect(s.glyphs).not.toContain("demotiles");
+
+  const fontOf = (id: string) =>
+    (s.layers.find((l) => l.id === id) as { layout: Record<string, unknown> })
+      .layout["text-font"];
+  // S-4 B-412.1 sets soundings in sloping numerals; B-412.4 reserves upright for soundings of
+  // lower reliability, so nothing else on the chart borrows the italic face.
+  expect(fontOf("soundings")).toEqual(["Noto Sans Italic"]);
+  expect(fontOf("contour-labels")).toEqual(["Noto Sans Regular"]);
+  expect(fontOf("source-labels")).toEqual(["Noto Sans Regular"]);
 });
 
 test("the safety contour is the one emphasized isobath", () => {

--- a/style/index.test.ts
+++ b/style/index.test.ts
@@ -342,7 +342,7 @@ test("contour labels print the depth number only — no unit suffix", () => {
   }
 });
 
-test("soundings drop the sub-unit digit, and never show a zero one", () => {
+test("soundings set the sub-unit as a real subscript glyph, never a zero one", () => {
   const field = (unit: "m" | "ft" | "fm") =>
     (
       layers(day, { unit }).find((l) => l.id === "soundings") as {
@@ -356,38 +356,35 @@ test("soundings drop the sub-unit digit, and never show a zero one", () => {
 
   const print = (unit: "m" | "fm", props: Record<string, number>, zoom = 12) => {
     const compiled = createExpression(field(unit), {
-      type: "formatted",
+      type: "string",
       "property-type": "data-driven",
       expression: { interpolated: false, parameters: ["zoom", "feature"] },
     });
     assert(compiled.result === "success");
-    return (
-      compiled.value.evaluate({ zoom }, { properties: props }) as {
-        sections: { text: string; scale: number | null }[];
-      }
-    ).sections.map((s) => [s.text, s.scale]);
+    return String(compiled.value.evaluate({ zoom }, { properties: props }));
   };
   const m = (depth_m: number, zoom?: number) => print("m", { depth_m }, zoom);
   const fm = (depth_ft: number) => print("fm", { depth_ft });
-  // The sub-unit scale is a tuning knob; assert the structure it produces, not its value.
-  const sub = m(3.9)[1][1] as number;
-  expect(sub).toBeGreaterThan(0).toBeLessThan(1);
+  const HAIR = "\u200a"; // hair space
 
   // Metres: decimetres to 21 m, half metres 21-31 (a .5 residual), whole metres beyond.
-  expect(m(3.9)).toEqual([["3", null], ["9", sub]]);
-  expect(m(23.5)).toEqual([["23", null], ["5", sub]]);
-  expect(m(5.0)).toEqual([["5", null], ["", sub]]);
-  expect(m(137)).toEqual([["137", null], ["", sub]]);
+  // Real subscript glyphs (the typeface owns drop and size), a hair space for air, and no
+  // decimal separator — S-4 B-412.1 separates only when the digits share a baseline, and on
+  // the fathom ladder a point would misread 3 fathoms 4 feet as 3.4 fathoms.
+  expect(m(3.9)).toBe("3" + HAIR + "\u2089");
+  expect(m(23.5)).toBe("23" + HAIR + "\u2085");
+  expect(m(5.0)).toBe("5");
+  expect(m(137)).toBe("137");
   // Sub-units are a function of depth (S-4 B-412), never of scale.
-  expect(m(3.9, 8)).toEqual([["3", null], ["9", sub]]);
+  expect(m(3.9, 8)).toBe("3" + HAIR + "\u2089");
 
   // Fathoms derive both digits from whole feet: 22 ft is 3 fathoms 4 feet.
-  expect(fm(22)).toEqual([["3", null], ["4", sub]]);
-  expect(fm(18)).toEqual([["3", null], ["", sub]]); // exactly 3 fathoms — no feet digit
+  expect(fm(22)).toBe("3" + HAIR + "\u2084");
+  expect(fm(18)).toBe("3"); // exactly 3 fathoms — no feet digit
   // From 11 fathoms the chart drops feet entirely (Canada CHS Chart 1, 2022).
-  expect(fm(11 * 6)).toEqual([["11", null], ["", sub]]);
-  expect(fm(11 * 6 + 5)).toEqual([["11", null], ["", sub]]);
-  expect(fm(10 * 6 + 5)).toEqual([["10", null], ["5", sub]]); // …but not one fathom earlier
+  expect(fm(11 * 6)).toBe("11");
+  expect(fm(11 * 6 + 5)).toBe("11");
+  expect(fm(10 * 6 + 5)).toBe("10" + HAIR + "\u2085"); // …but not one fathom earlier
 });
 
 test("a prime sounding outranks the field for collisions, in uniform ink", () => {
@@ -427,10 +424,11 @@ test("glyphs are self-hosted, and soundings alone are set sloping", () => {
     (s.layers.find((l) => l.id === id) as { layout: Record<string, unknown> })
       .layout["text-font"];
   // S-4 B-412.1 sets soundings in sloping numerals; B-412.4 reserves upright for soundings of
-  // lower reliability, so nothing else on the chart borrows the italic face.
-  expect(fontOf("soundings")).toEqual(["Noto Sans Italic"]);
-  expect(fontOf("contour-labels")).toEqual(["Noto Sans Regular"]);
-  expect(fontOf("source-labels")).toEqual(["Noto Sans Regular"]);
+  // lower reliability, so nothing else on the chart borrows an italic face. The weight is a
+  // flavor-tuning knob — the POSTURE is the invariant.
+  expect((fontOf("soundings") as string[])[0]).toMatch(/ Italic$/);
+  expect((fontOf("contour-labels") as string[])[0]).not.toMatch(/Italic/);
+  expect((fontOf("source-labels") as string[])[0]).not.toMatch(/Italic/);
 });
 
 test("the safety contour is the one emphasized isobath", () => {

--- a/style/index.ts
+++ b/style/index.ts
@@ -102,12 +102,12 @@ export const day: Flavor = {
   // only unsafe soundings jump, in soundingEmphasis (SNDG2).
   contour: "#768c97",
   label: "#768c97",
-  labelHalo: "rgba(255,255,255,0.8)",
+  labelHalo: "rgba(255,255,255,0.5)",
   soundingEmphasis: "#000",
   // Safety contour line (S-52 DEPSC day): darker grey, distinct from SNDG2 black.
   contourEmphasis: "#4C5B63",
-  font: ["Noto Sans Regular"],
-  soundingFont: ["Noto Sans Italic"],
+  font: ["Noto Sans Medium"],
+  soundingFont: ["Noto Sans Medium Italic"],
   hillshadeShadow: "#9adcfe",
   hillshadeHighlight: "#ffffff",
   coverage: "#f58231",
@@ -122,14 +122,13 @@ const DEFAULT_SHADING: Shading = "relief";
 // lines' presentation floor — depth shading carries lower zooms.
 const BANDS_MIN_ZOOM = 6;
 
-// Decimetre digit on soundings. S-52's glyphs (PresLib SOUNDG10-19 vs SOUNDG50-59)
-// are the same 8x11 size and differ only by a 4-unit drop, so the decimetre reads
-// at full weight on screen; S-4 B-412.1's "visibly smaller" is the paper rule.
-// vertical-align only offsets a section when its size differs, so the scale buys
-// the drop. It has to be small enough that 1.3 m never reads as 13 m — the two
-// occur side by side in the same view — which measured out at 0.6, not the ~0.8
-// that matches S-52's 4-of-11 geometry.
-const SUBSCRIPT_SCALE = 0.666;
+// Sub-unit digits on soundings are REAL subscript glyphs (U+2080-2089) from the self-hosted
+// stack — the type designer set the drop and the sidebearings. The alternative, a scaled
+// `format` section with vertical-align, aligns em-boxes rather than baselines, so the digit
+// sat visibly high and tight against the integer. A hair space (U+200A, also in the stack)
+// gives the pair its air.
+const SUB = "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089";
+const SUBSCRIPT = [...SUB].map((c, i) => (i ? "\u200A" + c : ""));
 
 // Self-hosted (openwatersio/tile-fonts). The MapLibre demo stack this replaced is a subset —
 // of the ten subscript digits it ships three — and a missing glyph is not an error, it simply
@@ -365,33 +364,31 @@ export function layers(
     whole: ExpressionSpecification,
     sub: ExpressionSpecification,
   ): ExpressionSpecification => [
-    "format",
+    "concat",
     ["to-string", whole],
-    {},
     [
       "match",
       sub,
       1,
-      "1",
+      SUBSCRIPT[1],
       2,
-      "2",
+      SUBSCRIPT[2],
       3,
-      "3",
+      SUBSCRIPT[3],
       4,
-      "4",
+      SUBSCRIPT[4],
       5,
-      "5",
+      SUBSCRIPT[5],
       6,
-      "6",
+      SUBSCRIPT[6],
       7,
-      "7",
+      SUBSCRIPT[7],
       8,
-      "8",
+      SUBSCRIPT[8],
       9,
-      "9",
+      SUBSCRIPT[9],
       "",
     ],
-    { "font-scale": SUBSCRIPT_SCALE, "vertical-align": "bottom" },
   ];
   // Metres: the tenths digit is decimetres. `round` on the residual recovers it through float
   // dust (3.9 % 1 == 0.9000000000000004).
@@ -459,11 +456,21 @@ export function layers(
 
   // Shared label styling so soundings and contour labels read as one chart. S-52
   // puts a sounding digit at ~3.5 mm (§5.2.1(2)) = ~13 px of digit height, and a
-  // digit is ~0.71 em, so 18 px em is the standard's size, not a large one. Flat
-  // across zoom because "text size should never be decreased when zooming out"
-  // (S-52 §3.1.5) — low-zoom clutter is thinned by per-feature minzoom and label
-  // collision, never by shrinking the type.
-  const labelSize = 13;
+  // digit is ~0.71 em, so the 18 px em at chart scale is the standard's size, not
+  // a large one. The ramp down at coarse zooms is a deliberate deviation from
+  // S-52 §3.1.5 ("text size should never be decreased when zooming out"): that
+  // rule assumes ECDIS's fixed compilation scale, and at a z8 overview the full-
+  // size type shouts over a whole sea. The decimetre subscript glyph is cut at
+  // roughly 0.6 em by the typeface, so the low anchor is also its legibility floor.
+  const labelSize: ExpressionSpecification = [
+    "interpolate",
+    ["linear"],
+    ["zoom"],
+    8,
+    12,
+    13,
+    16,
+  ];
 
   const coverageColor = flavor.coverage;
 
@@ -605,6 +612,7 @@ export function layers(
         "text-field": soundingText,
         "text-font": flavor.soundingFont,
         "text-size": labelSize,
+        "text-padding": 8,
         // Lower sorts first and wins the collision. A prime sounding outranks the whole field —
         // "must always be shown" (S-4 B-410b) fails if a deeper neighbour can displace it — and
         // the rest fall back to shoalest-first, so where two ordinary soundings collide the
@@ -615,7 +623,6 @@ export function layers(
           -1e6,
           ["get", "depth_m"],
         ] as unknown as ExpressionSpecification,
-        "text-padding": 20,
       },
       paint: {
         // One colour for the whole field, like a paper chart: S-4 sets every sounding in

--- a/style/index.ts
+++ b/style/index.ts
@@ -55,6 +55,9 @@ export interface Flavor {
   soundingEmphasis: string;
   contourEmphasis: string;
   font: string[];
+  /** Soundings only. S-4 B-412.1 sets them in sloping numerals; upright is reserved for
+   *  soundings of lower reliability (B-412.4). */
+  soundingFont: string[];
   hillshadeShadow: string;
   hillshadeHighlight: string;
   coverage: string;
@@ -99,11 +102,12 @@ export const day: Flavor = {
   // only unsafe soundings jump, in soundingEmphasis (SNDG2).
   contour: "#768c97",
   label: "#768c97",
-  labelHalo: "#fff",
+  labelHalo: "rgba(255,255,255,0.8)",
   soundingEmphasis: "#000",
   // Safety contour line (S-52 DEPSC day): darker grey, distinct from SNDG2 black.
   contourEmphasis: "#4C5B63",
   font: ["Noto Sans Regular"],
+  soundingFont: ["Noto Sans Italic"],
   hillshadeShadow: "#9adcfe",
   hillshadeHighlight: "#ffffff",
   coverage: "#f58231",
@@ -118,8 +122,20 @@ const DEFAULT_SHADING: Shading = "relief";
 // lines' presentation floor — depth shading carries lower zooms.
 const BANDS_MIN_ZOOM = 6;
 
+// Decimetre digit on soundings. S-52's glyphs (PresLib SOUNDG10-19 vs SOUNDG50-59)
+// are the same 8x11 size and differ only by a 4-unit drop, so the decimetre reads
+// at full weight on screen; S-4 B-412.1's "visibly smaller" is the paper rule.
+// vertical-align only offsets a section when its size differs, so the scale buys
+// the drop. It has to be small enough that 1.3 m never reads as 13 m — the two
+// occur side by side in the same view — which measured out at 0.6, not the ~0.8
+// that matches S-52's 4-of-11 geometry.
+const SUBSCRIPT_SCALE = 0.666;
+
+// Self-hosted (openwatersio/tile-fonts). The MapLibre demo stack this replaced is a subset —
+// of the ten subscript digits it ships three — and a missing glyph is not an error, it simply
+// does not draw, so a decimetre digit would vanish off the chart.
 const DEFAULT_GLYPHS =
-  "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf";
+  "https://tiles.openwaters.io/fonts/{fontstack}/{range}.pbf";
 
 // ─── Depth-shading ramp (elevation → colour) ─────────────────────────────────
 // The hazard tint folds into this one color-relief ramp: two color-relief
@@ -341,16 +357,68 @@ export function layers(
   // `safety` sets the unsafe-sounding emphasis. Everything is a literal, so
   // runtime changes go through applyState(), which regenerates these.
   //
-  // Soundings: props depth_m / depth_ft / depth_fm, all floored toward
-  // shallower; depth_m already carries one decimal in the shoal band (<6 m)
-  // and an integer deeper, so metres just print it.
-  const soundingText: ExpressionSpecification = [
-    "to-string",
+  // Soundings: props depth_m / depth_ft / depth_fm, all floored toward shallower by
+  // soundings_run.py — splitting the digits here must not re-round. The whole part is the chart
+  // number and the sub-unit is set smaller and dropped below it, never shown when zero
+  // (S-4 B-412.1).
+  const subUnitSounding = (
+    whole: ExpressionSpecification,
+    sub: ExpressionSpecification,
+  ): ExpressionSpecification => [
+    "format",
+    ["to-string", whole],
+    {},
     [
-      "get",
-      unit === "ft" ? "depth_ft" : unit === "fm" ? "depth_fm" : "depth_m",
+      "match",
+      sub,
+      1,
+      "1",
+      2,
+      "2",
+      3,
+      "3",
+      4,
+      "4",
+      5,
+      "5",
+      6,
+      "6",
+      7,
+      "7",
+      8,
+      "8",
+      9,
+      "9",
+      "",
     ],
+    { "font-scale": SUBSCRIPT_SCALE, "vertical-align": "bottom" },
   ];
+  // Metres: the tenths digit is decimetres. `round` on the residual recovers it through float
+  // dust (3.9 % 1 == 0.9000000000000004).
+  const metreSounding = subUnitSounding(
+    ["floor", ["get", "depth_m"]],
+    ["round", ["*", 10, ["%", ["get", "depth_m"], 1]]],
+  );
+  // Fathoms: "Fathoms and Feet up to 11 fathoms and in fathoms only in depths greater than 11
+  // fathoms" (Canada CHS Chart 1, 2022). A fathom is exactly six feet, so both digits come off
+  // depth_ft and the tiles never carry a mixed-radix number.
+  const FT_PER_FATHOM = 6;
+  const FATHOM_FEET_MAX_FM = 11;
+  const fathomSounding = subUnitSounding(
+    ["floor", ["/", ["get", "depth_ft"], FT_PER_FATHOM]],
+    [
+      "case",
+      [">=", ["get", "depth_ft"], FATHOM_FEET_MAX_FM * FT_PER_FATHOM],
+      0,
+      ["%", ["get", "depth_ft"], FT_PER_FATHOM],
+    ],
+  );
+  const soundingText: ExpressionSpecification =
+    unit === "ft"
+      ? ["to-string", ["get", "depth_ft"]]
+      : unit === "m"
+        ? metreSounding
+        : fathomSounding;
   // Contours: metre isobaths (sys != "ft", also legacy no-sys tiles) vs the
   // fathom-curve set (sys == "ft"), which labels as feet or fathoms. Both
   // systems label every curve — the standard isobath sets are sparse enough
@@ -389,16 +457,13 @@ export function layers(
       ? ["==", ["get", "depth_abs_m"], safetyContour]
       : ["==", ["get", "depth_fm"], Math.round(safetyContour / 1.8288)];
 
-  // Shared label styling so soundings and contour labels read as one chart.
-  const labelSize: ExpressionSpecification = [
-    "interpolate",
-    ["linear"],
-    ["zoom"],
-    8,
-    9,
-    13,
-    12,
-  ];
+  // Shared label styling so soundings and contour labels read as one chart. S-52
+  // puts a sounding digit at ~3.5 mm (§5.2.1(2)) = ~13 px of digit height, and a
+  // digit is ~0.71 em, so 18 px em is the standard's size, not a large one. Flat
+  // across zoom because "text size should never be decreased when zooming out"
+  // (S-52 §3.1.5) — low-zoom clutter is thinned by per-feature minzoom and label
+  // collision, never by shrinking the type.
+  const labelSize = 13;
 
   const coverageColor = flavor.coverage;
 
@@ -538,24 +603,29 @@ export function layers(
       minzoom: 7,
       layout: {
         "text-field": soundingText,
-        "text-font": flavor.font,
+        "text-font": flavor.soundingFont,
         "text-size": labelSize,
-        "symbol-sort-key": ["get", "depth_m"], // shoalest first → wins collisions
-        "text-padding": 8,
+        // Lower sorts first and wins the collision. A prime sounding outranks the whole field —
+        // "must always be shown" (S-4 B-410b) fails if a deeper neighbour can displace it — and
+        // the rest fall back to shoalest-first, so where two ordinary soundings collide the
+        // safer number survives.
+        "symbol-sort-key": [
+          "case",
+          ["==", ["get", "prime"], 1],
+          -1e6,
+          ["get", "depth_m"],
+        ] as unknown as ExpressionSpecification,
+        "text-padding": 20,
       },
       paint: {
-        // Soundings at or shoaler than the safety depth print in the emphasis
-        // colour (S-52's SNDG2 black-by-day) and the hazard tint carries the
-        // alarm; safety=0 → all normal.
-        "text-color":
-          safety > 0
-            ? [
-                "case",
-                ["<=", ["get", "depth_m"], safety],
-                flavor.soundingEmphasis,
-                flavor.label,
-              ]
-            : flavor.label,
+        // One colour for the whole field, like a paper chart: S-4 sets every sounding in
+        // one style and reserves type distinctions for reliability (B-412.4), not depth —
+        // hazard is carried by the depth-area tint and the isobaths themselves. `prime` (the
+        // least depth inside a closed isobath) still governs retention and collision priority
+        // above, but it is a topological fact of the build window, not a hazard ranking: a
+        // coastal shelf whose contour closes beyond the window edge is never prime, while a
+        // 0.5 m wrinkle at 29 m is, so inking it black read exactly backwards.
+        "text-color": flavor.label,
         "text-halo-color": flavor.labelHalo,
         "text-halo-width": 1,
       },

--- a/style/index.ts
+++ b/style/index.ts
@@ -1,11 +1,11 @@
 /**
  * @openwaters/seascape — MapLibre GL style for the Open Waters bathymetry tiles.
  *
- * Follows the protomaps-basemaps split: layer *structure* lives in these
- * functions, appearance lives in a plain "flavor" object, and the consumer owns
- * the style — either assembled piecemeal (`sources()` + `layers()` concat with
- * other layer groups) or whole via `style()` (what the tile Worker serves at
- * /style.json).
+ * Follows the protomaps-basemaps split: layer *structure* lives in the
+ * per-layer modules (one file per layer family), appearance lives in a plain
+ * "flavor" object (flavor.ts), and the consumer owns the style — either
+ * assembled piecemeal (`sources()` + `layers()` concat with other layer
+ * groups) or whole via `style()` (what the tile Worker serves at /style.json).
  *
  *   import { style } from "@openwaters/seascape";
  *   new maplibregl.Map({ style: style({ tilesBase }) });
@@ -15,282 +15,54 @@
  *
  * Runtime parameters: `unit` ("m" | "ft" | "fm") and `safety` (metres, 0 = off)
  * appear in the generated expressions as literals — every label, isobath
- * filter, sounding emphasis, and the depth-shading ramp. Literal expressions
- * run on any GL JS with color-relief (MapLibre >= 5.6). To change them on a
- * live map, applyState() re-derives the handful of unit/safety-dependent
- * properties and sets them in place; or fetch a regenerated style
+ * filter, and the depth-shading ramp. Literal expressions run on any GL JS
+ * with color-relief (MapLibre >= 5.6). To change them on a live map,
+ * applyState() re-derives each layer's declared state-dependent properties and
+ * sets them in place; or fetch a regenerated style
  * (`/style.json?unit=ft&safety=3`). `shading` ("relief" | "bands") picks the
  * water shading: the raster ramp, or the vector ENC depth-area bands above z6
  * (the relief keeps z<6 either way).
  */
 import type {
-  ExpressionSpecification,
   LayerSpecification,
   SourceSpecification,
   StyleSpecification,
 } from "@maplibre/maplibre-gl-style-spec";
+import {
+  DEFAULT_SAFETY,
+  DEFAULT_SHADING,
+  DEFAULT_UNIT,
+  day,
+  type Flavor,
+  type Shading,
+  type Unit,
+} from "./flavor.js";
+import { depthShadingLayer, depthShadingState } from "./depth-shading.js";
+import { depthAreasLayer, depthAreasState } from "./depth-areas.js";
+import { hillshadeLayer, hillshadeState } from "./hillshade.js";
+import {
+  contourLabelsLayer,
+  contourLabelsState,
+  contourLinesLayer,
+  contourLinesState,
+} from "./contours.js";
+import { soundingsLayer, soundingsState } from "./soundings.js";
+import { coverageLayers } from "./coverage.js";
+
+export { day, type Flavor, type Shading, type Unit } from "./flavor.js";
+export { depthRelief } from "./depth-shading.js";
+export { depthAreasColor } from "./depth-areas.js";
 
 // The tile-contract version this package targets (docs/schema.md). Compare it
 // against the `schema` field of the endpoint's TileJSON: a mismatch means the
 // tiles may decode plausibly but wrongly — treat it as fatal, not cosmetic.
 export const SCHEMA = 1;
 
-export type Unit = "m" | "ft" | "fm";
-// Water shading: the raster color-relief ramp (continuous, fuzzy edges) or the
-// vector ENC depth-area bands (crisp edges on the charted isobaths, safety
-// snapped to the next-deeper charted level). Never both at once — the 0.85
-// opacities would compound.
-export type Shading = "relief" | "bands";
-
-export interface Flavor {
-  bandColors: string[]; // deepest → shoalest (6 entries)
-  bandEdges: { m: number[]; ft: number[] }; // band-edge depths, metres
-  hazard: string;
-  land: string;
-  drying: string;
-  nodata: string;
-  contour: string;
-  label: string;
-  labelHalo: string;
-  soundingEmphasis: string;
-  contourEmphasis: string;
-  font: string[];
-  /** Soundings only. S-4 B-412.1 sets them in sloping numerals; upright is reserved for
-   *  soundings of lower reliability (B-412.4). */
-  soundingFont: string[];
-  hillshadeShadow: string;
-  hillshadeHighlight: string;
-  coverage: string;
-}
-
-// ─── Flavor (appearance only — custom looks are spread-overrides) ────────────
-// Depth-shading tints follow chart convention: shoal-dark → deep-white
-// (INT/NOAA), flat white beyond the deepest edge so tint stays monotonic in
-// depth. Bands are perceptually spaced (adjacent ΔE ≥ 7 after 0.85-opacity
-// compositing), weighted toward the shoal bands where depth discrimination
-// matters. Band edges sit on isobaths the chart draws — metric levels, or the
-// classic fathom curves in ft/fm mode — so tint boundaries land on contour
-// lines rather than between them (paper-chart practice).
-export const day: Flavor = {
-  bandColors: [
-    "#e9f7ff", // deepest band
-    "#c9e9fd",
-    "#a5d9fb",
-    "#7fc7f8",
-    "#5db5f0",
-    "#3fa2e4", // shoalest band
-  ],
-  bandEdges: {
-    m: [50, 20, 10, 5, 2],
-    ft: [30, 10, 5, 3, 1].map((fm) => fm * 1.8288), // fathom curves 30/10/5/3/1 fm
-  },
-  // One perceptual step darker than the shoalest band — water shallower than
-  // the safety depth.
-  hazard: "#1f86cb",
-  // Land above datum: translucent buff wash (paper-chart figure-ground — white
-  // stays unambiguously "deep water"); a raster base reads through it.
-  land: "rgba(247,240,221,0.66)",
-  // Drying areas (S-52 DEPIT day green): seabed above chart datum that covers
-  // and uncovers with the tide. Darker than the shoalest band — charts weight
-  // the foreshore as the heaviest tint in the shoaling sequence.
-  drying: "#58af9c",
-  // Unknown-depth water (ENC DEPARE nodata): mapped water we hold no depth for. Painted
-  // the hazard tint — unsurveyed water warrants the same caution as known-unsafe water
-  // (ECDIS treats it as unsafe for the safety check; S-52 hatching is the eventual upgrade).
-  nodata: "#1f86cb",
-  // Isobaths and their labels recede in chart grey (S-52 DEPCN/SNDG1 #768C97);
-  // only unsafe soundings jump, in soundingEmphasis (SNDG2).
-  contour: "#768c97",
-  label: "#768c97",
-  labelHalo: "rgba(255,255,255,0.5)",
-  soundingEmphasis: "#000",
-  // Safety contour line (S-52 DEPSC day): darker grey, distinct from SNDG2 black.
-  contourEmphasis: "#4C5B63",
-  font: ["Noto Sans Medium"],
-  soundingFont: ["Noto Sans Medium Italic"],
-  hillshadeShadow: "#9adcfe",
-  hillshadeHighlight: "#ffffff",
-  coverage: "#f58231",
-};
-
-// Mariner-setting defaults for layers()/style() when the caller omits them.
-const DEFAULT_UNIT: Unit = "m";
-const DEFAULT_SAFETY = 2;
-const DEFAULT_SHADING: Shading = "relief";
-
-// The depare layer's data floor (tippecanoe -Z in the pipeline) and the contour
-// lines' presentation floor — depth shading carries lower zooms.
-const BANDS_MIN_ZOOM = 6;
-
-// Sub-unit digits on soundings are REAL subscript glyphs (U+2080-2089) from the self-hosted
-// stack — the type designer set the drop and the sidebearings. The alternative, a scaled
-// `format` section with vertical-align, aligns em-boxes rather than baselines, so the digit
-// sat visibly high and tight against the integer. A hair space (U+200A, also in the stack)
-// gives the pair its air.
-const SUB = "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089";
-const SUBSCRIPT = [...SUB].map((c, i) => (i ? "\u200A" + c : ""));
-
 // Self-hosted (openwatersio/tile-fonts). The MapLibre demo stack this replaced is a subset —
 // of the ten subscript digits it ships three — and a missing glyph is not an error, it simply
 // does not draw, so a decimetre digit would vanish off the chart.
 const DEFAULT_GLYPHS =
   "https://tiles.openwaters.io/fonts/{fontstack}/{range}.pbf";
-
-// ─── Depth-shading ramp (elevation → colour) ─────────────────────────────────
-// The hazard tint folds into this one color-relief ramp: two color-relief
-// layers on one DEM source don't composite (only the first renders), so water
-// shallower than the safety depth is painted into the ramp itself.
-type RampStops = (number | string)[]; // alternating elevation, colour
-
-// Terrarium's vertical LSB. The encoder clamps water to <= -LSB; the non-negative domain is
-// categorical (0 unknown-depth water, 1 drying foreshore, 2 land — flat codes, exact at every
-// zoom): the shoal tint runs flat to -LSB, then the code tints; fractional values between codes
-// are overzoom/interpolation transitions and blend smoothly.
-const LSB = 1 / 256;
-const DRYING_CODE = 1;
-const LAND_CODE = 2;
-
-// Width (metres) of the normal→hazard colour transition at the safety depth.
-const EDGE = 0.01;
-
-const depthRamp = (flavor: Flavor, edges: number[]): RampStops => {
-  const stops: RampStops = [-10000, flavor.bandColors[0]];
-  // Blend on the shallow side of each edge: the encoder rounds toward shallow
-  edges.forEach((d, i) =>
-    stops.push(-d, flavor.bandColors[i], -d + 0.1, flavor.bandColors[i + 1]),
-  );
-  // The unknown tint is a knife-edge at exact 0 (native code pixels only): pinning drying
-  // green at +LSB keeps overzoom's wet/dry blend fractions out of the slate — otherwise the
-  // whole (0, 1) interval renders as a wide gray band along every foreshore seam.
-  stops.push(
-    -LSB,
-    flavor.bandColors[5],
-    0,
-    flavor.nodata,
-    LSB,
-    flavor.drying,
-    DRYING_CODE,
-    flavor.drying,
-    LAND_CODE - LSB,
-    flavor.drying,
-    LAND_CODE,
-    flavor.land,
-  );
-  return stops;
-};
-
-// Colour of the ramp at elevation e (linear-interpolated). Used to pin a
-// normal-coloured stop right at the safety depth so the flip to the hazard
-// colour is a crisp ~0.01 m edge at ANY safety value — otherwise the blend
-// feathers by however far −safety lands from the nearest ramp stop.
-const rampColorAt = (ramp: RampStops, e: number): string => {
-  for (let i = 2; i < ramp.length; i += 2)
-    if (e <= (ramp[i] as number)) {
-      const e0 = ramp[i - 2] as number,
-        c0 = ramp[i - 1] as string;
-      const e1 = ramp[i] as number,
-        c1 = ramp[i + 1] as string;
-      if (c0[0] !== "#" || c1[0] !== "#") return c0;
-      const t = (e - e0) / (e1 - e0);
-      const p = (c: string) =>
-        [1, 3, 5].map((k) => parseInt(c.slice(k, k + 2), 16));
-      const a = p(c0),
-        b = p(c1);
-      return `rgb(${a.map((v, k) => Math.round(v + t * (b[k] - v))).join(",")})`;
-    }
-  return ramp[1] as string;
-};
-
-// The color-relief expression for the active unit system and safety depth.
-// Unit/safety changes rebuild this and apply it with
-// setPaintProperty("depth-shading", ...) — applyState() does exactly that.
-export function depthRelief(
-  flavor: Flavor = day,
-  { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
-): ExpressionSpecification {
-  // The crisp-edge stops below need s + EDGE to land strictly between the
-  // safety depth and the -LSB water stop, or the interpolate stops go out of
-  // ascending order and MapLibre rejects the whole expression. No real safety
-  // depth is centimetres, so floor tiny values instead of failing.
-  if (safety > 0) safety = Math.max(safety, EDGE + 2 * LSB);
-  const ramp = depthRamp(flavor, flavor.bandEdges[unit === "m" ? "m" : "ft"]);
-  const s = -safety;
-  const stops: RampStops = [];
-  for (let i = 0; i < ramp.length; i += 2)
-    if (!(safety > 0) || (ramp[i] as number) < s)
-      stops.push(ramp[i], ramp[i + 1]);
-  // Crisp edge: normal colour pinned at the safety depth, hazard from just
-  // shallower up to shore.
-  if (safety > 0)
-    stops.push(
-      s,
-      rampColorAt(ramp, s),
-      s + EDGE,
-      flavor.hazard,
-      -LSB,
-      flavor.hazard,
-      0,
-      flavor.nodata,
-      LSB,
-      flavor.drying,
-      DRYING_CODE,
-      flavor.drying,
-      LAND_CODE - LSB,
-      flavor.drying,
-      LAND_CODE,
-      flavor.land,
-    );
-  return [
-    "interpolate",
-    ["linear"],
-    ["elevation"],
-    ...stops,
-  ] as unknown as ExpressionSpecification;
-}
-
-// ─── Depth-area (ENC DEPARE) band colour ─────────────────────────────────────
-// Charted isobath ladders, positive-down metres — must mirror pipelines/config.py
-// DEPARE_LEVELS / DEPARE_LEVELS_FT (the bucket edges baked into the depare
-// layer). The safety contour snaps UP this ladder to the next-deeper rung
-// (ECDIS behaviour, bias shallow) — vector bands can only flip at charted
-// levels, unlike the raster ramp's continuous crisp edge.
-const DEPARE_LADDER_M = [
-  2, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 4000, 5000, 6000,
-  8000, 10000,
-];
-const DEPARE_LADDER_FT = [
-  1, 2, 3, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000,
-].map((fm) => fm * 1.8288);
-
-// Comparisons against drval1 subtract this: tiles may carry the fathom-curve
-// drvals (1.8288, 5.4864, …) as 32-bit floats, which can land a hair below the
-// exact edge value. Ladder rungs are ≥ ~1.8 m apart, so 0.01 m is safely
-// inside every gap.
-const DRVAL_EPS = 0.01;
-
-// Fill colour for the depare partitions: the band tint keyed off drval1 (the
-// band's shallow bound), with every band shallower than the snapped safety
-// contour painted the hazard tint. Literals only, like depthRelief — runtime
-// changes go through applyState().
-export function depthAreasColor(
-  flavor: Flavor = day,
-  { unit = "m", safety = 0 }: { unit?: Unit; safety?: number } = {},
-): ExpressionSpecification {
-  const metric = unit === "m";
-  const edges = [...flavor.bandEdges[metric ? "m" : "ft"]].reverse(); // shoalest → deepest
-  const step: unknown[] = ["step", ["get", "drval1"], flavor.bandColors[5]];
-  edges.forEach((d, i) => step.push(d - DRVAL_EPS, flavor.bandColors[4 - i]));
-  if (!(safety > 0)) return step as unknown as ExpressionSpecification;
-  const ladder = metric ? DEPARE_LADDER_M : DEPARE_LADDER_FT;
-  const snap =
-    ladder.find((l) => l >= safety - DRVAL_EPS) ?? ladder[ladder.length - 1];
-  return [
-    "case",
-    ["<", ["get", "drval1"], snap - DRVAL_EPS],
-    flavor.hazard,
-    step,
-  ] as unknown as ExpressionSpecification;
-}
 
 // ─── Sources ─────────────────────────────────────────────────────────────────
 // tilesBase is the Worker endpoint; the sources reference its TileJSON docs
@@ -331,6 +103,10 @@ export function sources({
 }
 
 // ─── Layers ──────────────────────────────────────────────────────────────────
+// One entry per layer family, in paint order. `unit` picks every sounding and
+// contour label and which isobath set shows; `safety` moves the hazard tint
+// and the emphasized contour. Everything is a literal, so runtime changes go
+// through applyState(), which regenerates these.
 export function layers(
   flavor: Flavor = day,
   {
@@ -352,337 +128,14 @@ export function layers(
     hillshade?: boolean;
   } = {},
 ): LayerSpecification[] {
-  // `unit` picks every sounding/contour label and which isobath set shows;
-  // `safety` sets the unsafe-sounding emphasis. Everything is a literal, so
-  // runtime changes go through applyState(), which regenerates these.
-  //
-  // Soundings: props depth_m / depth_ft / depth_fm, all floored toward shallower by
-  // soundings_run.py — splitting the digits here must not re-round. The whole part is the chart
-  // number and the sub-unit is set smaller and dropped below it, never shown when zero
-  // (S-4 B-412.1).
-  const subUnitSounding = (
-    whole: ExpressionSpecification,
-    sub: ExpressionSpecification,
-  ): ExpressionSpecification => [
-    "concat",
-    ["to-string", whole],
-    [
-      "match",
-      sub,
-      1,
-      SUBSCRIPT[1],
-      2,
-      SUBSCRIPT[2],
-      3,
-      SUBSCRIPT[3],
-      4,
-      SUBSCRIPT[4],
-      5,
-      SUBSCRIPT[5],
-      6,
-      SUBSCRIPT[6],
-      7,
-      SUBSCRIPT[7],
-      8,
-      SUBSCRIPT[8],
-      9,
-      SUBSCRIPT[9],
-      "",
-    ],
-  ];
-  // Metres: the tenths digit is decimetres. `round` on the residual recovers it through float
-  // dust (3.9 % 1 == 0.9000000000000004).
-  const metreSounding = subUnitSounding(
-    ["floor", ["get", "depth_m"]],
-    ["round", ["*", 10, ["%", ["get", "depth_m"], 1]]],
-  );
-  // Fathoms: "Fathoms and Feet up to 11 fathoms and in fathoms only in depths greater than 11
-  // fathoms" (Canada CHS Chart 1, 2022). A fathom is exactly six feet, so both digits come off
-  // depth_ft and the tiles never carry a mixed-radix number.
-  const FT_PER_FATHOM = 6;
-  const FATHOM_FEET_MAX_FM = 11;
-  const fathomSounding = subUnitSounding(
-    ["floor", ["/", ["get", "depth_ft"], FT_PER_FATHOM]],
-    [
-      "case",
-      [">=", ["get", "depth_ft"], FATHOM_FEET_MAX_FM * FT_PER_FATHOM],
-      0,
-      ["%", ["get", "depth_ft"], FT_PER_FATHOM],
-    ],
-  );
-  const soundingText: ExpressionSpecification =
-    unit === "ft"
-      ? ["to-string", ["get", "depth_ft"]]
-      : unit === "m"
-        ? metreSounding
-        : fathomSounding;
-  // Contours: metre isobaths (sys != "ft", also legacy no-sys tiles) vs the
-  // fathom-curve set (sys == "ft"), which labels as feet or fathoms. Both
-  // systems label every curve — the standard isobath sets are sparse enough
-  // that GL collision thins the labels. The 0 m drying line is unit-independent
-  // and ships once with NO sys (like depare's drying/nodata), so both filters
-  // admit sys-less features.
-  const contourLineFilter = (unit === "m"
-    ? ["!=", ["get", "sys"], "ft"]
-    : [
-        "any",
-        ["!", ["has", "sys"]],
-        ["==", ["get", "sys"], "ft"],
-      ]) as unknown as ExpressionSpecification;
-  // Depth number only, like paper charts (S-4 B-411.3) — the unit lives in the
-  // consumer's UI, and soundings are already unitless.
-  const contourLabelText: ExpressionSpecification = [
-    "to-string",
-    [
-      "get",
-      unit === "ft" ? "depth_ft" : unit === "fm" ? "depth_fm" : "depth_abs_m",
-    ],
-  ];
-
-  // The safety contour snaps UP the charted ladder to the next-deeper level, exactly
-  // as depthAreasColor recolours the bands, so the emphasized line always bounds the
-  // hazard tint. Contours carry integer depth props (depth_abs_m / depth_fm,
-  // contour_run.py), so the match is exact equality on the active system's prop.
-  const ladder = unit === "m" ? DEPARE_LADDER_M : DEPARE_LADDER_FT;
-  const safetyContour =
-    safety > 0
-      ? (ladder.find((l) => l >= safety - DRVAL_EPS) ??
-        ladder[ladder.length - 1])
-      : 0;
-  const isSafetyContour: ExpressionSpecification =
-    unit === "m"
-      ? ["==", ["get", "depth_abs_m"], safetyContour]
-      : ["==", ["get", "depth_fm"], Math.round(safetyContour / 1.8288)];
-
-  // Shared label styling so soundings and contour labels read as one chart. S-52
-  // puts a sounding digit at ~3.5 mm (§5.2.1(2)) = ~13 px of digit height, and a
-  // digit is ~0.71 em, so the 18 px em at chart scale is the standard's size, not
-  // a large one. The ramp down at coarse zooms is a deliberate deviation from
-  // S-52 §3.1.5 ("text size should never be decreased when zooming out"): that
-  // rule assumes ECDIS's fixed compilation scale, and at a z8 overview the full-
-  // size type shouts over a whole sea. The decimetre subscript glyph is cut at
-  // roughly 0.6 em by the typeface, so the low anchor is also its legibility floor.
-  const labelSize: ExpressionSpecification = [
-    "interpolate",
-    ["linear"],
-    ["zoom"],
-    8,
-    12,
-    13,
-    16,
-  ];
-
-  const coverageColor = flavor.coverage;
-
-  // The depare layer carries three ENC DEPARE feature kinds in one fill, keyed by attribute
-  // presence: depth bands (drval1/drval2, sys-tagged per m/ft ladder, drval1 >= 0), drying
-  // foreshore (drval1 < 0, no sys), and unknown-depth water (no drval1, no sys). Bands
-  // duplicate per sys, so only the active ladder shows, and only in bands mode; drying +
-  // nodata have NO sys and ship once, so `!has sys` selects them and they render in BOTH
-  // shading modes — relief filters the bands out (the raster ramp carries depth; two 0.85
-  // fills would compound) but keeps the honesty fills, since a #24-cleared lake must read as
-  // unknown water — the render now tints 0-fill as unknown water too, and the depare polygon
-  // keeps that categorical (and adds the drying tint).
-  const bandSys = unit === "m" ? "m" : "ft";
-  const depareFilter = (shading === "bands"
-    ? ["any", ["!", ["has", "sys"]], ["==", ["get", "sys"], bandSys]]
-    : ["!", ["has", "sys"]]) as unknown as ExpressionSpecification;
-  // Fill: nodata (no drval1) → provisional flat tint; drying (drval1 < 0) → foreshore green;
-  // else the band ramp keyed off drval1. `case` short-circuits, so the drval1 comparison only
-  // runs once the no-drval1 branch has ruled nodata out.
-  const depareColor = [
-    "case",
-    ["!", ["has", "drval1"]],
-    flavor.nodata,
-    ["<", ["get", "drval1"], 0],
-    flavor.drying,
-    depthAreasColor(flavor, { unit, safety }),
-  ] as unknown as ExpressionSpecification;
-  // nodata carries the provisional lighter wash it had as its own layer; bands + drying stay
-  // at the depth-fill opacity.
-  const depareOpacity = [
-    "case",
-    ["!", ["has", "drval1"]],
-    0.55,
-    0.85,
-  ] as unknown as ExpressionSpecification;
-
   return [
-    {
-      id: "depth-shading",
-      type: "color-relief",
-      source: dem,
-      // Bands mode: the vector depth areas take over at their z6 data floor;
-      // the relief carries lower zooms (same palette, so the handoff is a
-      // sharpness change, not a colour change).
-      ...(shading === "bands" ? { maxzoom: BANDS_MIN_ZOOM } : {}),
-      paint: {
-        "color-relief-color": depthRelief(flavor, { unit, safety }),
-        "color-relief-opacity": 0.85,
-        // Linear resampling paints a light seam along every unknown-water boundary
-        resampling: "nearest",
-      },
-    },
-    {
-      // ENC DEPARE fill — the vector twin of depth-shading, carrying all three depare
-      // feature kinds keyed by attribute presence (see the expressions above): depth bands
-      // (crisp tint per drval1, safety recolour snapped to the next-deeper charted level),
-      // drying foreshore (INT-1 green, negative drval1), and unknown-depth water (provisional
-      // flat tint, no drval1). The three are disjoint by construction, so `fill-sort-key: rank`
-      // is only a stable tie-breaker at an incidental simplification-wobble edge — nodata under
-      // bands (real depth wins), drying over the shoal band it abuts along their shared 0 m seam.
-      // Bands are filtered out in relief mode (the raster ramp carries depth); drying
-      // + nodata stay in both modes. Where no drying/nodata polygon covers a >=0 pixel the DEM
-      // ramp still paints the land wash, so a mask miss degrades to plain land, never to
-      // water-over-land.
-      id: "depth-areas",
-      type: "fill",
-      source: vector,
-      "source-layer": "depare",
-      filter: depareFilter,
-      minzoom: BANDS_MIN_ZOOM,
-      layout: { "fill-sort-key": ["get", "rank"] },
-      paint: {
-        "fill-color": depareColor,
-        "fill-opacity": depareOpacity,
-      },
-    },
-    {
-      id: "depth-hillshade",
-      type: "hillshade",
-      source: dem,
-      layout: { visibility: hillshade ? "visible" : "none" },
-      paint: {
-        "hillshade-exaggeration": 0.5,
-        "hillshade-shadow-color": flavor.hillshadeShadow,
-        "hillshade-highlight-color": flavor.hillshadeHighlight,
-        "hillshade-illumination-direction": 315,
-      },
-    },
-    {
-      id: "contour-lines",
-      type: "line",
-      source: vector,
-      "source-layer": "contours",
-      filter: contourLineFilter,
-      // Presentation floor, not a data limit: below z6 isobaths read as clutter over depth shading.
-      minzoom: 6,
-      // Full-strength linework at DEPCN weight — translucent hairlines read as
-      // shading artefacts rather than isobaths.
-      paint: {
-        // The safety contour is the one emphasized isobath — thicker, in the emphasis
-        // colour, like S-52's DEPSC over DEPCN (IMO MSC.232 requires the emphasis);
-        // every other contour stays uniform DEPCN weight (S-4 B-411.1 recommends
-        // against emphasizing fixed standard contours).
-        "line-color": safetyContour
-          ? ["case", isSafetyContour, flavor.contourEmphasis, flavor.contour]
-          : flavor.contour,
-        "line-width": safetyContour ? ["case", isSafetyContour, 1.5, 0.8] : 0.8,
-      },
-    },
-    {
-      id: "contour-labels",
-      type: "symbol",
-      source: vector,
-      "source-layer": "contours",
-      filter: contourLineFilter,
-      minzoom: 8,
-      layout: {
-        "symbol-placement": "line",
-        "text-field": contourLabelText,
-        "text-size": labelSize,
-        "text-font": flavor.font,
-        "text-letter-spacing": 0.1,
-        "text-max-angle": 30,
-        "text-padding": 50,
-      },
-      paint: {
-        "text-color": flavor.label,
-        "text-halo-color": flavor.labelHalo,
-        "text-halo-width": 1,
-      },
-    },
-    {
-      id: "soundings",
-      type: "symbol",
-      source: vector,
-      "source-layer": "soundings",
-      minzoom: 7,
-      layout: {
-        "text-field": soundingText,
-        "text-font": flavor.soundingFont,
-        "text-size": labelSize,
-        "text-padding": 8,
-        // Lower sorts first and wins the collision. A prime sounding outranks the whole field —
-        // "must always be shown" (S-4 B-410b) fails if a deeper neighbour can displace it — and
-        // the rest fall back to shoalest-first, so where two ordinary soundings collide the
-        // safer number survives.
-        "symbol-sort-key": [
-          "case",
-          ["==", ["get", "prime"], 1],
-          -1e6,
-          ["get", "depth_m"],
-        ] as unknown as ExpressionSpecification,
-      },
-      paint: {
-        // One colour for the whole field, like a paper chart: S-4 sets every sounding in
-        // one style and reserves type distinctions for reliability (B-412.4), not depth —
-        // hazard is carried by the depth-area tint and the isobaths themselves. `prime` (the
-        // least depth inside a closed isobath) still governs retention and collision priority
-        // above, but it is a topological fact of the build window, not a hazard ranking: a
-        // coastal shelf whose contour closes beyond the window edge is never prime, while a
-        // 0.5 m wrinkle at 29 m is, so inking it black read exactly backwards.
-        "text-color": flavor.label,
-        "text-halo-color": flavor.labelHalo,
-        "text-halo-width": 1,
-      },
-    },
-    // Source coverage (provenance): footprint polygons with props source_id /
-    // source_name / source_maxzoom, from the standalone coverage tileset.
-    // Hidden by default; a viewer can toggle them on for click-to-identify.
-    {
-      id: "source-fill",
-      type: "fill",
-      source: coverage,
-      "source-layer": "coverage",
-      layout: { visibility: "none" },
-      paint: { "fill-color": coverageColor, "fill-opacity": 0.12 },
-    },
-    {
-      // Brightened fill of one source (filter set by the consumer on click).
-      id: "source-highlight",
-      type: "fill",
-      source: coverage,
-      "source-layer": "coverage",
-      filter: ["==", ["get", "source_id"], "__none__"],
-      layout: { visibility: "none" },
-      paint: { "fill-color": coverageColor, "fill-opacity": 0.4 },
-    },
-    {
-      id: "source-outline",
-      type: "line",
-      source: coverage,
-      "source-layer": "coverage",
-      layout: { visibility: "none" },
-      paint: { "line-color": coverageColor, "line-width": 1.5 },
-    },
-    {
-      id: "source-labels",
-      type: "symbol",
-      source: coverage,
-      "source-layer": "coverage",
-      layout: {
-        visibility: "none",
-        "text-field": ["get", "source_name"],
-        "text-size": 11,
-        "text-font": flavor.font,
-      },
-      paint: {
-        "text-color": coverageColor,
-        "text-halo-color": flavor.labelHalo,
-        "text-halo-width": 1.2,
-      },
-    },
+    depthShadingLayer(flavor, { dem, unit, safety, shading }),
+    depthAreasLayer(flavor, { vector, unit, safety, shading }),
+    hillshadeLayer(flavor, { dem, hillshade }),
+    contourLinesLayer(flavor, { vector, unit, safety }),
+    contourLabelsLayer(flavor, { vector, unit }),
+    soundingsLayer(flavor, { vector, unit }),
+    ...coverageLayers(flavor, { coverage }),
   ];
 }
 
@@ -750,15 +203,28 @@ export interface ChartMap {
   getLayer(id: string): unknown;
 }
 
-// Change the mariner settings on a live map: re-derive the unit/safety-
-// dependent layer properties (depth ramp, isobath filters, label text, unsafe-
-// sounding emphasis) and set them in place — the in-place equivalent of
-// reloading a regenerated style. Takes the full settings each call: nothing
-// map-side stores the previous values, so callers pass what their controls
-// currently show. `shading` also gates the depare fill's filter (relief hides
-// the depth bands but keeps drying/nodata), so pass the current mode — it
-// defaults to the relief mode when omitted. Layers absent from the map
-// (composed subsets) are skipped.
+// Which properties applyState re-derives, declared BY each layer module beside
+// the layer it describes — a layer that gains a state-dependent property
+// declares it there, in the same diff, instead of this file quietly not
+// updating it (the failure mode of the hardcoded per-layer switch this table
+// replaced).
+const STATEFUL: Record<string, string[]> = {
+  "depth-shading": depthShadingState,
+  "depth-areas": depthAreasState,
+  "depth-hillshade": hillshadeState,
+  "contour-lines": contourLinesState,
+  "contour-labels": contourLabelsState,
+  soundings: soundingsState,
+};
+
+// Change the mariner settings on a live map: re-derive each layer's declared
+// state-dependent properties (depth ramp, isobath filters, label text) and set
+// them in place — the in-place equivalent of reloading a regenerated style.
+// Takes the full settings each call: nothing map-side stores the previous
+// values, so callers pass what their controls currently show. `shading` also
+// gates the depare fill's filter (relief hides the depth bands but keeps
+// drying/nodata), so pass the current mode — it defaults to the relief mode
+// when omitted. Layers absent from the map (composed subsets) are skipped.
 export function applyState(
   map: ChartMap,
   {
@@ -771,52 +237,31 @@ export function applyState(
 ): void {
   const spec = Object.fromEntries(
     layers(flavor, { unit, safety, shading, hillshade }).map((l) => [l.id, l]),
-  ) as Record<string, { filter?: unknown; layout?: any; paint?: any }>;
-  if (map.getLayer("depth-shading"))
-    map.setPaintProperty(
-      "depth-shading",
-      "color-relief-color",
-      spec["depth-shading"].paint["color-relief-color"],
-    );
-  if (map.getLayer("depth-areas")) {
-    map.setFilter("depth-areas", spec["depth-areas"].filter);
-    map.setPaintProperty(
-      "depth-areas",
-      "fill-color",
-      spec["depth-areas"].paint["fill-color"],
-    );
-  }
-  if (map.getLayer("contour-lines")) {
-    map.setFilter("contour-lines", spec["contour-lines"].filter);
-    // safety moves the emphasized contour, so the paint is safety-dependent too
-    for (const p of ["line-color", "line-width"])
-      map.setPaintProperty("contour-lines", p, spec["contour-lines"].paint[p]);
-  }
-  if (map.getLayer("depth-hillshade"))
-    map.setLayoutProperty(
-      "depth-hillshade",
-      "visibility",
-      spec["depth-hillshade"].layout.visibility,
-    );
-  if (map.getLayer("contour-labels")) {
-    map.setFilter("contour-labels", spec["contour-labels"].filter);
-    map.setLayoutProperty(
-      "contour-labels",
-      "text-field",
-      spec["contour-labels"].layout["text-field"],
-    );
-  }
-  if (map.getLayer("soundings")) {
-    map.setLayoutProperty(
-      "soundings",
-      "text-field",
-      spec["soundings"].layout["text-field"],
-    );
-    map.setPaintProperty(
-      "soundings",
-      "text-color",
-      spec["soundings"].paint["text-color"],
-    );
+  ) as Record<
+    string,
+    {
+      filter?: unknown;
+      layout?: Record<string, unknown>;
+      paint?: Record<string, unknown>;
+    }
+  >;
+  for (const [id, props] of Object.entries(STATEFUL)) {
+    if (!map.getLayer(id)) continue;
+    for (const prop of props) {
+      if (prop === "filter") map.setFilter(id, spec[id].filter);
+      else if (prop.startsWith("layout."))
+        map.setLayoutProperty(
+          id,
+          prop.slice(7),
+          spec[id].layout?.[prop.slice(7)],
+        );
+      else if (prop.startsWith("paint."))
+        map.setPaintProperty(
+          id,
+          prop.slice(6),
+          spec[id].paint?.[prop.slice(6)],
+        );
+    }
   }
 }
 

--- a/style/index.ts
+++ b/style/index.ts
@@ -103,10 +103,23 @@ export function sources({
 }
 
 // ─── Layers ──────────────────────────────────────────────────────────────────
-// One entry per layer family, in paint order. `unit` picks every sounding and
-// contour label and which isobath set shows; `safety` moves the hazard tint
-// and the emphasized contour. Everything is a literal, so runtime changes go
-// through applyState(), which regenerates these.
+// One entry per layer family. `unit` picks every sounding and contour label
+// and which isobath set shows; `safety` moves the hazard tint and the
+// emphasized contour. Everything is a literal, so runtime changes go through
+// applyState(), which regenerates these.
+//
+// The array encodes TWO orderings at once:
+//  - Paint: later draws on top. Areas lowest, hillshade texture over the fills
+//    but under contour-lines so isobaths stay crisp, lines above areas —
+//    S-52 10.3.4.1's tie-break (lines over areas, points over both).
+//  - Symbol placement runs in REVERSE: the last symbol layer claims space
+//    first and wins cross-layer collisions. Soundings sit after contour-labels
+//    on purpose — a collision renderer culls (the paper regime, S-4: labels
+//    are fitted into gaps after soundings), so the contour label that repeats
+//    along its line yields to the point number that exists exactly once.
+//    Moving soundings earlier would let a repeating "10" delete them.
+//    source-labels last: the provenance overlay, when toggled on, is a
+//    diagnostic and outranks chart text while in use.
 export function layers(
   flavor: Flavor = day,
   {

--- a/style/package.json
+++ b/style/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwaters/seascape",
   "version": "0.3.0",
-  "description": "MapLibre GL style for Open Waters bathymetry tiles — depth shading, contours, soundings, depth areas",
+  "description": "MapLibre GL style for Open Waters bathymetry tiles \u2014 depth shading, contours, soundings, depth areas",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "dist/index.js",
@@ -15,8 +15,8 @@
   },
   "files": [
     "dist",
-    "index.ts",
-    "README.md"
+    "*.ts",
+    "!*.test.ts"
   ],
   "repository": {
     "type": "git",

--- a/style/soundings.ts
+++ b/style/soundings.ts
@@ -1,0 +1,125 @@
+/**
+ * soundings — spot depths, set as chart typography.
+ */
+import type {
+  ExpressionSpecification,
+  LayerSpecification,
+} from "@maplibre/maplibre-gl-style-spec";
+import { labelSize, type Flavor, type Unit } from "./flavor.js";
+
+// Sub-unit digits on soundings are REAL subscript glyphs (U+2080-2089) from the self-hosted
+// stack — the type designer set the drop and the sidebearings. The alternative, a scaled
+// `format` section with vertical-align, aligns em-boxes rather than baselines, so the digit
+// sat visibly high and tight against the integer. A hair space (U+200A, also in the stack)
+// gives the pair its air.
+const SUB = "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089";
+const SUBSCRIPT = [...SUB].map((c, i) => (i ? "\u200A" + c : ""));
+
+// Soundings: props depth_m / depth_ft / depth_fm, all floored toward shallower by
+// soundings_run.py — splitting the digits here must not re-round. The whole part is the chart
+// number and the sub-unit is set smaller and dropped below it, never shown when zero
+// (S-4 B-412.1).
+const subUnitSounding = (
+  whole: ExpressionSpecification,
+  sub: ExpressionSpecification,
+): ExpressionSpecification => [
+  "concat",
+  ["to-string", whole],
+  [
+    "match",
+    sub,
+    1,
+    SUBSCRIPT[1],
+    2,
+    SUBSCRIPT[2],
+    3,
+    SUBSCRIPT[3],
+    4,
+    SUBSCRIPT[4],
+    5,
+    SUBSCRIPT[5],
+    6,
+    SUBSCRIPT[6],
+    7,
+    SUBSCRIPT[7],
+    8,
+    SUBSCRIPT[8],
+    9,
+    SUBSCRIPT[9],
+    "",
+  ],
+];
+
+// Metres: the tenths digit is decimetres. `round` on the residual recovers it through float
+// dust (3.9 % 1 == 0.9000000000000004).
+const metreSounding = subUnitSounding(
+  ["floor", ["get", "depth_m"]],
+  ["round", ["*", 10, ["%", ["get", "depth_m"], 1]]],
+);
+
+// Fathoms: "Fathoms and Feet up to 11 fathoms and in fathoms only in depths greater than 11
+// fathoms" (Canada CHS Chart 1, 2022). A fathom is exactly six feet, so both digits come off
+// depth_ft and the tiles never carry a mixed-radix number.
+const FT_PER_FATHOM = 6;
+const FATHOM_FEET_MAX_FM = 11;
+const fathomSounding = subUnitSounding(
+  ["floor", ["/", ["get", "depth_ft"], FT_PER_FATHOM]],
+  [
+    "case",
+    [">=", ["get", "depth_ft"], FATHOM_FEET_MAX_FM * FT_PER_FATHOM],
+    0,
+    ["%", ["get", "depth_ft"], FT_PER_FATHOM],
+  ],
+);
+
+export function soundingsLayer(
+  flavor: Flavor,
+  { vector, unit }: { vector: string; unit: Unit },
+): LayerSpecification {
+  const soundingText: ExpressionSpecification =
+    unit === "ft"
+      ? ["to-string", ["get", "depth_ft"]]
+      : unit === "m"
+        ? metreSounding
+        : fathomSounding;
+
+  return {
+    id: "soundings",
+    type: "symbol",
+    source: vector,
+    "source-layer": "soundings",
+    minzoom: 7,
+    layout: {
+      "text-field": soundingText,
+      "text-font": flavor.soundingFont,
+      "text-size": labelSize,
+      "text-padding": 8,
+      // Lower sorts first and wins the collision. A prime sounding outranks the whole field —
+      // "must always be shown" (S-4 B-410b) fails if a deeper neighbour can displace it — and
+      // the rest fall back to shoalest-first, so where two ordinary soundings collide the
+      // safer number survives.
+      "symbol-sort-key": [
+        "case",
+        ["==", ["get", "prime"], 1],
+        -1e6,
+        ["get", "depth_m"],
+      ] as unknown as ExpressionSpecification,
+    },
+    paint: {
+      // One colour for the whole field, like a paper chart: S-4 sets every sounding in
+      // one style and reserves type distinctions for reliability (B-412.4), not depth —
+      // hazard is carried by the depth-area tint and the isobaths themselves. `prime` (the
+      // least depth inside a closed isobath) still governs retention and collision priority
+      // above, but it is a topological fact of the build window, not a hazard ranking: a
+      // coastal shelf whose contour closes beyond the window edge is never prime, while a
+      // 0.5 m wrinkle at 29 m is, so inking it black read exactly backwards.
+      "text-color": flavor.label,
+      "text-halo-color": flavor.labelHalo,
+      "text-halo-width": 1,
+    },
+  };
+}
+
+// Unit changes the label text; the colour rides along so an applyState with a
+// different flavor keeps the field coherent.
+export const soundingsState = ["layout.text-field", "paint.text-color"];


### PR DESCRIPTION
Soundings are the numbers a mariner actually reads a chart by, and ours diverged from the paper-chart standards in ways that ranged from cosmetic to unsafe. An audit against S-4, S-52, and the S-57 encoding guide turned up eleven divergences. This fixes seven of them, measures the rest, and leaves behind a harness that can tell whether the field is good.

The two that mattered most for safety:

**Shoal depths were being thrown away.** A 1.0 m floor deleted exactly the least depths that S-4 B-410b ranks above everything else. The floor is now 0.2 m, picked from the measured point where real shoals stop and waterline noise starts, not from a guess.

**Soundings sat where they weren't.** Each one was placed on a lattice node rather than on the pixel its depth came from — in a sampled New York view, a quarter of them landed on dry land, displaced by up to 400 m. The winning pixel's position now rides up the pyramid with the depth, so every sounding is where its depth is. S-57 UOC §5.3 is blunt about this: there is no "sounding, out of position" in an ENC.

**Channels had no deep line.** Taking only the shoalest pixel per cell meant a dredged channel could never show its axis — B-410b wants maximum depths too, and B-403.1a asks for "the full range of depth." Rather than special-casing channels, soundings are now inserted wherever the charted field interpolates wrong by more than a threshold, deep side included. The Ambrose Channel gets its 26-31 m line and axis infill out of a rule that knows nothing about channels.

Also fixed: decimetre precision now runs to 21 m and half-metres to 31 m per B-412 (it cut off at 6 m); fathoms print as fathoms-and-feet below 11 fathoms the way charts do; and the numbers are set in sloping type, since upright is the posture B-412.4 reserves for *unreliable* soundings — we had every sounding claiming to be untrustworthy.

## Typography

The decimetre digit is a real subscript glyph rather than a scaled-down copy of the numeral. MapLibre's `format` with `vertical-align` aligns em-boxes, not baselines, so the shrunken digit floated visibly high — the type designer already solved this, and the glyph carries the correct drop and sidebearings.

Getting there meant hosting the fonts: the MapLibre demo stack ships three of the ten subscript digits, and a missing glyph doesn't error, it silently doesn't draw. The full stack now lives at `tiles.openwaters.io/fonts` from the new [tile-fonts](https://github.com/openwatersio/tile-fonts) repo.

## Measurement

S-4 B-410a states an acceptance test outright: no source depth should be shoaler than a mariner would get by interpolating from the charted soundings and contours. `pipelines/perf/soundings.py` implements it as a standing gate, and it's what scoped the rest of this work — including talking me out of a redesign, since the violation rate turns out to be flat across zoom, so thinning was never the cause.

It also surfaced something not in the original audit: regions built from coarse sources starve as you zoom in. One stem freezes at 9,438 soundings past z10, so by z14 they sit 224 mm apart at chart scale. Correct per the current design, and exactly backwards from what a mariner wants — the weakest data presents as the emptiest chart precisely when someone zooms in for detail. Filed as a follow-up rather than fixed here.

## Style structure

The style module was one 850-line file. It's now one module per layer family, with appearance in `flavor.ts` and `index.ts` reduced to composition. The public API is unchanged and every expression moved verbatim.

One behavioural improvement rode along: each layer now declares which of its properties depend on the mariner settings, and `applyState` walks those declarations. The hand-maintained list it replaces would silently skip any property nobody remembered to add to it.

## Out of scope

Datum correction (finding 1) and CATZOC/`M_QUAL` quality attribution (finding 2) are tracked in their own workstreams. Drying heights (finding 7) are blocked on the datum work — printing a drying height off an MSL-referenced source would be worse than printing nothing.

Findings, phases, and the full measurements are in [docs/plans/2026-08-17-soundings-chart-conformance.md](docs/plans/2026-08-17-soundings-chart-conformance.md).

## Remaining

- [ ] Rebuild soundings — the position, floor, precision, and repair changes need one to take effect
- [ ] Verify the rebuilt field against the B-410a gate on the shoal-rich and deep fixtures
- [ ] Decide what to do about coarse-source starvation at high zoom
- [ ] Drying heights, once the datum workstream lands

Closes openwatersio/seamap#73.
